### PR TITLE
Feature/default open metric

### DIFF
--- a/build/ack/Dockerfile
+++ b/build/ack/Dockerfile
@@ -7,7 +7,7 @@ RUN yum install -y ca-certificates file tzdata nfs-utils xfsprogs e4fsprogs pciu
 ARG ossfsVer=1.80.6.ack.1
 ARG update_ossfsVer=1.86.1.ack.1
 RUN curl http://ack-csiplugin.oss-cn-hangzhou.aliyuncs.com/ossfs/ossfs_${ossfsVer}-b42b3a8_centos7.0_x86_64.rpm -o /root/ossfs_${ossfsVer}_centos7.0_x86_64.rpm
-RUN curl http://ack-csiplugin.oss-cn-hangzhou.aliyuncs.com/pre/ossfs/ossfs_${update_ossfsVer}-e85518d_centos7.0_x86_64.rpm -o /root/ossfs_${update_ossfsVer}_centos7.0_x86_64.rpm
+RUN curl http://ack-csiplugin.oss-cn-hangzhou.aliyuncs.com/pre/ossfs/ossfs_${update_ossfsVer}-e85518d_centos7.0_x86_64.rpm -o /root/ossfs_1.86.2_centos7.0_x86_64.rpm
 
 COPY nsenter /nsenter
 COPY entrypoint.sh /entrypoint.sh

--- a/build/ack/entrypoint.sh
+++ b/build/ack/entrypoint.sh
@@ -55,7 +55,7 @@ if [ "$run_oss" = "true" ]; then
 
     ossfsVer="1.80.6.ack.1"
     if [ "$USE_UPDATE_OSSFS" == "" ]; then
-        ossfsVer="1.86.1.ack.1"
+        ossfsVer="1.86.2"
     fi
 
     # install OSSFS

--- a/pkg/metric/common.go
+++ b/pkg/metric/common.go
@@ -127,7 +127,9 @@ func updateMap(clientSet *kubernetes.Clientset, lastPvStorageInfoMap *map[string
 		//Get disk pvName
 		pvName, diskID, err := getVolumeInfoByJSON(path, deriverName)
 		if err != nil {
-			logrus.Errorf("Get volume info by path %s is failed, err:%s", path, err)
+			if err.Error() != "VolumeType is not the expected type" {
+				logrus.Errorf("Get volume info by path %s is failed, err:%s", path, err)
+			}
 			continue
 		}
 

--- a/pkg/metric/diskstat_collector.go
+++ b/pkg/metric/diskstat_collector.go
@@ -272,7 +272,6 @@ func isExceedLatencyThreshold(stats []string, lastStats []string, iopsIndex int,
 	incrementLatency := thisLatency - lastLatency
 	incrementIOPS := thisIOPS - lastIOPS
 	if almostEqualFloat64(incrementIOPS, 0) {
-		logrus.Errorf("Convert incrementIOPS %f to int is failed, err:number is zero", incrementIOPS)
 		return 0, false
 	}
 	if (incrementLatency / incrementIOPS) > threshold {
@@ -337,7 +336,6 @@ func (p *diskStatCollector) capacityEventAlert(valueFloat64 float64, pvcName str
 			return
 		}
 		if almostEqualFloat64(capacityTotalFloat64, 0) {
-			logrus.Errorf("Equal capacityTotalFloat64 %s and zero is true", stats[10])
 			return
 		}
 		usedPercentage := (valueFloat64 / capacityTotalFloat64) * 100

--- a/pkg/metric/diskstat_collector.go
+++ b/pkg/metric/diskstat_collector.go
@@ -301,7 +301,7 @@ func (p *diskStatCollector) latencyEventAlert(pvName string, pvcName string, pvc
 		thisLatency, exceed := isExceedLatencyThreshold(stats, lastStats.([]string), index, index+3, p.milliSecondsLatencyThreshold)
 		if exceed {
 			ref := &v1.ObjectReference{
-				Kind:      "Volume",
+				Kind:      "PersistentVolumeClaim",
 				Name:      pvcName,
 				UID:       "",
 				Namespace: pvcNamespace,
@@ -318,7 +318,7 @@ func (p *diskStatCollector) ioHangEventAlert(devName string, pvName string, pvcN
 		isHang := isIOHang(stats, lastStats.([]string))
 		if isHang {
 			ref := &v1.ObjectReference{
-				Kind:      "Volume",
+				Kind:      "PersistentVolumeClaim",
 				Name:      pvcName,
 				UID:       "",
 				Namespace: pvcNamespace,
@@ -331,7 +331,7 @@ func (p *diskStatCollector) ioHangEventAlert(devName string, pvName string, pvcN
 
 func (p *diskStatCollector) capacityEventAlert(valueFloat64 float64, pvcName string, pvcNamespace string, stats []string) {
 	if p.alertSwtichSet.Contains(capacitySwitch) {
-		capacityTotalFloat64, err := strconv.ParseFloat(stats[10], 64)
+		capacityTotalFloat64, err := strconv.ParseFloat(stats[11], 64)
 		if err != nil {
 			logrus.Errorf("Convert diskCapacityTotalDesc %s to float64 is failed, err:%s", stats[10], err)
 			return
@@ -343,7 +343,7 @@ func (p *diskStatCollector) capacityEventAlert(valueFloat64 float64, pvcName str
 		usedPercentage := (valueFloat64 / capacityTotalFloat64) * 100
 		if usedPercentage >= p.capacityPercentageThreshold {
 			ref := &v1.ObjectReference{
-				Kind:      "Volume",
+				Kind:      "PersistentVolumeClaim",
 				Name:      pvcName,
 				UID:       "",
 				Namespace: pvcNamespace,


### PR DESCRIPTION
Delete redundant log printing.
Fix the bug that restarting pod will reinstall ossfs.
Fix the bug that the capacity formula is calculated incorrectly.