### PR TITLE
always force delete disk snapshot

### DIFF
--- a/pkg/disk/cloud.go
+++ b/pkg/disk/cloud.go
@@ -787,7 +787,7 @@ func DescribeDiskInstanceEvents(instanceId string, ecsClient *ecs.Client) (event
 }
 
 func requestAndCreateSnapshot(ecsClient *ecs.Client, sourceVolumeID, snapshotName, resourceGroupID string, retentionDays, instantAccessRetentionDays int,
-	instantAccess, forceDelete bool) (*ecs.CreateSnapshotResponse, error) {
+	instantAccess bool) (*ecs.CreateSnapshotResponse, error) {
 	// init createSnapshotRequest and parameters
 	createSnapshotRequest := ecs.CreateCreateSnapshotRequest()
 	createSnapshotRequest.DiskId = sourceVolumeID
@@ -805,10 +805,8 @@ func requestAndCreateSnapshot(ecsClient *ecs.Client, sourceVolumeID, snapshotNam
 	snapshotTags := []ecs.CreateSnapshotTag{}
 	tag1 := ecs.CreateSnapshotTag{Key: DISKTAGKEY2, Value: DISKTAGVALUE2}
 	snapshotTags = append(snapshotTags, tag1)
-	if forceDelete {
-		tag2 := ecs.CreateSnapshotTag{Key: SNAPSHOTTAGKEY1, Value: "true"}
-		snapshotTags = append(snapshotTags, tag2)
-	}
+	tag2 := ecs.CreateSnapshotTag{Key: SNAPSHOTTAGKEY1, Value: "true"}
+	snapshotTags = append(snapshotTags, tag2)
 	createSnapshotRequest.Tag = &snapshotTags
 
 	// Do Snapshot create
@@ -819,13 +817,11 @@ func requestAndCreateSnapshot(ecsClient *ecs.Client, sourceVolumeID, snapshotNam
 	return snapshotResponse, nil
 }
 
-func requestAndDeleteSnapshot(snapshotID string, forceDelete bool) (*ecs.DeleteSnapshotResponse, error) {
+func requestAndDeleteSnapshot(snapshotID string) (*ecs.DeleteSnapshotResponse, error) {
 	// Delete Snapshot
 	deleteSnapshotRequest := ecs.CreateDeleteSnapshotRequest()
 	deleteSnapshotRequest.SnapshotId = snapshotID
-	if forceDelete {
-		deleteSnapshotRequest.Force = requests.NewBoolean(true)
-	}
+	deleteSnapshotRequest.Force = requests.NewBoolean(true)
 	response, err := GlobalConfigVar.EcsClient.DeleteSnapshot(deleteSnapshotRequest)
 	if err != nil {
 		return response, status.Errorf(codes.Internal, "failed delete snapshot: %v", err)

--- a/pkg/disk/constants.go
+++ b/pkg/disk/constants.go
@@ -19,9 +19,7 @@ const (
 	DISKTAGVALUE2 = "alibabacloud-csi-plugin"
 	// DISKTAGKEY3 key
 	DISKTAGKEY3 = "ack.aliyun.com"
-	// SNAPSHOTFORCETAG tag
-	SNAPSHOTFORCETAG = "forceDelete"
-	// SNAPSHOTTAGKEY1 tag
+	// ECS snapshot tag from old version, keep it for compatibility
 	SNAPSHOTTAGKEY1 = "force.delete.snapshot.k8s.aliyun.com"
 	// SNAPSHOTTYPE ...
 	SNAPSHOTTYPE = "snapshotType"

--- a/pkg/disk/nodeserver.go
+++ b/pkg/disk/nodeserver.go
@@ -1117,7 +1117,7 @@ func deleteVolumeExpandAutoSnapshot(ctx context.Context, volumeExpandAutoSnapsho
 
 	GlobalConfigVar.EcsClient = updateEcsClient(GlobalConfigVar.EcsClient)
 
-	response, err := requestAndDeleteSnapshot(volumeExpandAutoSnapshotID, veasp.ForceDelete)
+	response, err := requestAndDeleteSnapshot(volumeExpandAutoSnapshotID)
 	if err != nil {
 		if response != nil {
 			log.Log.Errorf("NodeExpandVolume:: fail to delete %s with error: %s", volumeExpandAutoSnapshotID, err.Error())


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

If there are some disks created from a snapshot, that snapshot cannot be deleted without `force`. Because the disks cannot be re-initialized then. We don't support re-init, so just do force delete unconditionally.


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
`forceDelete` snapshot parameter is no longer respected. Now snapshot can always be deleted even if there are volumes created from it.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
