### PR TITLE
disk: update extended resource on startup

### DIFF
--- a/pkg/disk/constants.go
+++ b/pkg/disk/constants.go
@@ -3,6 +3,8 @@ package disk
 import (
 	"fmt"
 	"time"
+
+	k8sv1 "k8s.io/api/core/v1"
 )
 
 const (
@@ -55,6 +57,8 @@ const (
 	MinimumDiskSizeInGB = 20
 	// MinimumDiskSizeInBytes ...
 	MinimumDiskSizeInBytes = 21474836480
+
+	DiskExtendedResourceName = k8sv1.ResourceName("alibabacloud.com/disk")
 
 	// LastApplyKey key
 	LastApplyKey = "kubectl.kubernetes.io/last-applied-configuration"

--- a/pkg/disk/nodeserver.go
+++ b/pkg/disk/nodeserver.go
@@ -180,7 +180,7 @@ func NewNodeServer(d *csicommon.CSIDriver, c *ecs.Client) csi.NodeServer {
 	} else {
 		log.Log.Infof("Currently node is NOT VF model")
 	}
-	go UpdateNode(GlobalConfigVar.NodeID, c)
+	go UpdateNode(GlobalConfigVar.NodeID, c, maxVolumesNum)
 
 	if GlobalConfigVar.CheckBDFHotPlugin {
 		go checkVfhpOnlineReconcile()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Gives more visibility to users.

Also open the door to more flexible scheduling. In the future, we may dynamically update this, coordinate with DBFS drivers, etc.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

#### Special notes for your reviewer:

https://kubernetes.io/docs/tasks/administer-cluster/extended-resource-node/

terway already advertise a resource `aliyun/member-eni`, which is inconsistent with our `alibabacloud.com/disk`.
But I still want to follow the convention of using a domain name.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
publish a new resource type `alibabacloud.com/disk`, indicating the total number of disks available for pods. Not used for scheduling yet.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
