### PR TITLE
disk: fix config file leakage if VolumeDevice is detached from DeleteVolume

### DIFF
--- a/pkg/disk/cloud.go
+++ b/pkg/disk/cloud.go
@@ -113,10 +113,8 @@ func attachDisk(tenantUserUID, diskID, nodeID string, isSharedDisk bool) (string
 				log.Log.Infof("attachDisk: rootDevice: %s, subDevice: %s, err: %+v", rootDevice, subDevice, err)
 				deviceName := ChooseDevice(rootDevice, subDevice)
 				if err == nil && deviceName != "" && IsFileExisting(deviceName) {
-					if used, err := IsDeviceUsedOthers(deviceName, diskID); err == nil && used == false {
-						log.Log.Infof("AttachDisk: Disk %s is already attached to self Instance %s, and device is: %s", diskID, disk.InstanceId, deviceName)
-						return deviceName, nil
-					}
+					log.Log.Infof("AttachDisk: Disk %s is already attached to self Instance %s, and device is: %s", diskID, disk.InstanceId, deviceName)
+					return deviceName, nil
 				} else {
 					// wait for pci attach ready
 					time.Sleep(5 * time.Second)
@@ -125,10 +123,8 @@ func attachDisk(tenantUserUID, diskID, nodeID string, isSharedDisk bool) (string
 					rootDevice, subDevice, err := GetRootSubDevicePath(devicePaths)
 					deviceName = ChooseDevice(rootDevice, subDevice)
 					if err == nil && deviceName != "" && IsFileExisting(deviceName) {
-						if used, err := IsDeviceUsedOthers(deviceName, diskID); err == nil && used == false {
-							log.Log.Infof("AttachDisk: Disk %s is already attached to self Instance %s, and device is: %s", diskID, disk.InstanceId, deviceName)
-							return deviceName, nil
-						}
+						log.Log.Infof("AttachDisk: Disk %s is already attached to self Instance %s, and device is: %s", diskID, disk.InstanceId, deviceName)
+						return deviceName, nil
 					}
 					err = fmt.Errorf("AttachDisk: disk device cannot be found in node, diskid: %s, deviceName: %s, err: %+v", diskID, deviceName, err)
 					return "", err

--- a/pkg/disk/utils.go
+++ b/pkg/disk/utils.go
@@ -715,6 +715,23 @@ func saveVolumeConfig(volumeID, devicePath string) error {
 	if err := removeVolumeConfig(volumeID); err != nil {
 		return err
 	}
+	// cleanup all config files that is pointing to devicePath. Such files may be leaked
+	// if previous UnstageVolume is skipped. This is possible if the VolumeDevice is
+	// detached by others (e.g. DeleteVolume).
+	files, err := os.ReadDir(VolumeDir)
+	if err != nil {
+		return err
+	}
+	for _, file := range files {
+		if file.Type().IsRegular() && strings.HasSuffix(file.Name(), ".conf") {
+			tmpVolID := strings.TrimSuffix(file.Name(), ".conf")
+			if getVolumeConfig(tmpVolID) == devicePath {
+				if err := removeVolumeConfig(tmpVolID); err != nil {
+					return fmt.Errorf("failed to remove volume config for %s: %w", tmpVolID, err)
+				}
+			}
+		}
+	}
 
 	volumeFile := path.Join(VolumeDir, volumeID+".conf")
 	if err := ioutil.WriteFile(volumeFile, []byte(devicePath), 0644); err != nil {

--- a/pkg/disk/utils.go
+++ b/pkg/disk/utils.go
@@ -753,27 +753,6 @@ func removeVolumeConfig(volumeID string) error {
 	return nil
 }
 
-// IsDeviceUsedOthers check if the given device attached by other instance
-func IsDeviceUsedOthers(deviceName, volumeID string) (bool, error) {
-	files, err := ioutil.ReadDir(VolumeDir)
-	if err != nil {
-		return true, err
-	}
-	for _, file := range files {
-		if file.IsDir() {
-			continue
-		} else {
-			if strings.HasSuffix(file.Name(), ".conf") {
-				tmpVolID := strings.Replace(file.Name(), ".conf", "", 1)
-				if tmpVolID != volumeID && getVolumeConfig(tmpVolID) == deviceName {
-					return true, nil
-				}
-			}
-		}
-	}
-	return false, nil
-}
-
 func getMultiZones(segments map[string]string) (string, bool) {
 	parseZone := func(key string) string {
 		return key[len(TopologyMultiZonePrefix):]


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

disk: fix config file leakage if VolumeDevice is detached from DeleteVolume.

When kubelet restarts, it will call StageVolume again. and if the leakage does happen, we will detach and attach the disk again, because `IsDeviceUsedOthers` returns true, which is dangerous if the user of this disk is running.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fix potential I/O error after kubelet restarts.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
