### PR TITLE
cleanup unmountDuplicateMountPoint

### DIFF
--- a/deploy/chart/templates/plugin.yaml
+++ b/deploy/chart/templates/plugin.yaml
@@ -224,9 +224,6 @@ spec:
               mountPath: /host/etc
             - name: host-log
               mountPath: /var/log/
-            - name: container-dir
-              mountPath: /var/lib/container
-              mountPropagation: "Bidirectional"
             - name: host-dev
               mountPath: /dev
               mountPropagation: "HostToContainer"
@@ -285,10 +282,6 @@ spec:
         - name: registration-dir
           hostPath:
             path: /var/lib/kubelet/plugins_registry
-            type: DirectoryOrCreate
-        - name: container-dir
-          hostPath:
-            path: /var/lib/container
             type: DirectoryOrCreate
         - name: kubelet-dir
           hostPath:

--- a/pkg/utils/mounter.go
+++ b/pkg/utils/mounter.go
@@ -62,8 +62,6 @@ type Mounter interface {
 	MountBlock(source, target string, options ...string) error
 	// Unmount unmounts the given target
 	Unmount(target string) error
-
-	HasMountRefs(mountPath string, mountRefs []string) bool
 }
 
 // TODO(arslan): this is Linux only for now. Refactor this into a package with
@@ -239,22 +237,6 @@ func (m *mounter) Unmount(target string) error {
 	}
 
 	return nil
-}
-
-const kubernetesPluginPathPrefix = "/plugins/kubernetes.io/"
-
-func (m *mounter) HasMountRefs(mountPath string, mountRefs []string) bool {
-	// Copied from https://github.com/kubernetes/kubernetes/blob/53902ce5ede4/pkg/volume/util/util.go#L680-L706
-	pathToFind := mountPath
-	if i := strings.Index(mountPath, kubernetesPluginPathPrefix); i > -1 {
-		pathToFind = mountPath[i:]
-	}
-	for _, ref := range mountRefs {
-		if !strings.Contains(ref, pathToFind) {
-			return true
-		}
-	}
-	return false
 }
 
 // IsDirEmpty return status of dir empty or not

--- a/test/csi-sanity/csi-sanity-disk.yaml
+++ b/test/csi-sanity/csi-sanity-disk.yaml
@@ -97,10 +97,6 @@ spec:
     hostPath:
       path: /var/lib/kubelet/plugins_registry
       type: DirectoryOrCreate
-  - name: container-dir
-    hostPath:
-      path: /var/lib/container
-      type: DirectoryOrCreate
   - name: kubelet-dir
     hostPath:
       path: /var/lib/kubelet


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

When we raise the minimum supported k8s version above 1.26, we can drop the hack of unmount old staging path from NodeUnpublishVolume. Instead, we unmount all the old path at startup, since kubelet will not need it anymore. And duplicated mount point in data disk would not block unstaging volume.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
