### PR TITLE
disk: fixes for unmountDuplicateMountPoint

### DIFF
--- a/build/lib/amd64-entrypoint.sh
+++ b/build/lib/amd64-entrypoint.sh
@@ -1,5 +1,12 @@
 #!/bin/sh
 
+# skip all the setup if running in provisioner mode
+if [ "$SERVICE_TYPE" = "provisioner" ]; then
+    echo "Starting provisioner..."
+    /bin/plugin.csi.alibabacloud.com $@
+    exit $?
+fi
+
 run_oss="false"
 run_disk="false"
 run_nas="false"

--- a/build/lib/arm64-entrypoint.sh
+++ b/build/lib/arm64-entrypoint.sh
@@ -1,5 +1,12 @@
 #!/bin/sh
 
+# skip all the setup if running in provisioner mode
+if [ "$SERVICE_TYPE" = "provisioner" ]; then
+    echo "Starting provisioner..."
+    /bin/plugin.csi.alibabacloud.com $@
+    exit $?
+fi
+
 run_oss="false"
 run_disk="false"
 run_nas="false"

--- a/build/lib/arm64-entrypoint.sh
+++ b/build/lib/arm64-entrypoint.sh
@@ -19,6 +19,22 @@ armfsVer="1.80.6"
 
 HOST_CMD="/nsenter --mount=/proc/1/ns/mnt"
 
+# Host may have /var/lib/kubelet bind mounted to /var/lib/container/kubelet in shared mode,
+# where /var/lib/container is the data disk configured in node pool.
+# Fix this by making /var/lib/container private and unmounting the duplicate mount in it.
+if [ /var/lib/kubelet -ef /var/lib/container/kubelet ] && awk '{print $5}' /proc/1/mountinfo | grep -q "^/var/lib/container$"; then
+    # They refer to the same device and inode numbers and /var/lib/container is a mountpoint
+    echo "fixing mountpoints in /var/lib/container"
+    # Note that we make /var/lib/container private, but not /var/lib/kubelet,
+    # because the latter is also shared with CSI plugins.
+    $HOST_CMD mount --make-private /var/lib/container || exit 1
+    DUPICATE_MNTS=$(awk '{print $5}' /proc/1/mountinfo | grep "^/var/lib/container/kubelet")
+    if [ -n "$DUPICATE_MNTS" ]; then
+        echo "umounting $DUPICATE_MNTS"
+        $HOST_CMD umount $DUPICATE_MNTS || exit 1
+    fi
+fi
+
 ## check which plugin is running
 for item in $@;
 do

--- a/deploy/ecs/csi-plugin.yaml
+++ b/deploy/ecs/csi-plugin.yaml
@@ -154,9 +154,6 @@ spec:
               mountPath: /var/log/
             - name: ossconnectordir
               mountPath: /host/usr/
-            - name: container-dir
-              mountPath: /var/lib/container
-              mountPropagation: "Bidirectional"
             - name: host-dev
               mountPath: /dev
               mountPropagation: "HostToContainer"
@@ -181,10 +178,6 @@ spec:
         - name: registration-dir
           hostPath:
             path: /var/lib/kubelet/plugins_registry
-            type: DirectoryOrCreate
-        - name: container-dir
-          hostPath:
-            path: /var/lib/container
             type: DirectoryOrCreate
         - name: kubelet-dir
           hostPath:

--- a/deploy/nonecs/csi-plugin.yaml
+++ b/deploy/nonecs/csi-plugin.yaml
@@ -134,9 +134,6 @@ spec:
               mountPath: /var/log/
             - name: ossconnectordir
               mountPath: /host/usr/
-            - name: container-dir
-              mountPath: /var/lib/container
-              mountPropagation: "Bidirectional"
             - name: host-dev
               mountPath: /dev
               mountPropagation: "HostToContainer"
@@ -161,10 +158,6 @@ spec:
         - name: registration-dir
           hostPath:
             path: /var/lib/kubelet/plugins_registry
-            type: DirectoryOrCreate
-        - name: container-dir
-          hostPath:
-            path: /var/lib/container
             type: DirectoryOrCreate
         - name: kubelet-dir
           hostPath:

--- a/pkg/disk/nodeserver.go
+++ b/pkg/disk/nodeserver.go
@@ -514,21 +514,26 @@ func (ns *nodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVol
 		}
 	}
 
-	// Step 1: check oldVersion volumeMount
-	oldTargetPath := fmt.Sprintf("/var/lib/kubelet/plugins/kubernetes.io/csi/pv/%s/globalmount", req.VolumeId)
-	returned, err := ns.checkStagingPathMounted(req.VolumeId, oldTargetPath, targetPath)
-	if err != nil {
-		return nil, status.Error(codes.Internal, err.Error())
-	}
-	if returned {
-		return &csi.NodeStageVolumeResponse{}, nil
-	}
 	// Step 2: check target path mounted
-	returned, err = ns.checkStagingPathMounted(req.VolumeId, targetPath, targetPath)
+	notmounted, err := ns.k8smounter.IsLikelyNotMountPoint(targetPath)
 	if err != nil {
+		log.Log.Errorf("NodeStageVolume: check volume %s path %s error: %v", req.VolumeId, targetPath, err)
 		return nil, status.Error(codes.Internal, err.Error())
 	}
