### PR TITLE
unify status.Errorf usage

### DIFF
--- a/pkg/dbfs/nodeserver.go
+++ b/pkg/dbfs/nodeserver.go
@@ -247,7 +247,7 @@ func (ns *nodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVol
 	// Do mount
 	if err := ns.DoDBFSMount(req, req.StagingTargetPath, req.VolumeId); err != nil {
 		log.Log.Errorf("NodeStageVolume: Stage DBFS %s with error: %s", req.VolumeId, err.Error())
-		return nil, status.Error(codes.Internal, fmt.Sprintf("NodeStageVolume: Stage DBFS volumeid: %s, err: %v", req.VolumeId, err.Error()))
+		return nil, status.Errorf(codes.Internal, "NodeStageVolume: Stage DBFS volumeid: %s, err: %v", req.VolumeId, err.Error())
 	}
 
 	log.Log.Infof("NodeStageVolume: Stage DBFS Successful, volumeId: %s target %v", req.VolumeId, req.StagingTargetPath)

--- a/pkg/disk/cloud.go
+++ b/pkg/disk/cloud.go
@@ -814,7 +814,7 @@ func requestAndCreateSnapshot(ecsClient *ecs.Client, sourceVolumeID, snapshotNam
 	// Do Snapshot create
 	snapshotResponse, err := ecsClient.CreateSnapshot(createSnapshotRequest)
 	if err != nil {
-		return nil, status.Error(codes.Internal, fmt.Sprintf("failed create snapshot: %v", err))
+		return nil, status.Errorf(codes.Internal, "failed create snapshot: %v", err)
 	}
 	return snapshotResponse, nil
 }
@@ -828,7 +828,7 @@ func requestAndDeleteSnapshot(snapshotID string, forceDelete bool) (*ecs.DeleteS
 	}
 	response, err := GlobalConfigVar.EcsClient.DeleteSnapshot(deleteSnapshotRequest)
 	if err != nil {
-		return response, status.Error(codes.Internal, fmt.Sprintf("failed delete snapshot: %v", err))
+		return response, status.Errorf(codes.Internal, "failed delete snapshot: %v", err)
 	}
 	return response, nil
 }
@@ -928,7 +928,7 @@ func createDisk(diskName, snapshotID string, requestGB int, diskVol *diskVolumeA
 		}
 		err = rerr
 	}
-	return "", "", "", status.Error(codes.Internal, fmt.Sprintf("createDisk: err: %v, the zone:[%s] is not support specific disk type, please change the request disktype: %s or disk pl: %s", err, diskVol.ZoneID, diskTypes, diskPLs))
+	return "", "", "", status.Errorf(codes.Internal, "createDisk: err: %v, the zone:[%s] is not support specific disk type, please change the request disktype: %s or disk pl: %s", err, diskVol.ZoneID, diskTypes, diskPLs)
 }
 
 // reuse rpcrequest in ecs sdk is forbidden, because parameters can't be reassigned with empty string.(ecs sdk bug)
