### PR TITLE
support multi-zones node for virtual node

### DIFF
--- a/pkg/disk/controllerserver.go
+++ b/pkg/disk/controllerserver.go
@@ -26,7 +26,7 @@ import (
 	"strings"
 	"time"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/tools/record"
 
 	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/requests"
@@ -34,7 +34,7 @@ import (
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/golang/protobuf/ptypes"
 	"github.com/golang/protobuf/ptypes/timestamp"
-	"github.com/kubernetes-csi/drivers/pkg/csi-common"
+	csicommon "github.com/kubernetes-csi/drivers/pkg/csi-common"
 	volumeSnasphotV1 "github.com/kubernetes-csi/external-snapshotter/client/v4/apis/volumesnapshot/v1"
 	snapClientset "github.com/kubernetes-csi/external-snapshotter/client/v4/clientset/versioned"
 	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/disk/crds"
@@ -290,18 +290,7 @@ func (cs *controllerServer) CreateVolume(ctx context.Context, req *csi.CreateVol
 			return nil, status.Errorf(codes.Internal, "exist disk %s is different with requested for disk", req.GetName())
 		}
 		log.Infof("CreateVolume: Volume %s is already created: %s, %s, %s, %d", req.GetName(), disk.DiskId, disk.RegionId, disk.ZoneId, disk.Size)
-		tmpVol := &csi.Volume{
-			VolumeId:      disk.DiskId,
-			CapacityBytes: int64(volSizeBytes),
-			VolumeContext: req.GetParameters(),
-			AccessibleTopology: []*csi.Topology{
-				{
-					Segments: map[string]string{
-						TopologyZoneKey: diskVol.ZoneID,
-					},
-				},
-			},
-		}
+		tmpVol := volumeCreate(disk.DiskId, volSizeBytes, req.GetParameters(), diskVol.ZoneID, nil)
 		return &csi.CreateVolumeResponse{Volume: tmpVol}, nil
 	}
 
@@ -452,19 +441,7 @@ func (cs *controllerServer) CreateVolume(ctx context.Context, req *csi.CreateVol
 		}
 	}
 
-	tmpVol := &csi.Volume{
-		VolumeId:      volumeResponse.DiskId,
-		CapacityBytes: int64(volSizeBytes),
-		VolumeContext: volumeContext,
-		AccessibleTopology: []*csi.Topology{
-			{
-				Segments: map[string]string{
-					TopologyZoneKey: diskVol.ZoneID,
-				},
-			},
-		},
-		ContentSource: src,
-	}
+	tmpVol := volumeCreate(volumeResponse.DiskId, volSizeBytes, volumeContext, diskVol.ZoneID, src)
 
 	diskIDPVMap[volumeResponse.DiskId] = req.Name
 	createdVolumeMap[req.Name] = tmpVol

--- a/pkg/disk/nodeserver.go
+++ b/pkg/disk/nodeserver.go
@@ -25,7 +25,7 @@ import (
 
 	"github.com/aliyun/alibaba-cloud-sdk-go/services/ecs"
 	"github.com/container-storage-interface/spec/lib/go/csi"
-	"github.com/kubernetes-csi/drivers/pkg/csi-common"
+	csicommon "github.com/kubernetes-csi/drivers/pkg/csi-common"
 	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/options"
 	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/utils"
 	log "github.com/sirupsen/logrus"
@@ -112,6 +112,8 @@ const (
 	MaxVolumesPerNode = 15
 	// NOUUID is xfs fs mount opts
 	NOUUID = "nouuid"
+	// NodeMultiZoneEnable Enable node multi-zone mode
+	NodeMultiZoneEnable = "NODE_MULTI_ZONE_ENABLE"
 )
 
 var (


### PR DESCRIPTION
A virtual nodes can manage pods in different zones, so CSI provisioner needs to support multi-zone nodes.

After this feature is enabled, CSI provisioner can find all zones supported by the multi-zone nodes, and add affinity information compatible with multi-zone nodes for PV during PV production.