### PR TITLE
Add a parameter to the schema to automatically increase volume sizes …

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,6 +30,7 @@ require (
 	github.com/stretchr/testify v1.7.0
 	go.uber.org/ratelimit v0.1.0
 	golang.org/x/crypto v0.0.0-20200820211705-5c72a883971a // indirect
+	golang.org/x/lint v0.0.0-20210508222113-6edffad5e616 // indirect
 	golang.org/x/net v0.0.0-20200904194848-62affa334b73
 	golang.org/x/text v0.3.3 // indirect
 	golang.org/x/time v0.0.0-20200630173020-3af7569d3a1e // indirect

--- a/pkg/disk/controllerserver.go
+++ b/pkg/disk/controllerserver.go
@@ -97,6 +97,10 @@ const (
 	DefaultVolumeSnapshotClass = "alibabacloud-disk-snapshot"
 	// annDiskID tag
 	annDiskID = "volume.alibabacloud.com/disk-id"
+	// MinimumDiskSizeInGB ...
+	MinimumDiskSizeInGB = 20
+	// MinimumDiskSizeInBytes ...
+	MinimumDiskSizeInBytes = 21474836480
 )
 
 const (
@@ -135,19 +139,20 @@ type controllerServer struct {
 
 // Alicloud disk parameters
 type diskVolumeArgs struct {
-	Type             string              `json:"type"`
-	RegionID         string              `json:"regionId"`
-	ZoneID           string              `json:"zoneId"`
-	FsType           string              `json:"fsType"`
-	ReadOnly         bool                `json:"readOnly"`
-	MultiAttach      string              `json:"multiAttach"`
-	Encrypted        bool                `json:"encrypted"`
-	KMSKeyID         string              `json:"kmsKeyId"`
-	PerformanceLevel string              `json:"performanceLevel"`
-	ResourceGroupID  string              `json:"resourceGroupId"`
-	DiskTags         string              `json:"diskTags"`
-	NodeSelected     string              `json:"nodeSelected"`
-	ARN              []ecs.CreateDiskArn `json:"arn"`
+	Type                    string              `json:"type"`
+	RegionID                string              `json:"regionId"`
+	ZoneID                  string              `json:"zoneId"`
+	FsType                  string              `json:"fsType"`
+	ReadOnly                bool                `json:"readOnly"`
+	MultiAttach             string              `json:"multiAttach"`
+	Encrypted               bool                `json:"encrypted"`
+	KMSKeyID                string              `json:"kmsKeyId"`
+	PerformanceLevel        string              `json:"performanceLevel"`
+	ResourceGroupID         string              `json:"resourceGroupId"`
+	DiskTags                string              `json:"diskTags"`
+	NodeSelected            string              `json:"nodeSelected"`
+	ARN                     []ecs.CreateDiskArn `json:"arn"`
+	VolumeSizeAutoAvailable bool                `json:"volumeSizeAutoAvailable"`
 }
 
 // Alicloud disk snapshot parameters
@@ -275,6 +280,11 @@ func (cs *controllerServer) CreateVolume(ctx context.Context, req *csi.CreateVol
 	}
 	volSizeBytes := int64(req.GetCapacityRange().GetRequiredBytes())
 	requestGB := int((volSizeBytes + 1024*1024*1024 - 1) / (1024 * 1024 * 1024))
+	if diskVol.VolumeSizeAutoAvailable && requestGB < MinimumDiskSizeInGB {
+		log.Infof("CreateVolume: volume size was less than allowed limit. Setting request Size to %vGB. volumeSizeAutoAvailable is set.", MinimumDiskSizeInGB)
+		requestGB = MinimumDiskSizeInGB
+		volSizeBytes = MinimumDiskSizeInBytes
+	}
 	sharedDisk := diskVol.Type == DiskSharedEfficiency || diskVol.Type == DiskSharedSSD
 	nodeSupportDiskType := []string{}
 	if diskVol.NodeSelected != "" {

--- a/pkg/disk/utils.go
+++ b/pkg/disk/utils.go
@@ -23,7 +23,6 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	v1 "k8s.io/api/core/v1"
 	"net"
 	"net/http"
 	"os"
@@ -35,6 +34,8 @@ import (
 	"strings"
 	"time"
 	"unicode"
+
+	v1 "k8s.io/api/core/v1"
 
 	aliyunep "github.com/aliyun/alibaba-cloud-sdk-go/sdk/endpoints"
 	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/requests"
@@ -1100,6 +1101,19 @@ func getDiskVolumeOptions(req *csi.CreateVolumeRequest) (*diskVolumeArgs, error)
 	diskVolArgs.ResourceGroupID, ok = volOptions["resourceGroupId"]
 	if !ok {
 		diskVolArgs.ResourceGroupID = ""
+	}
+
+	// volumeSizeAutoAvailable
+	value, ok = volOptions["volumeSizeAutoAvailable"]
+	if !ok {
+		diskVolArgs.VolumeSizeAutoAvailable = false
+	} else {
+		value = strings.ToLower(value)
+		if value == "yes" || value == "true" || value == "1" {
+			diskVolArgs.VolumeSizeAutoAvailable = true
+		} else {
+			diskVolArgs.VolumeSizeAutoAvailable = false
+		}
 	}
 
 	return diskVolArgs, nil

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -553,7 +553,7 @@ k8s.io/kubernetes/pkg/volume/util/fsquota/common
 k8s.io/kubernetes/pkg/volume/util/hostutil
 k8s.io/kubernetes/pkg/volume/util/recyclerclient
 k8s.io/kubernetes/pkg/volume/util/subpath
-# k8s.io/utils v0.0.0-20200324210504-a9aa75ae1b89 => k8s.io/utils v0.0.0-20200324210504-a9aa75ae1b89
+# k8s.io/utils v0.0.0-20211116205334-6203023598ed => k8s.io/utils v0.0.0-20200324210504-a9aa75ae1b89
 k8s.io/utils/buffer
 k8s.io/utils/exec
 k8s.io/utils/integer


### PR DESCRIPTION
…to Alibaba minimum limit of 20Gi

#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
Currently Alibaba Cloud provider has a minimum volume size limit of 20 GiB. This current behavior causes the test cases for statefulsets (use 1KiB) as well as some PVC (use 1MiB) tests to fail.

This pull request adds a flag to the storage class, that when set, allows the cloud provider to provision the minimum size (currently 20GiB) for requested volumes that are smaller than this limit.

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Added allowIncrease flag to storageclass parameters for the ability to automatically increase volumes to the minimum size of 20GB. The flag is false by default.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs
```
