### PR TITLE
volume spec to kata

### DIFF
--- a/pkg/disk/nodeserver.go
+++ b/pkg/disk/nodeserver.go
@@ -383,21 +383,23 @@ func (ns *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 
-	// save volume data to json file
-	volumeData := map[string]string{}
-	volumeData["csi.alibabacloud.com/fsType"] = fsType
-	if len(options) != 0 {
-		volumeData["csi.alibabacloud.com/mountOptions"] = strings.Join(options, ",")
-	}
-	if value, ok := req.VolumeContext[MkfsOptions]; ok {
-		volumeData["csi.alibabacloud.com/mkfsOptions"] = value
-	}
-	fileName := filepath.Join(filepath.Dir(targetPath), utils.VolDataFileName)
-	if strings.HasSuffix(targetPath, "/") {
-		fileName = filepath.Join(filepath.Dir(filepath.Dir(targetPath)), utils.VolDataFileName)
-	}
-	if err = utils.AppendJsonData(fileName, volumeData); err != nil {
-		log.Warnf("NodeStageVolume: append volume spec to %s with error: %s", fileName, err.Error())
+	if utils.IsKataInstall() {
+		// save volume data to json file
+		volumeData := map[string]string{}
+		volumeData["csi.alibabacloud.com/fsType"] = fsType
+		if len(options) != 0 {
+			volumeData["csi.alibabacloud.com/mountOptions"] = strings.Join(options, ",")
+		}
+		if value, ok := req.VolumeContext[MkfsOptions]; ok {
+			volumeData["csi.alibabacloud.com/mkfsOptions"] = value
+		}
+		fileName := filepath.Join(filepath.Dir(targetPath), utils.VolDataFileName)
+		if strings.HasSuffix(targetPath, "/") {
+			fileName = filepath.Join(filepath.Dir(filepath.Dir(targetPath)), utils.VolDataFileName)
+		}
+		if err = utils.AppendJsonData(fileName, volumeData); err != nil {
+			log.Warnf("NodeStageVolume: append volume spec to %s with error: %s", fileName, err.Error())
+		}
 	}
 
 	log.Infof("NodePublishVolume: Mount Successful Volume: %s, from source %s to target %v", req.VolumeId, sourcePath, targetPath)

--- a/pkg/disk/nodeserver.go
+++ b/pkg/disk/nodeserver.go
@@ -383,6 +383,23 @@ func (ns *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 
+	// save volume data to json file
+	volumeData := map[string]string{}
+	volumeData["csi.alibabacloud.com/fsType"] = fsType
+	if len(options) != 0 {
+		volumeData["csi.alibabacloud.com/mountOptions"] = strings.Join(options, ",")
+	}
+	if value, ok := req.VolumeContext[MkfsOptions]; ok {
+		volumeData["csi.alibabacloud.com/mkfsOptions"] = value
+	}
+	fileName := filepath.Join(filepath.Dir(targetPath), utils.VolDataFileName)
+	if strings.HasSuffix(targetPath, "/") {
+		fileName = filepath.Join(filepath.Dir(filepath.Dir(targetPath)), utils.VolDataFileName)
+	}
+	if err = utils.AppendJsonData(fileName, volumeData); err != nil {
+		log.Warnf("NodeStageVolume: append volume spec to %s with error: %s", fileName, err.Error())
+	}
+
 	log.Infof("NodePublishVolume: Mount Successful Volume: %s, from source %s to target %v", req.VolumeId, sourcePath, targetPath)
 	return &csi.NodePublishVolumeResponse{}, nil
 }

--- a/pkg/disk/nodeserver.go
+++ b/pkg/disk/nodeserver.go
@@ -397,7 +397,7 @@ func (ns *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 		if strings.HasSuffix(targetPath, "/") {
 			fileName = filepath.Join(filepath.Dir(filepath.Dir(targetPath)), utils.VolDataFileName)
 		}
-		if err = utils.AppendJsonData(fileName, volumeData); err != nil {
+		if err = utils.AppendJSONData(fileName, volumeData); err != nil {
 			log.Warnf("NodeStageVolume: append volume spec to %s with error: %s", fileName, err.Error())
 		}
 	}

--- a/pkg/disk/nodeserver.go
+++ b/pkg/disk/nodeserver.go
@@ -387,8 +387,9 @@ func (ns *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 		// save volume data to json file
 		volumeData := map[string]string{}
 		volumeData["csi.alibabacloud.com/fsType"] = fsType
-		if len(options) != 0 {
-			volumeData["csi.alibabacloud.com/mountOptions"] = strings.Join(options, ",")
+		saveOptions := req.VolumeCapability.GetMount().MountFlags
+		if len(saveOptions) != 0 {
+			volumeData["csi.alibabacloud.com/mountOptions"] = strings.Join(saveOptions, ",")
 		}
 		if value, ok := req.VolumeContext[MkfsOptions]; ok {
 			volumeData["csi.alibabacloud.com/mkfsOptions"] = value

--- a/pkg/nas/nodeserver.go
+++ b/pkg/nas/nodeserver.go
@@ -331,7 +331,7 @@ func (ns *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 		if strings.HasSuffix(mountPath, "/") {
 			fileName = filepath.Join(filepath.Dir(filepath.Dir(mountPath)), utils.VolDataFileName)
 		}
-		if err = utils.AppendJsonData(fileName, volumeData); err != nil {
+		if err = utils.AppendJSONData(fileName, volumeData); err != nil {
 			log.Warnf("NodePublishVolume: append nas volume spec to %s with error: %s", fileName, err.Error())
 		}
 	}

--- a/pkg/nas/nodeserver.go
+++ b/pkg/nas/nodeserver.go
@@ -313,6 +313,27 @@ func (ns *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 	if !utils.IsMounted(mountPath) {
 		return nil, errors.New("Check mount fail after mount:" + mountPath)
 	}
+
+	// save volume data to json file
+	volumeData := map[string]string{}
+	volumeData["csi.alibabacloud.com/version"] = opt.Vers
+	if len(opt.Options) != 0 {
+		volumeData["csi.alibabacloud.com/options"] = opt.Options
+	}
+	if len(opt.Server) != 0 {
+		volumeData["csi.alibabacloud.com/server"] = opt.Server
+	}
+	if len(opt.Path) != 0 {
+		volumeData["csi.alibabacloud.com/path"] = opt.Path
+	}
+	fileName := filepath.Join(filepath.Dir(mountPath), utils.VolDataFileName)
+	if strings.HasSuffix(mountPath, "/") {
+		fileName = filepath.Join(filepath.Dir(filepath.Dir(mountPath)), utils.VolDataFileName)
+	}
+	if err = utils.AppendJsonData(fileName, volumeData); err != nil {
+		log.Warnf("NodePublishVolume: append nas volume spec to %s with error: %s", fileName, err.Error())
+	}
+
 	log.Infof("NodePublishVolume:: Volume %s Mount success on mountpoint: %s", req.VolumeId, mountPath)
 
 	return &csi.NodePublishVolumeResponse{}, nil

--- a/pkg/nas/nodeserver.go
+++ b/pkg/nas/nodeserver.go
@@ -315,23 +315,25 @@ func (ns *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 	}
 
 	// save volume data to json file
-	volumeData := map[string]string{}
-	volumeData["csi.alibabacloud.com/version"] = opt.Vers
-	if len(opt.Options) != 0 {
-		volumeData["csi.alibabacloud.com/options"] = opt.Options
-	}
-	if len(opt.Server) != 0 {
-		volumeData["csi.alibabacloud.com/server"] = opt.Server
-	}
-	if len(opt.Path) != 0 {
-		volumeData["csi.alibabacloud.com/path"] = opt.Path
-	}
-	fileName := filepath.Join(filepath.Dir(mountPath), utils.VolDataFileName)
-	if strings.HasSuffix(mountPath, "/") {
-		fileName = filepath.Join(filepath.Dir(filepath.Dir(mountPath)), utils.VolDataFileName)
-	}
-	if err = utils.AppendJsonData(fileName, volumeData); err != nil {
-		log.Warnf("NodePublishVolume: append nas volume spec to %s with error: %s", fileName, err.Error())
+	if utils.IsKataInstall() {
+		volumeData := map[string]string{}
+		volumeData["csi.alibabacloud.com/version"] = opt.Vers
+		if len(opt.Options) != 0 {
+			volumeData["csi.alibabacloud.com/options"] = opt.Options
+		}
+		if len(opt.Server) != 0 {
+			volumeData["csi.alibabacloud.com/server"] = opt.Server
+		}
+		if len(opt.Path) != 0 {
+			volumeData["csi.alibabacloud.com/path"] = opt.Path
+		}
+		fileName := filepath.Join(filepath.Dir(mountPath), utils.VolDataFileName)
+		if strings.HasSuffix(mountPath, "/") {
+			fileName = filepath.Join(filepath.Dir(filepath.Dir(mountPath)), utils.VolDataFileName)
+		}
+		if err = utils.AppendJsonData(fileName, volumeData); err != nil {
+			log.Warnf("NodePublishVolume: append nas volume spec to %s with error: %s", fileName, err.Error())
+		}
 	}
 
 	log.Infof("NodePublishVolume:: Volume %s Mount success on mountpoint: %s", req.VolumeId, mountPath)

--- a/pkg/utils/util.go
+++ b/pkg/utils/util.go
@@ -672,7 +672,7 @@ func GetPvNameFormPodMnt(mntPath string) string {
 	return ""
 }
 
-// AppendJsonData append map data to json file.
+// AppendJSONData append map data to json file.
 func AppendJSONData(dataFilePath string, appData map[string]string) error {
 	curData, err := loadJSONData(dataFilePath)
 	if err != nil {
@@ -692,7 +692,7 @@ func AppendJSONData(dataFilePath string, appData map[string]string) error {
 	return nil
 }
 
-// loadJsonData loads json info from specified json file
+// loadJSONData loads json info from specified json file
 func loadJSONData(dataFileName string) (map[string]string, error) {
 	file, err := os.Open(dataFileName)
 	if err != nil {

--- a/pkg/utils/util.go
+++ b/pkg/utils/util.go
@@ -673,8 +673,8 @@ func GetPvNameFormPodMnt(mntPath string) string {
 }
 
 // AppendJsonData append map data to json file.
-func AppendJsonData(dataFilePath string, appData map[string]string) error {
-	curData, err := loadJsonData(dataFilePath)
+func AppendJSONData(dataFilePath string, appData map[string]string) error {
+	curData, err := loadJSONData(dataFilePath)
 	if err != nil {
 		return err
 	}
@@ -693,7 +693,7 @@ func AppendJsonData(dataFilePath string, appData map[string]string) error {
 }
 
 // loadJsonData loads json info from specified json file
-func loadJsonData(dataFileName string) (map[string]string, error) {
+func loadJSONData(dataFileName string) (map[string]string, error) {
 	file, err := os.Open(dataFileName)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open json data file [%s]: %v", dataFileName, err)

--- a/pkg/utils/util.go
+++ b/pkg/utils/util.go
@@ -705,3 +705,11 @@ func loadJsonData(dataFileName string) (map[string]string, error) {
 	}
 	return data, nil
 }
+
+// IsKataInstall check kata daemon installed
+func IsKataInstall() bool {
+	if IsFileExisting("/host/etc/kata-containers") || IsFileExisting("/host/etc/kata-containers2") {
+		return true
+	}
+	return false
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind feature
-->

#### What this PR does / why we need it:
kata runtime need mount options.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

record volume spec to vol_data.json file, and kata runtime can get spec from the file.

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
