### PR TITLE
disk: fix unmountDuplicateMountPoint to handle no data disk node

### DIFF
--- a/pkg/disk/nodeserver.go
+++ b/pkg/disk/nodeserver.go
@@ -514,21 +514,26 @@ func (ns *nodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVol
 		}
 	}
 
-	// Step 1: check oldVersion volumeMount
-	oldTargetPath := fmt.Sprintf("/var/lib/kubelet/plugins/kubernetes.io/csi/pv/%s/globalmount", req.VolumeId)
-	returned, err := ns.checkStagingPathMounted(req.VolumeId, oldTargetPath, targetPath)
-	if err != nil {
-		return nil, status.Error(codes.Internal, err.Error())
-	}
-	if returned {
-		return &csi.NodeStageVolumeResponse{}, nil
-	}
 	// Step 2: check target path mounted
-	returned, err = ns.checkStagingPathMounted(req.VolumeId, targetPath, targetPath)
+	notmounted, err := ns.k8smounter.IsLikelyNotMountPoint(targetPath)
 	if err != nil {
+		log.Log.Errorf("NodeStageVolume: check volume %s path %s error: %v", req.VolumeId, targetPath, err)
 		return nil, status.Error(codes.Internal, err.Error())
 	}
-	if returned {
+	if !notmounted {
+		// if target path is mounted tmpfs, return
+		if utils.IsDirTmpfs(req.StagingTargetPath) {
+			log.Log.Infof("NodeStageVolume: TargetPath(%s) is mounted as tmpfs, not need mount again", req.StagingTargetPath)
+			return &csi.NodeStageVolumeResponse{}, nil
+		}
+
+		// check device available
+		deviceName := GetDeviceByMntPoint(targetPath)
+		if err := checkDeviceAvailable(deviceName, req.VolumeId, targetPath); err != nil {
+			log.Log.Errorf("NodeStageVolume: mountPath is mounted %s, but check device available error: %s", targetPath, err.Error())
+			return nil, status.Error(codes.Internal, err.Error())
+		}
+		log.Log.Infof("NodeStageVolume:  volumeId: %s, Path: %s is already mounted, device: %s", req.VolumeId, targetPath, deviceName)
 		return &csi.NodeStageVolumeResponse{}, nil
 	}
 
@@ -1115,43 +1120,4 @@ func deleteUntagAutoSnapshot(snapshotID, diskID string) {
 	if err != nil {
 		log.Log.Errorf("NodeExpandVolume:: failed to untag volumeExpandAutoSnapshot: %s", err.Error())
 	}
-}
-
-// checkStagingPathMounted ...
-func (ns *nodeServer) checkStagingPathMounted(volumeId, path, passedPath string) (bool, error) {
-
-	notMounted, err := ns.k8smounter.IsLikelyNotMountPoint(path)
-	log.Log.Infof("checkStagingPathMounted: check path: %s, passedPath: %s, mounted: %v", path, passedPath, !notMounted)
-	if err != nil && strings.Contains(err.Error(), "no such file or directory") && path != passedPath {
-		return false, nil
-	}
-	if err != nil {
-		log.Log.Errorf("NodeStageVolume: check volume %s path %s error: %v", volumeId, path, err)
-		return true, status.Error(codes.Internal, err.Error())
-	}
-	if !notMounted {
-		// if target path is mounted tmpfs, return
-		if utils.IsDirTmpfs(path) {
-			log.Log.Infof("NodeStageVolume: TargetPath(%s) is mounted as tmpfs, not need mount again", path)
-			return true, nil
-		}
-
-		// check device available
-		deviceName := GetDeviceByMntPoint(path)
-		if err := checkDeviceAvailable(deviceName, volumeId, path); err != nil {
-			if path != passedPath {
-				log.Log.Infof("checkStagingPathMounted: old version globalmount path: %s exists with empty dev: %v umount it", path, err)
-				err = ns.unmountStageTarget(path)
-				if err != nil {
-					return true, status.Error(codes.Internal, err.Error())
-				}
-				return false, nil
-			}
-			log.Log.Errorf("NodeStageVolume: mountPath is mounted %s, but check device available error: %s", path, err.Error())
-			return true, status.Error(codes.Internal, err.Error())
-		}
-		log.Log.Infof("NodeStageVolume:  volumeId: %s, Path: %s is already mounted, device: %s", volumeId, path, deviceName)
-		return true, nil
-	}
-	return false, nil
 }

--- a/pkg/disk/nodeserver.go
+++ b/pkg/disk/nodeserver.go
@@ -993,27 +993,31 @@ func (ns *nodeServer) unmountDuplicateMountPoint(targetPath, volumeId string) er
 	pathParts := strings.Split(targetPath, "/")
 	partsLen := len(pathParts)
 	if partsLen > 2 && pathParts[partsLen-1] == "mount" {
-		globalPath2 := filepath.Join("/var/lib/container/kubelet/plugins/kubernetes.io/csi/pv/", pathParts[partsLen-2], "/globalmount")
-
-		result := sha256.Sum256([]byte(volumeId))
-		volSha := fmt.Sprintf("%x", result)
-		globalPath3 := filepath.Join("/var/lib/container/kubelet/plugins/kubernetes.io/csi/", driverName, volSha, "/globalmount")
 		var err error
-		oldExists := utils.IsFileExisting(globalPath2)
-		if oldExists {
+		// V1 used in Kubernetes 1.23 and earlier
+		globalPathV1 := filepath.Join(utils.KubeletRootDir, "plugins/kubernetes.io/csi/pv/", pathParts[partsLen-2], "/globalmount")
+		// V2 used in Kubernetes 1.24 and later, see https://github.com/kubernetes/kubernetes/pull/107065
+		// If a volume is mounted at globalPathV1 then kubelet is upgraded, kubelet will also mount the same volume at globalPathV2.
+		volSha := fmt.Sprintf("%x", sha256.Sum256([]byte(volumeId)))
+		globalPathV2 := filepath.Join(utils.KubeletRootDir, "plugins/kubernetes.io/csi/", driverName, volSha, "/globalmount")
+
+		v1Exists := utils.IsFileExisting(globalPathV1)
+		v2Exists := utils.IsFileExisting(globalPathV2)
+		// Community requires the node to be drained before upgrading, but we do not. So clean the V1 mountpoint here if both exists.
+		if v1Exists && v2Exists {
+			log.Log.Info("unmountDuplicateMountPoint: oldPath & newPath exists at same time")
+			err = ns.forceUnmountPath(globalPathV1)
+		}
+
+		// Now we have either V1 or V2 mountpoint.
+		// Unmount it if it is propagated to data disk, or kubelet with version < 1.26 will refuse to unstage the volume.
+		// Unmounting may also be propagated back to KubeletRootDir, we will fix that in NodePublishVolume.
+		globalPath2 := filepath.Join("/var/lib/container/kubelet/plugins/kubernetes.io/csi/pv/", pathParts[partsLen-2], "/globalmount")
+		globalPath3 := filepath.Join("/var/lib/container/kubelet/plugins/kubernetes.io/csi/", driverName, volSha, "/globalmount")
+		if utils.IsFileExisting(globalPath2) {
 			err = ns.unmountDuplicationPath(globalPath2)
 		}
-		newExists := utils.IsFileExisting(globalPath3)
-		if newExists {
-			err = ns.unmountDuplicationPath(globalPath3)
-		}
-		if oldExists && newExists {
-			log.Log.Info("unmountDuplicateMountPoint: oldPath & newPath exists at same time")
-			globalPath4 := filepath.Join("/var/lib/kubelet/plugins/kubernetes.io/csi/pv/", pathParts[partsLen-2], "/globalmount")
-			exists := utils.IsFileExisting(globalPath4)
-			if exists {
-				err = ns.forceUnmountPath(globalPath4)
-			}
+		if utils.IsFileExisting(globalPath3) {
 			err = ns.unmountDuplicationPath(globalPath3)
 		}
 		return err


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

We should unmount the 1.23- path even if no data disk present. Or kubelet will not unstage the volume.

#910 is not suitable for now, because we have no reliable way to remove volumeMount from csi-plugin DaemonSet in ACK.

Mount points in data disk are still always unmounted, because they also prevent kubelet from unstage the volume before 1.26 (See https://github.com/kubernetes/kubernetes/pull/112607 for the behaviour in 1.26+). Although this is incorrect: the unmount will propagate to `/var/lib/kubelet` and the real stage path is also unmounted. But we are already fixing this in NodePublishVolume. So, I left it as it is for now.

We do not mount v2 path in NodeStageVolume if v1 path is present, maybe trying to prevent two mounts to exists simultaneously. However, this does not work. If user mount the same PV again on the same node, we will also mount the v2 path in NodePublishVolume, resulting in two mounts existing simultaneously. And we also have users upgraded to Kubernetes 1.24 before he upgrades CSI plugin to https://github.com/kubernetes-sigs/alibaba-cloud-csi-driver/commit/758da746493eadb8e6bc317c1cb05869cc37f255 .
So, revert that change.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

#### Special notes for your reviewer:

See #910 for the test plan.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
fix the bug that volume cannot be unmounted after upgrade to Kubernetes 1.24, and no data disk is present on node.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
