### PR TITLE
fix repeat update pv annotations

### DIFF
--- a/pkg/local/controllerserver.go
+++ b/pkg/local/controllerserver.go
@@ -465,13 +465,17 @@ func (cs *controllerServer) DeleteVolume(ctx context.Context, req *csi.DeleteVol
 				return nil, err
 			}
 		} else if !types.GlobalConfigVar.GrpcProvision && nodeName != "" {
-			createLabels := map[string]string{}
-			createLabels[types.VolumeLifecycleLabel] = types.VolumeLifecycleDeleting
-			createLabels[types.VolumeSpecLabel] = vgName + "/" + volumeID
-			if err := generator.DeleteVolumeWithAnnotations(volumeID, createLabels); err != nil {
-				log.Errorf("DeleteVolume: delete volume with label for volume %s error: %s", volumeID, err.Error())
-				return nil, err
+			createAnnotations := map[string]string{}
+			createAnnotations[types.VolumeLifecycleLabel] = types.VolumeLifecycleDeleting
+			createAnnotations[types.VolumeSpecLabel] = vgName + "/" + volumeID
+			pvAnnotations := pvObj.Annotations
+			if pvAnnotations == nil || (pvAnnotations != nil && pvAnnotations[types.VolumeLifecycleLabel] != types.VolumeLifecycleDeleted) {
+				if err := generator.DeleteVolumeWithAnnotations(volumeID, createAnnotations); err != nil {
+					log.Errorf("DeleteVolume: delete volume with label for volume %s error: %s", volumeID, err.Error())
+					return nil, err
+				}
 			}
+
 			log.Infof("DeleteVolume: delete local volume %s with label at node %s", volumeID, nodeName)
 		} else {
 			log.Infof("DeleteVolume: delete local volume %s with node empty", volumeID)


### PR DESCRIPTION
when csi run on large kubernetes cluster , controller/DeleteVolume may return error before waiting successfully delete lv. 

The extener-provisioner will retry. But the  controller/DeleteVolume not check the PV's annotations , update it to deleting.