### PR TITLE
Fix max volume count

### DIFF
--- a/pkg/disk/cloud.go
+++ b/pkg/disk/cloud.go
@@ -1042,3 +1042,12 @@ func getDefaultDiskTags(diskVol *diskVolumeArgs) []ecs.CreateDiskTag {
 	}
 	return diskTags
 }
+
+func IsDiskCreatedByCsi(disk ecs.Disk) bool {
+	for _, tag := range disk.Tags.Tag {
+		if tag.TagKey == DISKTAGKEY2 {
+			return tag.TagValue == DISKTAGVALUE2
+		}
+	}
+	return false
+}

--- a/pkg/disk/nodeserver.go
+++ b/pkg/disk/nodeserver.go
@@ -132,24 +132,6 @@ type QueryResponse struct {
 
 // NewNodeServer creates node server
 func NewNodeServer(d *csicommon.CSIDriver, c *ecs.Client) csi.NodeServer {
-	var maxVolumesNum int64 = MaxVolumesPerNode
-	volumeNum := os.Getenv("MAX_VOLUMES_PERNODE")
-	if "" != volumeNum {
-		num, err := strconv.ParseInt(volumeNum, 10, 64)
-		if err != nil {
-			log.Log.Fatalf("NewNodeServer: MAX_VOLUMES_PERNODE must be int64, but get: %s", volumeNum)
-		} else {
-			if num < 0 || num > 64 {
-				log.Log.Errorf("NewNodeServer: MAX_VOLUMES_PERNODE must between 0-15, but get: %s", volumeNum)
-			} else {
-				maxVolumesNum = num
-				log.Log.Infof("NewNodeServer: MAX_VOLUMES_PERNODE is set to(not default): %d", maxVolumesNum)
-			}
-		}
-	} else {
-		maxVolumesNum = getVolumeCount()
-	}
-
 	zoneID := GlobalConfigVar.ZoneID
 	nodeID := GlobalConfigVar.NodeID
 	internalMode := os.Getenv("INTERNAL_MODE")
@@ -168,6 +150,24 @@ func NewNodeServer(d *csicommon.CSIDriver, c *ecs.Client) csi.NodeServer {
 
 	if GlobalConfigVar.NodeID == "" {
 		GlobalConfigVar.NodeID = nodeID
+	}
+
+	var maxVolumesNum int64 = MaxVolumesPerNode
+	volumeNum := os.Getenv("MAX_VOLUMES_PERNODE")
+	if "" != volumeNum {
+		num, err := strconv.ParseInt(volumeNum, 10, 64)
+		if err != nil {
+			log.Log.Fatalf("NewNodeServer: MAX_VOLUMES_PERNODE must be int64, but get: %s", volumeNum)
+		} else {
+			if num < 0 || num > 64 {
+				log.Log.Errorf("NewNodeServer: MAX_VOLUMES_PERNODE must between 0-15, but get: %s", volumeNum)
+			} else {
+				maxVolumesNum = num
+				log.Log.Infof("NewNodeServer: MAX_VOLUMES_PERNODE is set to(not default): %d", maxVolumesNum)
+			}
+		}
+	} else {
+		maxVolumesNum = getVolumeCount()
 	}
 
 	// Create Directory


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

When deciding the number of supported volumes for the disk driver, we are not counting for the already mounted volumes by the previous instance of this plugin.

This PR partially fixes this by calling `DescribeDisks` and counting for the disks provisioned by CSI. However, the static PVs are still not counted and would cause fewer volumes can be scheduled to this node.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
