### PR TITLE
add retry logic for ossfs install and upgrade for entrypoint of amd64

### DIFF
--- a/build/lib/amd64-entrypoint.sh
+++ b/build/lib/amd64-entrypoint.sh
@@ -125,23 +125,63 @@ if [ "$run_oss" = "true" ]; then
 
 	if [[ ${reconcileOssFS} == "install" ]]; then
       if [[ ${host_os} == "lifsea" ]]; then
-          rpm2cpio /root/ossfs_${ossfsVer}_${ossfsArch}_x86_64.rpm | cpio -idmv
+          for((i=1;i<=5;i++));
+          do
+            echo "Starting install ossfs in ${host_os}."
+            rpm2cpio /root/ossfs_${ossfsVer}_${ossfsArch}_x86_64.rpm | cpio -idmv
+            if [ $? -eq 0 ]; then
+                break
+            else
+                echo "Starting retry again install ossfs in ${host_os}.retry count:$i"
+                sleep 2
+            fi
+          done
           cp ./usr/local/bin/ossfs /host/etc/csi-tool/
           ${HOST_CMD} cp /etc/csi-tool/ossfs /usr/local/bin/ossfs
       else
-          ${HOST_CMD} rpm -i /etc/csi-tool/ossfs_${ossfsVer}_${ossfsArch}_x86_64.rpm
+          for((i=1;i<=5;i++));
+          do
+            echo "Starting install ossfs in ${host_os}."
+            ${HOST_CMD} rpm -i /etc/csi-tool/ossfs_${ossfsVer}_${ossfsArch}_x86_64.rpm
+            if [ $? -eq 0 ]; then
+                break
+            else
+                echo "Starting retry again install ossfs in ${host_os}.retry count:$i"
+                sleep 2
+            fi
+          done
       fi
     fi
 
     if [[ ${reconcileOssFS} == "upgrade" ]]; then
       if [[ ${host_os} == "lifsea" ]]; then
           ${HOST_CMD}  rm /usr/local/bin/ossfs
-          rpm2cpio /root/ossfs_${ossfsVer}_${ossfsArch}_x86_64.rpm | cpio -idmv
+          for((i=1;i<=5;i++));
+          do
+            echo "Starting upgrade ossfs in ${host_os}."
+            rpm2cpio /root/ossfs_${ossfsVer}_${ossfsArch}_x86_64.rpm | cpio -idmv
+            if [ $? -eq 0 ]; then
+                break
+            else
+                echo "Starting retry again upgrade ossfs in ${host_os}.retry count:$i"
+                sleep 2
+            fi
+          done
           cp ./usr/local/bin/ossfs /host/etc/csi-tool/
           ${HOST_CMD}  cp /etc/csi-tool/ossfs /usr/local/bin/ossfs
       else
           ${HOST_CMD}  yum remove -y ossfs
-          ${HOST_CMD}  rpm -i /etc/csi-tool/ossfs_${ossfsVer}_${ossfsArch}_x86_64.rpm
+          for((i=1;i<=5;i++));
+          do
+            echo "Starting upgrade ossfs in ${host_os}."
+            ${HOST_CMD} rpm -i /etc/csi-tool/ossfs_${ossfsVer}_${ossfsArch}_x86_64.rpm
+            if [ $? -eq 0 ]; then
+                break
+            else
+                echo "Starting retry again upgrade ossfs in ${host_os}.retry count:$i"
+                sleep 2
+            fi
+          done
       fi
     fi
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Retry to install / upgrade ossfs when getting rpm lock failed.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:
Only fixed in AMD arch as rpm is not used in ARM arch entrypoint in current version.
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
