### PR TITLE
disk: refined volume count detection

### DIFF
--- a/deploy/ecs/csi-plugin.yaml
+++ b/deploy/ecs/csi-plugin.yaml
@@ -105,8 +105,6 @@ spec:
               value: unix://var/lib/kubelet/csi-plugins/driverplugin.csi.alibabacloud.com-replace/csi.sock
             - name: SERVICE_TYPE
               value: "plugin"
-            - name: MAX_VOLUMES_PERNODE
-              value: "15"
             - name: ACCESS_KEY_ID
               valueFrom:
                 secretKeyRef:

--- a/deploy/ecs/csi-provisioner.yaml
+++ b/deploy/ecs/csi-provisioner.yaml
@@ -236,8 +236,6 @@ spec:
           env:
             - name: CSI_ENDPOINT
               value: unix://var/lib/kubelet/csi-provisioner/driverplugin.csi.alibabacloud.com-replace/csi.sock
-            - name: MAX_VOLUMES_PERNODE
-              value: "15"
             - name: SERVICE_TYPE
               value: "provisioner"
             - name: KUBE_NODE_NAME

--- a/pkg/cloud/ecsinterface.go
+++ b/pkg/cloud/ecsinterface.go
@@ -7,4 +7,6 @@ type ECSInterface interface {
 	DeleteDisk(request *ecs.DeleteDiskRequest) (response *ecs.DeleteDiskResponse, err error)
 	DescribeRegions(request *ecs.DescribeRegionsRequest) (response *ecs.DescribeRegionsResponse, err error)
 	DescribeInstances(request *ecs.DescribeInstancesRequest) (response *ecs.DescribeInstancesResponse, err error)
+	DescribeInstanceTypes(request *ecs.DescribeInstanceTypesRequest) (response *ecs.DescribeInstanceTypesResponse, err error)
+	DescribeDisks(request *ecs.DescribeDisksRequest) (response *ecs.DescribeDisksResponse, err error)
 }

--- a/pkg/cloud/ecsmock.go
+++ b/pkg/cloud/ecsmock.go
@@ -64,6 +64,36 @@ func (mr *MockECSInterfaceMockRecorder) DescribeAvailableResource(request interf
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeAvailableResource", reflect.TypeOf((*MockECSInterface)(nil).DescribeAvailableResource), request)
 }
 