@@ -1008,7 +1008,7 @@ cusDiskType:
 		provisionDiskTypes = intersect(nodeSupportDiskType, allTypes)
 		if len(provisionDiskTypes) == 0 {
 			log.Log.Errorf("CreateVolume:: node(%s) support type: [%v] is incompatible with provision disk type: [%s]", diskVol.NodeSelected, nodeSupportDiskType, allTypes)
-			return nil, nil, status.Error(codes.InvalidArgument, fmt.Sprintf("CreateVolume:: node support type: [%v] is incompatible with provision disk type: [%s]", nodeSupportDiskType, allTypes))
+			return nil, nil, status.Errorf(codes.InvalidArgument, "CreateVolume:: node support type: [%v] is incompatible with provision disk type: [%s]", nodeSupportDiskType, allTypes)
 		}
 	} else {
 		provisionDiskTypes = allTypes

--- a/pkg/disk/controllerserver.go
+++ b/pkg/disk/controllerserver.go
@@ -461,7 +461,7 @@ func getVolumeSnapshotConfig(req *csi.CreateSnapshotRequest) (int, bool, int, st
 	if value, ok := params[RETENTIONDAYS]; ok {
 		days, err := strconv.Atoi(value)
 		if err != nil {
-			err := status.Error(codes.InvalidArgument, fmt.Sprintf("CreateSnapshot: retentiondays err %s", value))
+			err := status.Errorf(codes.InvalidArgument, "CreateSnapshot: retentiondays err %s", value)
 			return retentionDays, useInstanceAccess, instantAccessRetentionDays, "", err
 		}
 		retentionDays = days
@@ -469,7 +469,7 @@ func getVolumeSnapshotConfig(req *csi.CreateSnapshotRequest) (int, bool, int, st
 	if value, ok := params[INSTANTACCESSRETENTIONDAYS]; ok {
 		days, err := strconv.Atoi(value)
 		if err != nil {
-			err := status.Error(codes.InvalidArgument, fmt.Sprintf("CreateSnapshot: retentiondays err %s", value))
+			err := status.Errorf(codes.InvalidArgument, "CreateSnapshot: retentiondays err %s", value)
 			return retentionDays, useInstanceAccess, instantAccessRetentionDays, "", err
 		}
 		instantAccessRetentionDays = days
@@ -576,7 +576,7 @@ func (cs *controllerServer) CreateSnapshot(ctx context.Context, req *csi.CreateS
 			}, nil
 		}
 		log.Log.Errorf("CreateSnapshot:: Snapshot already exist with same name: name[%s], volumeID[%s]", req.Name, existsSnapshot.SourceDiskId)
-		err := status.Error(codes.AlreadyExists, fmt.Sprintf("snapshot with the same name: %s but with different SourceVolumeId already exist", req.GetName()))
+		err := status.Errorf(codes.AlreadyExists, "snapshot with the same name: %s but with different SourceVolumeId already exist", req.GetName())
 		utils.CreateEvent(cs.recorder, ref, v1.EventTypeWarning, snapshotAlreadyExist, err.Error())
 		return nil, err
 	case snapNum > 1:
@@ -586,7 +586,7 @@ func (cs *controllerServer) CreateSnapshot(ctx context.Context, req *csi.CreateS
 		return nil, err
 	case err != nil:
 		log.Log.Errorf("CreateSnapshot:: Expect to find Snapshot name[%s], but get error: %v", req.Name, err)
-		e := status.Error(codes.Internal, fmt.Sprintf("CreateSnapshot: get snapshot with error: %s", err.Error()))
+		e := status.Errorf(codes.Internal, "CreateSnapshot: get snapshot with error: %s", err.Error())
 		utils.CreateEvent(cs.recorder, ref, v1.EventTypeWarning, snapshotCreateError, e.Error())
 		return nil, e
 	}
@@ -606,14 +606,14 @@ func (cs *controllerServer) CreateSnapshot(ctx context.Context, req *csi.CreateS
 	disks := getDisk(sourceVolumeID, ecsClient)
 	if len(disks) == 0 {
 		log.Log.Warnf("CreateSnapshot: no disk found: %s", sourceVolumeID)
-		return nil, status.Error(codes.Internal, fmt.Sprintf("CreateSnapshot:: failed to get disk from sourceVolumeID: %v", sourceVolumeID))
+		return nil, status.Errorf(codes.Internal, "CreateSnapshot:: failed to get disk from sourceVolumeID: %v", sourceVolumeID)
 	} else if len(disks) != 1 {
 		log.Log.Warnf("CreateSnapshot: multi disk found: %s", sourceVolumeID)
-		return nil, status.Error(codes.Internal, fmt.Sprintf("CreateSnapshot:: failed to get disk from sourceVolumeID: %v", sourceVolumeID))
+		return nil, status.Errorf(codes.Internal, "CreateSnapshot:: failed to get disk from sourceVolumeID: %v", sourceVolumeID)
 	}
 	// if disks[0].Status != "In_use" {
 	// 	log.Errorf("CreateSnapshot: disk [%s] not attached, status: [%s]", sourceVolumeID, disks[0].Status)
-	// 	e := status.Error(codes.InvalidArgument, fmt.Sprintf("CreateSnapshot:: target disk: %v must be attached", sourceVolumeID))
+	// 	e := status.Errorf(codes.InvalidArgument, "CreateSnapshot:: target disk: %v must be attached", sourceVolumeID)
 	// 	utils.CreateEvent(cs.recorder, ref, v1.EventTypeWarning, snapshotCreateError, e.Error())
 	// 	return nil, e
 	// }
@@ -757,7 +757,7 @@ func (cs *controllerServer) DeleteSnapshot(ctx context.Context, req *csi.DeleteS
 		return &csi.DeleteSnapshotResponse{}, nil
 	case snapNum > 1:
 		log.Log.Errorf("DeleteSnapshot: snapShot cannot be deleted %s, with more than 1 snapshot", snapshotID)
-		err = status.Error(codes.Internal, fmt.Sprintf("snapShot cannot be deleted %s, with more than 1 snapshot", snapshotID))
+		err = status.Errorf(codes.Internal, "snapShot cannot be deleted %s, with more than 1 snapshot", snapshotID)
 		return nil, err
 	}
 
@@ -811,7 +811,7 @@ func (cs *controllerServer) ListSnapshots(ctx context.Context, req *csi.ListSnap
 		return nil, err
 	case err != nil:
 		log.Log.Errorf("CreateSnapshot:: Expect to find Snapshot id[%s], but get error: %v", req.SnapshotId, err)
-		e := status.Error(codes.Internal, fmt.Sprintf("ListSnapshots:: Expect to find Snapshot id but get error: %v", err.Error()))
+		e := status.Errorf(codes.Internal, "ListSnapshots:: Expect to find Snapshot id but get error: %v", err.Error())
 		utils.CreateEvent(cs.recorder, ref, v1.EventTypeWarning, snapshotCreateError, e.Error())
 		return nil, e
 	}
@@ -845,7 +845,7 @@ func (cs *controllerServer) ListSnapshots(ctx context.Context, req *csi.ListSnap
 	describeRequest.DiskId = volumeID
 	response, err := GlobalConfigVar.EcsClient.DescribeSnapshots(describeRequest)
 	if err != nil {
-		return nil, status.Error(codes.Internal, fmt.Sprintf("ListSnapshots:: Request describeSnapshots error: %+v", err))
+		return nil, status.Errorf(codes.Internal, "ListSnapshots:: Request describeSnapshots error: %+v", err)
 	}
 	if response.PageSize == 0 {
 		return &csi.ListSnapshotsResponse{}, nil
@@ -1143,7 +1143,7 @@ func (cs *controllerServer) createVolumeExpandAutoSnapshot(ctx context.Context, 
 	if err != nil {
 		log.Log.Errorf("ControllerExpandVolume:: volumeExpandAutoSnapshot create Failed: snapshotName[%s], sourceId[%s], error[%s]", volumeExpandAutoSnapshotName, sourceVolumeID, err.Error())
 		cs.recorder.Event(pvc, v1.EventTypeWarning, snapshotCreateError, err.Error())
-		return nil, status.Error(codes.Internal, fmt.Sprintf("volumeExpandAutoSnapshot create Failed: %v", err))
+		return nil, status.Errorf(codes.Internal, "volumeExpandAutoSnapshot create Failed: %v", err)
 	}
 
 	// as a IA snapshot, volumeExpandAutoSnapshot should be ready immediately
@@ -1183,7 +1183,7 @@ func (cs *controllerServer) deleteVolumeExpandAutoSnapshot(ctx context.Context, 
 		}
 
 		cs.recorder.Event(pvc, v1.EventTypeWarning, snapshotDeleteError, err.Error())
-		return status.Error(codes.Internal, fmt.Sprintf("volumeExpandAutoSnapshot delete Failed: %v", err))
+		return status.Errorf(codes.Internal, "volumeExpandAutoSnapshot delete Failed: %v", err)
 	}
 
 	str := fmt.Sprintf("ControllerExpandVolume:: Successfully delete snapshot %s", snapshotID)

--- a/pkg/disk/controllerserver.go
+++ b/pkg/disk/controllerserver.go
@@ -806,7 +806,7 @@ func (cs *controllerServer) ListSnapshots(ctx context.Context, req *csi.ListSnap
 		return newListSnapshotsResponse(snapshot)
 	case snapNum > 1:
 		log.Log.Errorf("ListSnapshots:: Find Snapshot id[%s], but get more than 1 instance", req.SnapshotId)
-		err := status.Error(codes.Internal, fmt.Sprint("ListSnapshots:: Find Snapshot id but get more than 1 instance"))
+		err := status.Error(codes.Internal, "ListSnapshots:: Find Snapshot id but get more than 1 instance")
 		utils.CreateEvent(cs.recorder, ref, v1.EventTypeWarning, snapshotTooMany, err.Error())
 		return nil, err
 	case err != nil:
@@ -833,7 +833,7 @@ func (cs *controllerServer) ListSnapshots(ctx context.Context, req *csi.ListSnap
 			entries := []*csi.ListSnapshotsResponse_Entry{entry}
 			return &csi.ListSnapshotsResponse{Entries: entries}, nil
 		}
-		return nil, status.Error(codes.Internal, fmt.Sprint("ListSnapshots:: Expect to find snapshot by volumeID but get volumeID is null"))
+		return nil, status.Error(codes.Internal, "ListSnapshots:: Expect to find snapshot by volumeID but get volumeID is null")
 	}
 	nextToken := req.GetStartingToken()
 	maxEntries := int(req.GetMaxEntries())

--- a/pkg/disk/nodeserver.go
+++ b/pkg/disk/nodeserver.go
@@ -493,7 +493,7 @@ func (ns *nodeServer) NodeUnpublishVolume(ctx context.Context, req *csi.NodeUnpu
 	}
 	err = os.Remove(targetPath)
 	if err != nil {
-		return nil, status.Error(codes.Internal, fmt.Sprintf("NodeUnpublishVolume: Cannot remove targetPath %s: %v", targetPath, err))
+		return nil, status.Errorf(codes.Internal, "NodeUnpublishVolume: Cannot remove targetPath %s: %v", targetPath, err)
 	}
 
 	// below directory can not be umounted by kubelet in ack
@@ -616,7 +616,7 @@ func (ns *nodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVol
 		if err != nil {
 			fullErrorMessage := utils.FindSuggestionByErrorMessage(err.Error(), utils.DiskAttachDetach)
 			log.Log.Errorf("NodeStageVolume: Attach volume: %s with error: %s", req.VolumeId, fullErrorMessage)
-			return nil, status.Error(codes.Aborted, fmt.Sprintf("NodeStageVolume: Attach volume: %s with error: %+v", req.VolumeId, err))
+			return nil, status.Errorf(codes.Aborted, "NodeStageVolume: Attach volume: %s with error: %+v", req.VolumeId, err)
 		}
 	}
 
@@ -960,7 +960,7 @@ func (ns *nodeServer) NodeExpandVolume(ctx context.Context, req *csi.NodeExpandV
 		log.Log.Infof("NodeExpandVolume:: resizefs successful volumeId: %s, devicePath: %s, volumePath: %s", diskID, devicePath, volumePath)
 		return &csi.NodeExpandVolumeResponse{}, nil
 	}
-	return nil, status.Error(codes.Internal, fmt.Sprintf("requestGB: %v, diskCapacity: %v not in range", requestGB, diskCapacity))
+	return nil, status.Errorf(codes.Internal, "requestGB: %v, diskCapacity: %v not in range", requestGB, diskCapacity)
 }
 
 // NodeGetVolumeStats used for csi metrics

--- a/pkg/disk/utils.go
+++ b/pkg/disk/utils.go
@@ -1056,7 +1056,7 @@ func checkDeviceAvailable(devicePath, volumeID, targetPath string) error {
 			return nil
 		}
 		if newVolumeID != volumeID {
-			return status.Error(codes.Internal, fmt.Sprintf("device [%s] associate with volumeID: [%s] rather than volumeID: [%s]", device, newVolumeID, volumeID))
+			return status.Errorf(codes.Internal, "device [%s] associate with volumeID: [%s] rather than volumeID: [%s]", device, newVolumeID, volumeID)
 		}
 
 		return nil

--- a/pkg/ens/controllerserver.go
+++ b/pkg/ens/controllerserver.go
@@ -97,7 +97,7 @@ func (cs *controllerServer) CreateVolume(ctx context.Context, req *csi.CreateVol
 	}
 	if actualDiskType == "" || actualDiskID == "" {
 		log.Errorf("CreateVolume: no disk created")
-		return nil, status.Error(codes.InvalidArgument, fmt.Sprintf("no disk created by regionID: %s, diskType: %s, requestGB: %s", diskParams.RegionID, diskParams.DiskType, requestGB))
+		return nil, status.Errorf(codes.InvalidArgument, "no disk created by regionID: %s, diskType: %s, requestGB: %s", diskParams.RegionID, diskParams.DiskType, requestGB)
 	}
 	volumeContext := updateVolumeContext(req.GetParameters())
 	volumeContext["type"] = actualDiskType

--- a/pkg/ens/nodeserver.go
+++ b/pkg/ens/nodeserver.go
@@ -265,7 +265,7 @@ func (ns *nodeServer) NodeUnpublishVolume(ctx context.Context, req *csi.NodeUnpu
 	}
 	err = os.Remove(targetPath)
 	if err != nil {
-		return nil, status.Error(codes.Internal, fmt.Sprintf("NodeUnpublishVolume: Cannot remove targetPath %s: %v", targetPath, err))
+		return nil, status.Errorf(codes.Internal, "NodeUnpublishVolume: Cannot remove targetPath %s: %v", targetPath, err)
 	}
 
 	// below directory can not be umounted by kubelet in ack
@@ -345,7 +345,7 @@ func (ns *nodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVol
 		if err != nil {
 			fullErrorMessage := utils.FindSuggestionByErrorMessage(err.Error(), utils.DiskAttachDetach)
 			log.Errorf("NodeStageVolume: Attach volume: %s with error: %s", req.VolumeId, fullErrorMessage)
-			return nil, status.Error(codes.Aborted, fmt.Sprintf("NodeStageVolume: Attach volume: %s with error: %+v", req.VolumeId, err))
+			return nil, status.Errorf(codes.Aborted, "NodeStageVolume: Attach volume: %s with error: %+v", req.VolumeId, err)
 		}
 	}
 

--- a/pkg/local/nodeserver.go
+++ b/pkg/local/nodeserver.go
@@ -253,7 +253,7 @@ func (ns *nodeServer) NodeUnpublishVolume(ctx context.Context, req *csi.NodeUnpu
 	isNotMnt, err = ns.mounter.IsNotMountPoint(targetPath)
 	if !isNotMnt {
 		log.Errorf("NodeUnpublishVolume: Umount volume %s for path %s not successful", req.VolumeId, targetPath)
-		return nil, status.Error(codes.Internal, fmt.Sprintf("Umount volume %s not successful", req.VolumeId))
+		return nil, status.Errorf(codes.Internal, "Umount volume %s not successful", req.VolumeId)
 	}
 
 	log.Infof("NodeUnpublishVolume: Successful umount target path %s for volume %s", targetPath, req.VolumeId)

--- a/pkg/pov/controller.go
+++ b/pkg/pov/controller.go
@@ -293,10 +293,10 @@ func (d *controllerService) ControllerExpandVolume(ctx context.Context, req *csi
 func (d *controllerService) ControllerPublishVolume(ctx context.Context, req *csi.ControllerPublishVolumeRequest) (*csi.ControllerPublishVolumeResponse, error) {
 	pvs, err := getPVBympId(req.GetVolumeId())
 	if err != nil {
-		return nil, status.Error(codes.InvalidArgument, fmt.Sprintf("failed to get pv by mpId: %s err: %v", req.GetVolumeId(), err))
+		return nil, status.Errorf(codes.InvalidArgument, "failed to get pv by mpId: %s err: %v", req.GetVolumeId(), err)
 	}
 	if len(pvs) == 0 {
-		return nil, status.Error(codes.InvalidArgument, fmt.Sprintf("failed to get pv by mpId: %s", req.GetVolumeId()))
+		return nil, status.Errorf(codes.InvalidArgument, "failed to get pv by mpId: %s", req.GetVolumeId())
 	}
 
 	var fsId string
@@ -304,7 +304,7 @@ func (d *controllerService) ControllerPublishVolume(ctx context.Context, req *cs
 		log.Log.Infof("ControllerPublishVolume: pv:[%s]'s fsId: %s", pvs[0].Name, value)
 		fsId = value
 	} else {
-		return nil, status.Error(codes.InvalidArgument, fmt.Sprintf("failed to get fsId by mpId: %s, pvs: %+v", req.GetVolumeId(), pvs))
+		return nil, status.Errorf(codes.InvalidArgument, "failed to get fsId by mpId: %s, pvs: %+v", req.GetVolumeId(), pvs)
 	}
 
 	requestID, err := d.cloud.AttachVscMountPoint(ctx, req.GetVolumeId(), fsId, req.GetNodeId())
@@ -336,7 +336,7 @@ VSCREADY:
 		}
 	}
 	if vscId == "" {
-		return nil, status.Error(codes.Internal, fmt.Sprintf("can't get vscId by fsId: %s, mpId: %s, instanceId: %s", fsId, req.GetVolumeId(), req.GetNodeId()))
+		return nil, status.Errorf(codes.Internal, "can't get vscId by fsId: %s, mpId: %s, instanceId: %s", fsId, req.GetVolumeId(), req.GetNodeId())
 	}
 	log.Log.Infof("ControllerPublishVolume: patch pv vsc vscid: %v mpId: %v", vscId, req.GetVolumeId())
 	if err := patchVscId2PV(fsId, vscId, req.GetVolumeId(), req.GetNodeId()); err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

the outcome is exactly the same, just be consistent in the codebase.

replace
```regex
status.Error\(codes\.(\w+),\s+fmt.Sprintf\((.+)\)\)
```
with
```
status.Errorf(codes.$1, $2)
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
