### PR TITLE
disk: enable ADController by default

### DIFF
--- a/pkg/disk/disk.go
+++ b/pkg/disk/disk.go
@@ -231,10 +231,9 @@ func GlobalConfigSet(m metadata.MetadataProvider) *restclient.Config {
 
 	// Global Config Set
 	GlobalConfigVar = GlobalConfig{
-		Region: metadata.MustGet(m, metadata.RegionID),
-		NodeID: nodeID,
-		ADControllerEnable: features.FunctionalMutableFeatureGate.Enabled(features.DiskADController) ||
-			csiCfg.GetBool("disk-adcontroller-enable", "DISK_AD_CONTROLLER", false),
+		Region:                metadata.MustGet(m, metadata.RegionID),
+		NodeID:                nodeID,
+		ADControllerEnable:    features.FunctionalMutableFeatureGate.Enabled(features.DiskADController),
 		DiskTagEnable:         csiCfg.GetBool("disk-tag-by-plugin", "DISK_TAGED_BY_PLUGIN", false),
 		DiskBdfEnable:         csiCfg.GetBool("disk-bdf-enable", "DISK_BDF_ENABLE", false),
 		MetricEnable:          csiCfg.GetBool("disk-metric-by-plugin", "DISK_METRIC_BY_PLUGIN", true),

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -14,7 +14,7 @@ const (
 var (
 	FunctionalMutableFeatureGate = featuregate.NewFeatureGate()
 	defaultDiskFeatureGate       = map[featuregate.Feature]featuregate.FeatureSpec{
-		DiskADController: {Default: false, PreRelease: featuregate.Alpha},
+		DiskADController: {Default: true, PreRelease: featuregate.Beta},
 	}
 	defaultDBFSFeatureGate = map[featuregate.Feature]featuregate.FeatureSpec{
 		DBFSMetricByPlugin: {Default: false, PreRelease: featuregate.Alpha},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup
/kind deprecation
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Currently, we are doing attach/detach on node. This can cause a lot of issues:
- node needs OpenAPI authorizations
- disk cannot be detached if node is down
    
We are deprecating the function of attaching on node, and will remove it.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

Some old disks cannot be found by serial number. These disks cannot be found if mounted by controller.  We need a script to scan for such disks, and provide a way to fix them.

When upgrading, controller must be updated first, before plugin.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
disk: attach/detach is now performed on controller. Some old disks will not work. Please check for them, action required.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