+// DescribeDisks mocks base method.
+func (m *MockECSInterface) DescribeDisks(request *ecs.DescribeDisksRequest) (*ecs.DescribeDisksResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DescribeDisks", request)
+	ret0, _ := ret[0].(*ecs.DescribeDisksResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DescribeDisks indicates an expected call of DescribeDisks.
+func (mr *MockECSInterfaceMockRecorder) DescribeDisks(request interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeDisks", reflect.TypeOf((*MockECSInterface)(nil).DescribeDisks), request)
+}
+
+// DescribeInstanceTypes mocks base method.
+func (m *MockECSInterface) DescribeInstanceTypes(request *ecs.DescribeInstanceTypesRequest) (*ecs.DescribeInstanceTypesResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DescribeInstanceTypes", request)
+	ret0, _ := ret[0].(*ecs.DescribeInstanceTypesResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DescribeInstanceTypes indicates an expected call of DescribeInstanceTypes.
+func (mr *MockECSInterfaceMockRecorder) DescribeInstanceTypes(request interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeInstanceTypes", reflect.TypeOf((*MockECSInterface)(nil).DescribeInstanceTypes), request)
+}
+
 // DescribeInstances mocks base method.
 func (m *MockECSInterface) DescribeInstances(request *ecs.DescribeInstancesRequest) (*ecs.DescribeInstancesResponse, error) {
 	m.ctrl.T.Helper()

--- a/pkg/cloud/metadata/metadata.go
+++ b/pkg/cloud/metadata/metadata.go
@@ -192,3 +192,15 @@ func MustGet(m MetadataProvider, key MetadataKey) string {
 	}
 	return value
 }
+
+// FakeProvider is a fake metadata provider for testing
+type FakeProvider struct {
+	Values map[MetadataKey]string
+}
+
+func (p FakeProvider) Get(key MetadataKey) (string, error) {
+	if v, ok := p.Values[key]; ok {
+		return v, nil
+	}
+	return "", ErrUnknownMetadataKey
+}

--- a/pkg/cloud/metadata/metadata_test.go
+++ b/pkg/cloud/metadata/metadata_test.go
@@ -14,17 +14,6 @@ import (
 	fake "k8s.io/client-go/kubernetes/fake"
 )
 
-type fakeProvider struct {
-	values map[MetadataKey]string
-}
-
-func (p *fakeProvider) Get(key MetadataKey) (string, error) {
-	if v, ok := p.values[key]; ok {
-		return v, nil
-	}
-	return "", ErrUnknownMetadataKey
-}
-
 func TestEcsUnreachable(t *testing.T) {
 	t.Parallel()
 	trans := httpmock.NewMockTransport()
@@ -116,7 +105,7 @@ func TestCreateOpenAPI(t *testing.T) {
 			}
 
 			m := NewMetadata()
-			m.providers = append(m.providers, &fakeProvider{values: c.values})
+			m.providers = append(m.providers, FakeProvider{Values: c.values})
 
 			m.EnableOpenAPI(ecsClient)
 			zone, err := m.Get(ZoneID)
@@ -170,8 +159,8 @@ type noopFetcher struct{}
 
 func (f *noopFetcher) FetchFor(MetadataKey) (MetadataProvider, error) {
 	time.Sleep(10 * time.Millisecond)
-	return &fakeProvider{
-		values: map[MetadataKey]string{
+	return FakeProvider{
+		Values: map[MetadataKey]string{
 			RegionID: "cn-beijing",
 		},
 	}, nil
@@ -198,8 +187,8 @@ func TestParallelLazyInit(t *testing.T) {
 // Run this with "-race"
 func TestParallelImmutableProvider(t *testing.T) {
 	t.Parallel()
-	m := newImmutableProvider(&fakeProvider{
-		values: map[MetadataKey]string{
+	m := newImmutableProvider(FakeProvider{
+		Values: map[MetadataKey]string{
 			RegionID: "cn-beijing",
 		},
 	}, "fake")

--- a/pkg/common/constants.go
+++ b/pkg/common/constants.go
@@ -31,4 +31,8 @@ const (
 	// the external provisioner sidecar is started with --extra-create-metadata=true and
 	// thus provides such metadata to the CSI driver.
 	PVNameTag = "kubernetes.io/created-for/pv/name"
+
+	// VolumeNameTag is tag applied to provisioned alibaba cloud disk
+	// Disk name have many restrictions, so we use this tag to store the original name
+	VolumeNameTag = "csi.alibabacloud.com/volume-name"
 )

--- a/pkg/disk/cloud.go
+++ b/pkg/disk/cloud.go
@@ -1035,15 +1035,6 @@ func getDefaultDiskTags(diskVol *diskVolumeArgs) []ecs.CreateDiskTag {
 	return diskTags
 }
 
-func IsDiskCreatedByCsi(disk ecs.Disk) bool {
-	for _, tag := range disk.Tags.Tag {
-		if tag.TagKey == DISKTAGKEY2 {
-			return tag.TagValue == DISKTAGVALUE2
-		}
-	}
-	return false
-}
-
 func deleteDisk(ecsClient cloud.ECSInterface, diskId string) (*ecs.DeleteDiskResponse, error) {
 	deleteDiskRequest := ecs.CreateDeleteDiskRequest()
 	deleteDiskRequest.DiskId = diskId

--- a/pkg/disk/disk.go
+++ b/pkg/disk/disk.go
@@ -90,6 +90,7 @@ type GlobalConfig struct {
 	RequestBaseInfo       map[string]string
 	SnapshotBeforeDelete  bool
 	OmitFilesystemCheck   bool
+	DiskAllowAllType      bool
 }
 
 // define global variable
@@ -142,7 +143,7 @@ func NewDriver(m metadata.MetadataProvider, endpoint string, runAsController boo
 	tmpdisk.controllerServer = NewControllerServer(tmpdisk.driver, apiExtentionClient)
 
 	if !runAsController {
-		tmpdisk.nodeServer = NewNodeServer(tmpdisk.driver, client)
+		tmpdisk.nodeServer = NewNodeServer(tmpdisk.driver, m)
 	}
 
 	return tmpdisk
@@ -265,6 +266,7 @@ func GlobalConfigSet(m metadata.MetadataProvider) *restclient.Config {
 		SnapshotBeforeDelete:  csiCfg.GetBool("volume-del-auto-snap", "VOLUME_DEL_AUTO_SNAP", false),
 		RequestBaseInfo:       map[string]string{"owner": "alibaba-cloud-csi-driver", "nodeName": nodeName},
 		OmitFilesystemCheck:   csiCfg.GetBool("disable-fs-check", "DISABLE_FS_CHECK", false),
+		DiskAllowAllType:      csiCfg.GetBool("disk-allow-all-type", "DISK_ALLOW_ALL_TYPE", false),
 	}
 	if GlobalConfigVar.ADControllerEnable {
 		log.Log.Infof("AD-Controller is enabled, CSI Disk Plugin running in AD Controller mode.")

--- a/test/csi-sanity/csi-sanity-disk.yaml
+++ b/test/csi-sanity/csi-sanity-disk.yaml
@@ -87,8 +87,6 @@ spec:
         fieldRef:
           apiVersion: v1
           fieldPath: spec.nodeName
-    - name: MAX_VOLUMES_PERNODE
-      value: "7"
     - name: SERVICE_PORT
       value: "13260"
     securityContext:

--- a/test/csi-sanity/csi-sanity-disk.yaml
+++ b/test/csi-sanity/csi-sanity-disk.yaml
@@ -117,6 +117,7 @@ spec:
       "--csi.mountdir", "/var/lib/kubelet/csi-sanity/csi-mount",
       "--csi.stagingdir", "/var/lib/kubelet/csi-sanity/csi-staging",
       "--csi.testvolumeparameters", "/etc/csi-test/volume-parameters.yaml",
+      "--csi.testnodevolumeattachlimit",
       "--ginkgo.junit-report", "/var/lib/kubelet/csi-sanity/report.xml",
       "--ginkgo.no-color",
       "--ginkgo.v",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature
/kind api-change
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Volume count detection now also works for static PV. 
We detect whether a disk is managed by us by reading k8s node resource, instead of disk tag.

This makes OpenAPI access on node mandatory. We cannot startup if we cannot access OpenAPI.
set DISK_ALLOW_ALL_TYPE env to skip this.

Also makes KUBE_NODE_NAME env mandatory.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
action required: make sure you have KUBE_NODE_NAME env set for plugin Pod.
action required: make sure `ecs:DescribeInstanceTypes` and `ecs:DescribeDisks` RAM permission is granted to plugin.
a new tag csi.alibabacloud.com/volume-name is added to EBS disk
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
