### PR TITLE
pass supported disk type as CSI topology

### DIFF
--- a/pkg/disk/constants.go
+++ b/pkg/disk/constants.go
@@ -101,31 +101,17 @@ const (
 	GBSIZE = 1024 * MBSIZE
 	// ZoneID ...
 	ZoneID = "zoneId"
-	// instanceTypeLabel ...
-	instanceTypeLabel = "beta.kubernetes.io/instance-type"
-	// zoneIDLabel ...
-	zoneIDLabel = "failure-domain.beta.kubernetes.io/zone"
-	// sigmaLabel instance type ...
-	sigmaInstanceTypeLabel = "sigma.ali/machine-model"
-	// sigmaLabel zoneid ....
-	sigmaLabelZoneId = "sigma.ali/ecs-zone-id"
-	// nodeStorageLabel ...
-	nodeStorageLabel = "node.csi.alibabacloud.com/disktype.%s"
 
 	nodeDiskCountAnnotation = "node.csi.alibabacloud.com/allocatable-disk"
 	// kubeNodeName ...
 	kubeNodeName = "KUBE_NODE_NAME"
 	// describeResourceType ...
 	describeResourceType = "DataDisk"
-	// NodeSchedueTag in annotations
-	NodeSchedueTag = "volume.kubernetes.io/selected-node"
 	// RetryMaxTimes ...
 	RetryMaxTimes = 5
 
 	labelAppendPrefix = "csi.alibabacloud.com/label-prefix/"
-	annVolumeTopoKey  = "csi.alibabacloud.com/volume-topology"
 	labelVolumeType   = "csi.alibabacloud.com/disktype"
-	annAppendPrefix   = "csi.alibabacloud.com/annotation-prefix/"
 
 	VolumeDeleteAutoSnapshotKey                    = "csi.alibabacloud.com/volume-delete-autosnapshot-retentiondays"
 	VOLUME_EXPAND_AUTO_SNAPSHOT_OP_KEY             = "volumeExpandAutoSnapshot"

--- a/pkg/disk/disk.go
+++ b/pkg/disk/disk.go
@@ -43,9 +43,11 @@ import (
 
 // PluginFolder defines the location of diskplugin
 const (
-	driverName              = "diskplugin.csi.alibabacloud.com"
-	TopologyZoneKey         = "topology." + driverName + "/zone"
-	TopologyMultiZonePrefix = TopologyZoneKey + "-"
+	driverName                = "diskplugin.csi.alibabacloud.com"
+	TopologyZoneKey           = "topology." + driverName + "/zone"
+	TopologyMultiZonePrefix   = TopologyZoneKey + "-"
+	TopologyDiskTypePrefix    = "node.csi.alibabacloud.com/disktype."
+	TopologyDiskTypeAvailable = "available"
 )
 
 // DISK the DISK object


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

We no longer update Kubernetes Node with supported disk type labels. kubelet will add them instead.

We also no longer query the Node for supported disk types, external-provisioner will pass them as preferred topology.

We no longer set the annotation csi.alibabacloud.com/volume-topology in PV, which is opaque to user. They are set in nodeAffinity instead.

As the consequence, we can remove some non-standard operation:
- support for csi.alibabacloud.com/annotation-prefix/ to add annotations to PV
- support for reading csi.alibabacloud.com/volume-topology annotation in scheduler

This also make us depends less on Kubernetes, which we should not as a CSI driver

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