-	if returned {
+	if !notmounted {
+		// if target path is mounted tmpfs, return
+		if utils.IsDirTmpfs(req.StagingTargetPath) {
+			log.Log.Infof("NodeStageVolume: TargetPath(%s) is mounted as tmpfs, not need mount again", req.StagingTargetPath)
+			return &csi.NodeStageVolumeResponse{}, nil
+		}
+
+		// check device available
+		deviceName := GetDeviceByMntPoint(targetPath)
+		if err := checkDeviceAvailable(deviceName, req.VolumeId, targetPath); err != nil {
+			log.Log.Errorf("NodeStageVolume: mountPath is mounted %s, but check device available error: %s", targetPath, err.Error())
+			return nil, status.Error(codes.Internal, err.Error())
+		}
+		log.Log.Infof("NodeStageVolume:  volumeId: %s, Path: %s is already mounted, device: %s", req.VolumeId, targetPath, deviceName)
 		return &csi.NodeStageVolumeResponse{}, nil
 	}
 
@@ -1079,43 +1084,4 @@ func deleteUntagAutoSnapshot(snapshotID, diskID string) {
 	if err != nil {
 		log.Log.Errorf("NodeExpandVolume:: failed to untag volumeExpandAutoSnapshot: %s", err.Error())
 	}
-}
-
-// checkStagingPathMounted ...
-func (ns *nodeServer) checkStagingPathMounted(volumeId, path, passedPath string) (bool, error) {
-
-	notMounted, err := ns.k8smounter.IsLikelyNotMountPoint(path)
-	log.Log.Infof("checkStagingPathMounted: check path: %s, passedPath: %s, mounted: %v", path, passedPath, !notMounted)
-	if err != nil && strings.Contains(err.Error(), "no such file or directory") && path != passedPath {
-		return false, nil
-	}
-	if err != nil {
-		log.Log.Errorf("NodeStageVolume: check volume %s path %s error: %v", volumeId, path, err)
-		return true, status.Error(codes.Internal, err.Error())
-	}
-	if !notMounted {
-		// if target path is mounted tmpfs, return
-		if utils.IsDirTmpfs(path) {
-			log.Log.Infof("NodeStageVolume: TargetPath(%s) is mounted as tmpfs, not need mount again", path)
-			return true, nil
-		}
-
-		// check device available
-		deviceName := GetDeviceByMntPoint(path)
-		if err := checkDeviceAvailable(deviceName, volumeId, path); err != nil {
-			if path != passedPath {
-				log.Log.Infof("checkStagingPathMounted: old version globalmount path: %s exists with empty dev: %v umount it", path, err)
-				err = ns.unmountStageTarget(path)
-				if err != nil {
-					return true, status.Error(codes.Internal, err.Error())
-				}
-				return false, nil
-			}
-			log.Log.Errorf("NodeStageVolume: mountPath is mounted %s, but check device available error: %s", path, err.Error())
-			return true, status.Error(codes.Internal, err.Error())
-		}
-		log.Log.Infof("NodeStageVolume:  volumeId: %s, Path: %s is already mounted, device: %s", volumeId, path, deviceName)
-		return true, nil
-	}
-	return false, nil
 }

--- a/test/csi-sanity/csi-sanity-disk.yaml
+++ b/test/csi-sanity/csi-sanity-disk.yaml
@@ -38,10 +38,6 @@ spec:
     hostPath:
       path: /var/lib/kubelet/plugins_registry
       type: DirectoryOrCreate
-  - name: container-dir
-    hostPath:
-      path: /var/lib/container
-      type: DirectoryOrCreate
   - name: kubelet-dir
     hostPath:
       path: /var/lib/kubelet


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

There are several issues about the original implementation:
1. We should not just umount the mountpoints in data disk, as it will propagate to `/var/lib/kubelet`. Instead, we handle this in entrypoint.sh, by mount data disk as private then umount all mountpoint in it.
2. We should umount the 1.23- path even if no data disk present.
3. We will not mount v2 path in NodeStageVolume if v1 path is present, maybe trying to prevent two mounts to exists simultaneously. However, this does not work. We see a `FailedMount` event from kubelet, which may be related. Also, If we mount the same PV again on the same node, we will also mount the v2 path in NodePublishVolume, resulting in two mounts existing simultaneously. And we also have users upgraded to Kubernetes 1.24 before he upgrades CSI plugin to 758da746493eadb8e6bc317c1cb05869cc37f255 .

In summary, the proposed solution is:
1. Fixing mountpoints in data disk once and for all in entrypoint.sh
1. In NodeStageVolume, mount the target path as requested by CSI, either v1 or v2, allowing them to exist simultaneously.
1. Cleanup v1 if v2 is also present in NodeUnpublishVolume

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

#### Special notes for your reviewer:

Test plan:

1. Create a 1.22 ACK cluster, with 2 nodes. One with data disk, one without.
2. Upgrade the CSI plugin to this PR. Check that the mountpoints in data disk are cleaned up, and the mountpoints in `/var/lib/kubelet` are intact.
3. Create one pod with disk on each node. Check that the v1 mount created.
4. Delete the pods, Check that all mount points are cleaned up.
5. Repeat 3.
6. Upgrade the cluster to 1.24. Check that v1 and v2 mounts exist simultaneously.
7. Delete the pods, check that all mount points are cleaned up.
8. Repeat 3. Check that only v2 mount created.
9. Delete the pods, check that all mount points are cleaned up.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
fix a bug that volume cannot be unmounted after upgrade to Kubernetes 1.24, and no data disk is present on node.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
