### PR TITLE
disk: verify VolumeCapabilities

### DIFF
--- a/pkg/disk/cloud.go
+++ b/pkg/disk/cloud.go
@@ -843,7 +843,7 @@ func createDisk(diskName, snapshotID string, requestGB int, diskVol *diskVolumeA
 	diskTags = append(diskTags, ecs.CreateDiskTag{Key: common.VolumeNameTag, Value: diskName})
 	createDiskRequest.Tag = &diskTags
 
-	if strings.ToLower(diskVol.MultiAttach) == "true" || strings.ToLower(diskVol.MultiAttach) == "enabled" {
+	if diskVol.MultiAttach {
 		createDiskRequest.MultiAttach = "Enabled"
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind api-change
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Reject CreateVolume if capability cannot be supported: MULTI_NODE_MULTI_WRITER
and MULTI_NODE_SINGLE_WRITER for mount volumes.

Require MultiAttach to be enabled in parameters if multi-node access is requested.
We do not enable it automatically because multi-attach implies additional limits,
which may be unexpected to user.

Also implement the ValidateVolumeCapabilities controller RPC call.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes CSI sanity case:
* controller service [controller server] validatevolumecapabilities [it] should fail when the requested volume does not exist

#### Special notes for your reviewer:

PVC with `volumeMode: Filesystem` and `accessModes: [ ReadWriteMany ]` will fail with this event:

Warning  ProvisioningFailed    2s (x3 over 3s)  diskplugin.csi.alibabacloud.com_csi-provisioner-647f8bccfb-w22zq_d72ba154-98bf-4c6d-b276-8cb0120fcbbc  failed to provision volume with StorageClass "csi-disk-essd-immediate": rpc error: code = InvalidArgument desc = Invalid parameters from input: disk-ebddaed2-f256-4d6b-8855-785a1072fc11, with error: multi-node writing is only supported for block volume

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
action required. New mount volume cannot be created if it has ReadWriteMany access mode. multiAttach is now required if other multi-node access is requested in access mode.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
