### PR TITLE
remove meaningless SafePathRemove function

### DIFF
--- a/pkg/dbfs/nodeserver.go
+++ b/pkg/dbfs/nodeserver.go
@@ -287,7 +287,7 @@ func (ns *nodeServer) NodeUnstageVolume(ctx context.Context, req *csi.NodeUnstag
 			msgLog = fmt.Sprintf("NodeUnstageVolume: VolumeId: %s, mountpoint: %s not mounted, skipping", req.VolumeId, req.StagingTargetPath)
 		}
 		// safe remove mountpoint
-		err = ns.mounter.SafePathRemove(req.StagingTargetPath)
+		err = os.Remove(req.StagingTargetPath)
 		if err != nil {
 			log.Log.Errorf("NodeUnstageVolume: VolumeId: %s, Remove targetPath failed, target %v", req.VolumeId, req.StagingTargetPath)
 			return nil, status.Error(codes.Internal, err.Error())

--- a/pkg/disk/nodeserver.go
+++ b/pkg/disk/nodeserver.go
@@ -799,7 +799,7 @@ func (ns *nodeServer) NodeUnstageVolume(ctx context.Context, req *csi.NodeUnstag
 			msgLog = fmt.Sprintf("NodeUnstageVolume: VolumeId: %s, mountpoint: %s not mounted, skipping and continue to detach", req.VolumeId, targetPath)
 		}
 		// safe remove mountpoint
-		err = ns.mounter.SafePathRemove(targetPath)
+		err = os.Remove(targetPath)
 		if err != nil {
 			log.Log.Errorf("NodeUnstageVolume: VolumeId: %s, Remove targetPath failed, target %v", req.VolumeId, targetPath)
 			return nil, status.Error(codes.Internal, err.Error())

--- a/pkg/ens/nodeserver.go
+++ b/pkg/ens/nodeserver.go
@@ -500,7 +500,7 @@ func (ns *nodeServer) NodeUnstageVolume(ctx context.Context, req *csi.NodeUnstag
 			msgLog = fmt.Sprintf("NodeUnstageVolume: VolumeId: %s, mountpoint: %s not mounted, skipping and continue to detach", req.VolumeId, targetPath)
 		}
 		// safe remove mountpoint
-		err = ns.mounter.SafePathRemove(targetPath)
+		err = os.Remove(targetPath)
 		if err != nil {
 			log.Errorf("NodeUnstageVolume: VolumeId: %s, Remove targetPath failed, target %v", req.VolumeId, targetPath)
 			return nil, status.Error(codes.Internal, err.Error())

--- a/pkg/utils/mounter.go
+++ b/pkg/utils/mounter.go
@@ -88,8 +88,6 @@ type Mounter interface {
 
 	IsNotMountPoint(file string) (bool, error)
 
-	SafePathRemove(target string) error
-
 	HasMountRefs(mountPath string, mountRefs []string) bool
 }
 
@@ -317,34 +315,6 @@ func (m *mounter) IsMounted(target string) (bool, error) {
 		return true, nil
 	}
 	return false, nil
-}
-
-func (m *mounter) SafePathRemove(targetPath string) error {
-	fo, err := os.Lstat(targetPath)
-	if err != nil {
-		return err
-	}
-	isMounted, err := m.IsMounted(targetPath)
-	if err != nil {
-		return err
-	}
-	if isMounted {
-		return errors.New("Path is mounted, not remove: " + targetPath)
-	}
-	if fo.IsDir() {
-		empty, err := IsDirEmpty(targetPath)
-		if err != nil {
-			return errors.New("Check path empty error: " + targetPath + err.Error())
-		}
-		if !empty {
-			return errors.New("Cannot remove Path not empty: " + targetPath)
-		}
-	}
-	err = os.Remove(targetPath)
-	if err != nil {
-		return err
-	}
-	return nil
 }
 
 func (m *mounter) HasMountRefs(mountPath string, mountRefs []string) bool {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

remove meaningless SafePathRemove function

SafePathRemove checks whether the target path is mounted, or if it is a directory, check whether it is empty before removing. However, this approach is not atomic, thus unreliable. And os.Remove already properly returns error in these 2 cases:
* When removing a mount point, it returns "device or resource busy"
* When removing a non-empty directory, it returns "directory not empty"

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
