### PR TITLE
bugfix: silence metrics volume devices logic

### DIFF
--- a/pkg/metric/disk_stat_collector.go
+++ b/pkg/metric/disk_stat_collector.go
@@ -429,6 +429,9 @@ func (p *diskStatCollector) updateMap(lastPvDiskInfoMap *map[string]diskInfo, js
 			logrus.Errorf("Get dev name by diskID %s is failed, err:%s", diskID, err)
 			continue
 		}
+		if deviceName == "" {
+			continue
+		}
 		diskInfo := diskInfo{
 			DiskID:      diskID,
 			DeviceName:  deviceName,

--- a/pkg/metric/pfs_stat_collector.go
+++ b/pkg/metric/pfs_stat_collector.go
@@ -207,6 +207,9 @@ func (p *pfsRawBlockStatCollector) updateMap(clientSet *kubernetes.Clientset, la
 			logrus.Errorf("Get dev name by diskID %s is failed, err:%s", diskID, err)
 			continue
 		}
+		if deviceName == "" {
+			continue
+		}
 		strorageInfo := pfsInfo{
 			DiskID:      diskID,
 			DeviceName:  deviceName,

--- a/pkg/metric/utils.go
+++ b/pkg/metric/utils.go
@@ -201,11 +201,12 @@ func getDeviceByVolumeID(pvName, volumeID string) (device string, err error) {
 	}
 
 	if device, err = getDeviceBySymlink(volumeID); err != nil {
+		// strange logic... ignore findmnt error
 		mountPath := filepath.Join(utils.KubeletRootDir, "/plugins/kubernetes.io/csi/volumeDevices/staging", pvName, volumeID)
 		cmd := fmt.Sprintf("findmnt -o SOURCE --noheadings %s", mountPath)
 		out, err := utils.Run(cmd)
 		if err != nil {
-			return "", fmt.Errorf("getDeviceByVolumeID %s with error %s", volumeID, err.Error())
+			return "", nil
 		}
 		mountInfo := strings.TrimSpace(out)
 		if strings.HasPrefix(mountInfo, "devtmpfs[") && strings.HasSuffix(mountInfo, "]") {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Solve "Get dev name by diskID xxxx  failed, err:getDeviceByVolumeIDxxxxx with error Failed to run cmd: findmnt" error

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
None

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
