### PR TITLE
Changes to get reasonable csi-sanity test results

### DIFF
--- a/pkg/disk/controllerserver.go
+++ b/pkg/disk/controllerserver.go
@@ -237,6 +237,9 @@ func (cs *controllerServer) CreateVolume(ctx context.Context, req *csi.CreateVol
 	}
 
 	volumeContext := req.GetParameters()
+	if volumeContext == nil {
+		volumeContext = make(map[string]string)
+	}
 	if sharedDisk {
 		volumeContext[SharedEnable] = "enable"
 	}

--- a/pkg/disk/nodeserver.go
+++ b/pkg/disk/nodeserver.go
@@ -497,6 +497,10 @@ func (ns *nodeServer) NodeUnpublishVolume(ctx context.Context, req *csi.NodeUnpu
 		log.Log.Errorf("NodeUnpublishVolume: TargetPath mounted yet, volumeId %s with target %s", req.VolumeId, targetPath)
 		return nil, status.Error(codes.Internal, "NodeUnpublishVolume: TargetPath mounted yet with target "+targetPath)
 	}
+	err = os.Remove(targetPath)
+	if err != nil {
+		return nil, status.Error(codes.Internal, fmt.Sprintf("NodeUnpublishVolume: Cannot remove targetPath %s: %v", targetPath, err))
+	}
 
 	// below directory can not be umounted by kubelet in ack
 	if err := ns.unmountDuplicateMountPoint(targetPath, req.VolumeId); err != nil {

--- a/pkg/disk/nodeserver.go
+++ b/pkg/disk/nodeserver.go
@@ -338,9 +338,6 @@ func (ns *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 		return &csi.NodePublishVolumeResponse{}, nil
 	}
 
-	if !strings.HasSuffix(targetPath, "/mount") {
-		return nil, status.Errorf(codes.InvalidArgument, "NodePublishVolume: volume %s malformed the value of target path: %s", req.VolumeId, targetPath)
-	}
 	if err := ns.mounter.EnsureFolder(targetPath); err != nil {
 		log.Log.Errorf("NodePublishVolume: create volume %s path %s error: %v", req.VolumeId, targetPath, err)
 		return nil, status.Error(codes.Internal, err.Error())

--- a/pkg/ens/nodeserver.go
+++ b/pkg/ens/nodeserver.go
@@ -143,9 +143,6 @@ func (ns *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 		return &csi.NodePublishVolumeResponse{}, nil
 	}
 
-	if !strings.HasSuffix(targetPath, "/mount") {
-		return nil, status.Errorf(codes.InvalidArgument, "NodePublishVolume: volume %s malformed the value of target path: %s", req.VolumeId, targetPath)
-	}
 	if err := ns.mounter.EnsureFolder(targetPath); err != nil {
 		log.Errorf("NodePublishVolume: create volume %s path %s error: %v", req.VolumeId, targetPath, err)
 		return nil, status.Error(codes.Internal, err.Error())

--- a/pkg/ens/nodeserver.go
+++ b/pkg/ens/nodeserver.go
@@ -269,6 +269,10 @@ func (ns *nodeServer) NodeUnpublishVolume(ctx context.Context, req *csi.NodeUnpu
 		log.Errorf("NodeUnpublishVolume: TargetPath mounted yet, volumeId %s with target %s", req.VolumeId, targetPath)
 		return nil, status.Error(codes.Internal, "NodeUnpublishVolume: TargetPath mounted yet with target "+targetPath)
 	}
+	err = os.Remove(targetPath)
+	if err != nil {
+		return nil, status.Error(codes.Internal, fmt.Sprintf("NodeUnpublishVolume: Cannot remove targetPath %s: %v", targetPath, err))
+	}
 
 	// below directory can not be umounted by kubelet in ack
 	if err := ns.unmountDuplicateMountPoint(targetPath); err != nil {

--- a/pkg/oss/controllerserver.go
+++ b/pkg/oss/controllerserver.go
@@ -119,6 +119,9 @@ func (cs *controllerServer) CreateVolume(ctx context.Context, req *csi.CreateVol
 	ossVol := getOssVolumeOptions(req)
 	csiTargetVolume := &csi.Volume{}
 	volumeContext := req.GetParameters()
+	if volumeContext == nil {
+		volumeContext = map[string]string{}
+	}
 	volumeContext["path"] = ossVol.Path
 	volSizeBytes := int64(req.GetCapacityRange().GetRequiredBytes())
 	csiTargetVolume = &csi.Volume{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Fix some low risk issue that prevent csi-sanity from producing reasonable result.

* `NodePublishVolume`: don't require `targetPath` to end with /mount
* in `CreateVolume`, `parameters` are optional and can be `nil`, fix the panic in this case
* `NodeUnpublishVolume` should delete `targetPath` as per [CSI spec](https://github.com/container-storage-interface/spec/blob/master/spec.md#nodeunpublishvolume):
  > The SP MUST delete the file or directory it created at this path.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
