### PR TITLE
disk: wait to serialize attach & detach

### DIFF
--- a/pkg/disk/attachdetach_slot.go
+++ b/pkg/disk/attachdetach_slot.go
@@ -1,0 +1,102 @@
+package disk
+
+import (
+	"context"
+	"sync"
+)
+
+type AttachDetachSlots struct {
+	mu          sync.RWMutex
+	nodes       map[string]slot
+	slotFactory func() slot
+}
+
+func (a *AttachDetachSlots) GetSlotFor(node string) slot {
+	a.mu.RLock()
+	if s, ok := a.nodes[node]; ok {
+		a.mu.RUnlock()
+		return s
+	}
+	a.mu.RUnlock()
+
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if s, ok := a.nodes[node]; ok {
+		return s
+	}
+	s := a.slotFactory()
+	a.nodes[node] = s
+	return s
+}
+
+type slot interface {
+	AquireDetach(ctx context.Context) error
+	AquireAttach(ctx context.Context) error
+	Release()
+}
+
+type serialSlot struct {
+	// slot is a buffered channel with size 1.
+	// The buffer is filled if and only if an attach or detach is in progress.
+	slot chan struct{}
+
+	// highPriorityChannel is a channel without buffer.
+	// detach requests are fulfilled from this channel first.
+	highPriorityChannel chan struct{}
+}
+
+func (s *serialSlot) AquireDetach(ctx context.Context) error {
+	select {
+	case s.highPriorityChannel <- struct{}{}:
+		return nil
+	case s.slot <- struct{}{}:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (s *serialSlot) AquireAttach(ctx context.Context) error {
+	select {
+	case s.slot <- struct{}{}:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (s *serialSlot) Release() {
+	select {
+	// wake up a high priority request first
+	case <-s.highPriorityChannel:
+	default:
+		// if no high priority request waiting, free the slot
+		<-s.slot
+	}
+}
+
+func NewSerialAttachDetachSlots() AttachDetachSlots {
+	return AttachDetachSlots{
+		slotFactory: func() slot {
+			return &serialSlot{
+				highPriorityChannel: make(chan struct{}),
+				slot:                make(chan struct{}, 1),
+			}
+		},
+		nodes: map[string]slot{},
+	}
+}
+
+type parallelSlot struct{}
+
+func (s parallelSlot) AquireDetach(ctx context.Context) error { return nil }
+func (s parallelSlot) AquireAttach(ctx context.Context) error { return nil }
+func (s parallelSlot) Release()                               {}
+
+func NewParallelAttachDetachSlots() AttachDetachSlots {
+	return AttachDetachSlots{
+		slotFactory: func() slot {
+			return parallelSlot{}
+		},
+	}
+}

--- a/pkg/disk/attachdetach_slot_test.go
+++ b/pkg/disk/attachdetach_slot_test.go
@@ -1,0 +1,48 @@
+package disk
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestDetachPriority(t *testing.T) {
+	slots := NewSerialAttachDetachSlots()
+	s := slots.GetSlotFor("node1")
+	seq := 0
+
+	wg := sync.WaitGroup{}
+	wg.Add(3)
+	for i := 0; i < 3; i++ {
+		go func() {
+			if err := s.AquireAttach(context.Background()); err != nil {
+				t.Error(err)
+				return
+			}
+			t.Log("Attach seq", seq)
+			seq += 1
+			time.Sleep(200 * time.Millisecond)
+			s.Release()
+			wg.Done()
+		}()
+	}
+	time.Sleep(100 * time.Millisecond)
+	if err := s.AquireDetach(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if seq != 1 {
+		// detach should go after the first attach, but before the second
+		t.Fatalf("Expected seq to be 1, got %d", seq)
+	}
+	s.Release()
+	wg.Wait()
+}
+
+func BenchmarkGetSlot(b *testing.B) {
+	slots := NewSerialAttachDetachSlots()
+	nodeName := "node1"
+	for i := 0; i < b.N; i++ {
+		slots.GetSlotFor(nodeName)
+	}
+}

--- a/pkg/disk/cloud.go
+++ b/pkg/disk/cloud.go
@@ -48,7 +48,7 @@ var DEFAULT_VMFATAL_EVENTS = []string{
 const DISK_DELETE_MAX_RETRY = 60
 
 // attach alibaba cloud disk
-func attachDisk(tenantUserUID, diskID, nodeID string, isSharedDisk bool) (string, error) {
+func attachDisk(ctx context.Context, tenantUserUID, diskID, nodeID string, isSharedDisk bool) (string, error) {
 	log.Log.Infof("AttachDisk: Starting Do AttachDisk: DiskId: %s, InstanceId: %s, Region: %v", diskID, nodeID, GlobalConfigVar.Region)
 
 	ecsClient, err := getEcsClientByID("", tenantUserUID)
@@ -62,14 +62,11 @@ func attachDisk(tenantUserUID, diskID, nodeID string, isSharedDisk bool) (string
 		return "", status.Errorf(codes.Internal, "AttachDisk: csi can't find disk: %s in region: %s, Please check if the cloud disk exists, if the region is correct, or if the csi permissions are correct", diskID, GlobalConfigVar.Region)
 	}
 
-	if !GlobalConfigVar.ADControllerEnable {
-		// NodeStageVolume/NodeUnstageVolume should be called by sequence
-		if GlobalConfigVar.AttachMutex.TryLock() {
-			defer GlobalConfigVar.AttachMutex.Unlock()
-		} else {
-			return "", status.Errorf(codes.Aborted, "NodeStageVolume: Previous attach/detach action is still in process. volume: %s", diskID)
-		}
+	slot := GlobalConfigVar.AttachDetachSlots.GetSlotFor(nodeID)
+	if err := slot.AquireAttach(ctx); err != nil {
+		return "", status.Errorf(codes.Aborted, "AttachDisk: get ad-slot for disk %s failed: %v", diskID, err)
 	}
+	defer slot.Release()
 
 	// tag disk as k8s.aliyun.com=true
 	if GlobalConfigVar.DiskTagEnable {
@@ -409,7 +406,7 @@ func detachMultiAttachDisk(ecsClient *ecs.Client, diskID, nodeID string) (isMult
 	return true, nil
 }
 
-func detachDisk(ecsClient *ecs.Client, diskID, nodeID string) error {
+func detachDisk(ctx context.Context, ecsClient *ecs.Client, diskID, nodeID string) error {
 	disk, err := findDiskByID(diskID, ecsClient)
 	if err != nil {
 		log.Log.Errorf("DetachDisk: Describe volume: %s from node: %s, with error: %s", diskID, nodeID, err.Error())
@@ -430,13 +427,12 @@ func detachDisk(ecsClient *ecs.Client, diskID, nodeID string) error {
 		return nil
 	}
 	// NodeStageVolume/NodeUnstageVolume should be called by sequence
-	if !GlobalConfigVar.ADControllerEnable {
-		if GlobalConfigVar.AttachMutex.TryLock() {
-			defer GlobalConfigVar.AttachMutex.Unlock()
-		} else {
-			return status.Errorf(codes.Aborted, "DetachDisk: Previous attach/detach action is still in process, volume: %s", diskID)
-		}
+	slot := GlobalConfigVar.AttachDetachSlots.GetSlotFor(nodeID)
+	if err := slot.AquireDetach(ctx); err != nil {
+		return status.Errorf(codes.Aborted, "DetachDisk: get ad-slot for disk %s failed: %v", diskID, err)
 	}
+	defer slot.Release()
+
 	if GlobalConfigVar.DiskBdfEnable {
 		if allowed, err := forceDetachAllowed(ecsClient, disk, disk.InstanceId); err != nil {
 			err = perrors.Wrapf(err, "detachDisk forceDetachAllowed")

--- a/pkg/disk/controllerserver.go
+++ b/pkg/disk/controllerserver.go
@@ -295,7 +295,7 @@ func (cs *controllerServer) DeleteVolume(ctx context.Context, req *csi.DeleteVol
 			}
 		}
 		if disk != nil && disk.Status == DiskStatusInuse && canDetach {
-			err := detachDisk(ecsClient, req.VolumeId, disk.InstanceId)
+			err := detachDisk(ctx, ecsClient, req.VolumeId, disk.InstanceId)
 			if err != nil {
 				newErrMsg := utils.FindSuggestionByErrorMessage(err.Error(), utils.DiskDelete)
 				log.Log.Errorf("DeleteVolume: detach disk: %s from node: %s with error: %s", req.VolumeId, disk.InstanceId, newErrMsg)
@@ -388,7 +388,7 @@ func (cs *controllerServer) ControllerPublishVolume(ctx context.Context, req *cs
 		}
 	}
 
-	_, err := attachDisk(req.VolumeContext[TenantUserUID], req.VolumeId, req.NodeId, isSharedDisk)
+	_, err := attachDisk(ctx, req.VolumeContext[TenantUserUID], req.VolumeId, req.NodeId, isSharedDisk)
 	if err != nil {
 		log.Log.Errorf("ControllerPublishVolume: attach disk: %s to node: %s with error: %s", req.VolumeId, req.NodeId, err.Error())
 		return nil, status.Error(codes.Aborted, err.Error())
@@ -425,7 +425,7 @@ func (cs *controllerServer) ControllerUnpublishVolume(ctx context.Context, req *
 	}
 
 	log.Log.Infof("ControllerUnpublishVolume: detach disk: %s from node: %s", req.VolumeId, req.NodeId)
-	err = detachDisk(ecsClient, req.VolumeId, req.NodeId)
+	err = detachDisk(ctx, ecsClient, req.VolumeId, req.NodeId)
 	if err != nil {
 		log.Log.Errorf("ControllerUnpublishVolume: detach disk: %s from node: %s with error: %s", req.VolumeId, req.NodeId, err.Error())
 		return nil, err

--- a/pkg/disk/disk.go
+++ b/pkg/disk/disk.go
@@ -21,7 +21,6 @@ import (
 	"os"
 	"strconv"
 	"strings"
-	"sync"
 
 	"github.com/aliyun/alibaba-cloud-sdk-go/services/ecs"
 	"github.com/container-storage-interface/spec/lib/go/csi"
@@ -67,7 +66,7 @@ type GlobalConfig struct {
 	NodeID                string
 	ZoneID                string
 	DiskTagEnable         bool
-	AttachMutex           sync.Mutex
+	AttachDetachSlots     AttachDetachSlots
 	ADControllerEnable    bool
 	DetachDisabled        bool
 	MetricEnable          bool
@@ -281,6 +280,13 @@ func GlobalConfigSet(m metadata.MetadataProvider) *restclient.Config {
 		GlobalConfigVar.DetachBeforeDelete,
 		GlobalConfigVar.ClusterID,
 	)
+
+	if controllerServerType && !csiCfg.GetBool("disk-serial-attach", "DISK_SERIAL_ATTACH", false) {
+		log.Log.Infof("Disk parallel attach/detach enabled, please set DISK_SERIAL_ATTACH if you see a lot of InvalidOperation.Conflict error.")
+		GlobalConfigVar.AttachDetachSlots = NewParallelAttachDetachSlots()
+	} else {
+		GlobalConfigVar.AttachDetachSlots = NewSerialAttachDetachSlots()
+	}
 
 	return cfg
 }

--- a/pkg/disk/nodeserver.go
+++ b/pkg/disk/nodeserver.go
@@ -585,7 +585,7 @@ func (ns *nodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVol
 			device = ChooseDevice(rootDevice, subDevice)
 		}
 	} else {
-		device, err = attachDisk(req.VolumeContext[TenantUserUID], req.GetVolumeId(), ns.nodeID, isSharedDisk)
+		device, err = attachDisk(ctx, req.VolumeContext[TenantUserUID], req.GetVolumeId(), ns.nodeID, isSharedDisk)
 		if err != nil {
 			fullErrorMessage := utils.FindSuggestionByErrorMessage(err.Error(), utils.DiskAttachDetach)
 			log.Log.Errorf("NodeStageVolume: Attach volume: %s with error: %s", req.VolumeId, fullErrorMessage)
@@ -792,7 +792,7 @@ func (ns *nodeServer) NodeUnstageVolume(ctx context.Context, req *csi.NodeUnstag
 		if err != nil {
 			return nil, status.Error(codes.Internal, err.Error())
 		}
-		err = detachDisk(ecsClient, req.VolumeId, ns.nodeID)
+		err = detachDisk(ctx, ecsClient, req.VolumeId, ns.nodeID)
 		if err != nil {
 			log.Log.Errorf("NodeUnstageVolume: VolumeId: %s, Detach failed with error %v", req.VolumeId, err.Error())
 			return nil, err


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Avoid backoff caused by InvalidOperation.Conflict thus speed up attaching.
Prioritize detach over attach to avoid InstanceDiskLimitExceeded error with best effort
set DISK_SERIAL_ATTACH env to opt-in this behaviour in controller

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

This is necessary to pass the external-storage test in k/k repository. Or we will almost certainly get timeout for volume not attached in 5 minutes.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Attach/detach multiple volumes to one node at the same time is optimized to have higher throughput, and less conflict error.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
