### PR TITLE
disk: ensure NodeUnstageVolume is called if attached but not mounted

### DIFF
--- a/pkg/disk/nodeserver.go
+++ b/pkg/disk/nodeserver.go
@@ -582,6 +582,7 @@ func (ns *nodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVol
 	}
 
 	// Step 4 Attach volume
+	defaultErrCode := codes.Internal
 	if GlobalConfigVar.ADControllerEnable || isMultiAttach {
 		var bdf string
 		devicePaths, err := GetDeviceByVolumeID(req.GetVolumeId())
@@ -617,15 +618,18 @@ func (ns *nodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVol
 			log.Errorf("NodeStageVolume: Attach volume: %s with error: %s", req.VolumeId, fullErrorMessage)
 			return nil, status.Errorf(codes.Aborted, "NodeStageVolume: Attach volume: %s with error: %+v", req.VolumeId, err)
 		}
+		// Now we have attached the disk, if we fail later, NodeStageVolume is in-progress.
+		// Return Aborted so that the CO will call NodeUnstageVolume later to detach.
+		defaultErrCode = codes.Aborted
 	}
 
 	if err := checkDeviceAvailable(mountInfoPath, device, req.VolumeId, targetPath); err != nil {
 		log.Errorf("NodeStageVolume: check device %s for volume %s with error: %s", device, req.VolumeId, err.Error())
-		return nil, status.Error(codes.Internal, err.Error())
+		return nil, status.Error(defaultErrCode, err.Error())
 	}
 	if err := saveVolumeConfig(req.VolumeId, device); err != nil {
 		log.Errorf("NodeStageVolume: saveVolumeConfig %s for volume %s with error: %s", device, req.VolumeId, err.Error())
-		return nil, status.Error(codes.Aborted, "NodeStageVolume: saveVolumeConfig for ("+req.VolumeId+device+") error with: "+err.Error())
+		return nil, status.Error(defaultErrCode, "NodeStageVolume: saveVolumeConfig for ("+req.VolumeId+device+") error with: "+err.Error())
 	}
 	log.Infof("NodeStageVolume: Volume Successful Attached: %s, to Node: %s, Device: %s", req.VolumeId, ns.nodeID, device)
 
@@ -636,17 +640,17 @@ func (ns *nodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVol
 			key, value, found := strings.Cut(configStr, "=")
 			if !found {
 				log.Errorf("NodeStageVolume: Volume Block System Config with format error: %s", configStr)
-				return nil, status.Error(codes.Aborted, "NodeStageVolume: Volume Block System Config with format error "+configStr)
+				return nil, status.Error(defaultErrCode, "NodeStageVolume: Volume Block System Config with format error "+configStr)
 			}
 			base := fmt.Sprintf("/sys/block/%s/", filepath.Base(device))
 			fileName := filepath.Clean(base + key)
 			if !strings.HasPrefix(fileName, base) {
 				// Note this cannot prevent user from access other device through e.g. /sys/block/vda/subsystem/vdb
-				return nil, status.Errorf(codes.Aborted, "NodeStageVolume: invalid relative path in sysConfig: %s", key)
+				return nil, status.Errorf(defaultErrCode, "NodeStageVolume: invalid relative path in sysConfig: %s", key)
 			}
 			err := utils.WriteTrunc(unix.AT_FDCWD, fileName, value)
 			if err != nil {
-				return nil, status.Errorf(codes.Internal,
+				return nil, status.Errorf(defaultErrCode,
 					"NodeStageVolume: Volume Block System Config failed, failed to write %s to %s: %v", value, fileName, err)
 			}
 			log.Infof("NodeStageVolume: set sysConfig %s=%s", key, value)
@@ -665,7 +669,7 @@ func (ns *nodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVol
 		}
 		options := []string{"bind"}
 		if err := ns.mounter.MountBlock(device, targetPath, options...); err != nil {
-			return nil, status.Error(codes.Internal, err.Error())
+			return nil, status.Error(defaultErrCode, err.Error())
 		}
 		log.Infof("NodeStageVolume: Successfully Mount Device %s to %s with options: %v", device, targetPath, options)
 		return &csi.NodeStageVolumeResponse{}, nil
@@ -680,7 +684,7 @@ func (ns *nodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVol
 	}
 	mountOptions := collectMountOptions(fsType, options)
 	if err := ns.mounter.EnsureFolder(targetPath); err != nil {
-		return nil, status.Error(codes.Internal, err.Error())
+		return nil, status.Error(defaultErrCode, err.Error())
 	}
 
 	// Set mkfs options for ext3, ext4
@@ -693,17 +697,17 @@ func (ns *nodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVol
 	diskMounter := &k8smount.SafeFormatAndMount{Interface: ns.k8smounter, Exec: utilexec.New()}
 	if err := utils.FormatAndMount(diskMounter, device, targetPath, fsType, mkfsOptions, mountOptions, omitfsck); err != nil {
 		log.Errorf("Mountdevice: FormatAndMount fail with mkfsOptions %s, %s, %s, %s, %s with error: %s", device, targetPath, fsType, mkfsOptions, mountOptions, err.Error())
-		return nil, status.Error(codes.Internal, err.Error())
+		return nil, status.Error(defaultErrCode, err.Error())
 	}
 	// if len(mkfsOptions) > 0 && (fsType == "ext4" || fsType == "ext3") {
 	// 	if err := utils.FormatAndMount(diskMounter, device, targetPath, fsType, mkfsOptions, mountOptions, GlobalConfigVar.OmitFilesystemCheck); err != nil {
 	// 		log.Errorf("Mountdevice: FormatAndMount fail with mkfsOptions %s, %s, %s, %s, %s with error: %s", device, targetPath, fsType, mkfsOptions, mountOptions, err.Error())
-	// 		return nil, status.Error(codes.Internal, err.Error())
+	// 		return nil, status.Error(defaultErrCode, err.Error())
 	// 	}
 	// } else {
 	// 	if err := diskMounter.FormatAndMount(device, targetPath, fsType, mountOptions); err != nil {
 	// 		log.Errorf("NodeStageVolume: Volume: %s, Device: %s, FormatAndMount error: %s", req.VolumeId, device, err.Error())
-	// 		return nil, status.Error(codes.Internal, err.Error())
+	// 		return nil, status.Error(defaultErrCode, err.Error())
 	// 	}
 	// }
 	log.Infof("NodeStageVolume: Mount Successful: volumeId: %s target %v, device: %s, mkfsOptions: %v, options: %v", req.VolumeId, targetPath, device, mkfsOptions, mountOptions)
@@ -723,7 +727,7 @@ func (ns *nodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVol
 		if needResize {
 			log.Infof("NodeStageVolume: Resizing volume %q created from a snapshot/volume", req.VolumeId)
 			if _, err := r.Resize(device, targetPath); err != nil {
-				return nil, status.Errorf(codes.Internal, "Could not resize volume %s: %v", req.VolumeId, err)
+				return nil, status.Errorf(defaultErrCode, "Could not resize volume %s: %v", req.VolumeId, err)
 			}
 		}
 	}


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

We need NodeUnstageVolume to detach the disk.
Although we have logic to detach the disk on deleting or attaching to another node, but they are less tested.
And detaching the disk earlier is preferred.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
