### PR TITLE
unify node/controller service enabling

### DIFF
--- a/deploy/chart/templates/controller.yaml
+++ b/deploy/chart/templates/controller.yaml
@@ -292,6 +292,8 @@ spec:
             - "--endpoint=unix://csi/driverplugin.csi.alibabacloud.com-replace/csi.sock"
             - "--v=2"
             - "--driver={{ include "enabledControllers" .Values.csi }}"
+            - --run-controller-service=true
+            - --run-node-service=false
 {{- if .Values.deploy.featureGates }}
             - "--feature-gates={{ .Values.deploy.featureGates }}"
 {{- end -}}
@@ -299,8 +301,6 @@ spec:
             - --nodeid=$(KUBE_NODE_NAME)
 {{- end }}
           env:
-            - name: SERVICE_TYPE
-              value: "provisioner"
             - name: "DEFAULT_REGISTRY"
               value: {{ .Values.images.registry | quote }}
 {{- if .Values.deploy.ack }}

--- a/deploy/chart/templates/plugin.yaml
+++ b/deploy/chart/templates/plugin.yaml
@@ -103,6 +103,8 @@ spec:
             - "--endpoint=unix://csi/driverplugin.csi.alibabacloud.com-replace/csi.sock"
             - "--v=2"
             - "--driver={{ include "enabledPlugins" $nodePool.csi }}"
+            - --run-controller-service=false
+            - --run-node-service=true
 {{- if $nodePool.deploy.featureGates }}
             - "--feature-gates={{ $nodePool.deploy.featureGates }}"
 {{- end -}}
@@ -115,8 +117,6 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: spec.nodeName
-            - name: SERVICE_TYPE
-              value: "plugin"
 {{- if $nodePool.deploy.regionID }}
             - name: REGION_ID
               value: {{ $nodePool.deploy.regionID | quote }}

--- a/pkg/disk/controllerserver.go
+++ b/pkg/disk/controllerserver.go
@@ -396,7 +396,7 @@ func (cs *controllerServer) ControllerPublishVolume(ctx context.Context, req *cs
 		isSingleInstance = AllCategories[Category(value)].SingleInstance
 	}
 
-	_, err := attachDisk(ctx, req.VolumeContext[TenantUserUID], req.VolumeId, req.NodeId, isSharedDisk, isSingleInstance)
+	_, err := attachDisk(ctx, req.VolumeContext[TenantUserUID], req.VolumeId, req.NodeId, isSharedDisk, isSingleInstance, false)
 	if err != nil {
 		klog.Errorf("ControllerPublishVolume: attach disk: %s to node: %s with error: %s", req.VolumeId, req.NodeId, err.Error())
 		return nil, err

--- a/pkg/disk/nodeserver.go
+++ b/pkg/disk/nodeserver.go
@@ -606,7 +606,7 @@ func (ns *nodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVol
 			}
 		}
 	} else {
-		device, err = attachDisk(ctx, req.VolumeContext[TenantUserUID], req.GetVolumeId(), ns.NodeID, isSharedDisk, isSingleInstance)
+		device, err = attachDisk(ctx, req.VolumeContext[TenantUserUID], req.GetVolumeId(), ns.NodeID, isSharedDisk, isSingleInstance, true)
 		if err != nil {
 			fullErrorMessage := utils.FindSuggestionByErrorMessage(err.Error(), utils.DiskAttachDetach)
 			klog.Errorf("NodeStageVolume: Attach volume: %s with error: %s", req.VolumeId, fullErrorMessage)

--- a/pkg/disk/nodeserver.go
+++ b/pkg/disk/nodeserver.go
@@ -182,7 +182,7 @@ func NewNodeServer(m metadata.MetadataProvider) csi.NodeServer {
 		go checkVfhpOnlineReconcile()
 	}
 
-	if !GlobalConfigVar.ControllerService && IsVFNode() && GlobalConfigVar.BdfHealthCheck {
+	if IsVFNode() && GlobalConfigVar.BdfHealthCheck {
 		go BdfHealthCheck()
 	}
 

--- a/pkg/ens/ens.go
+++ b/pkg/ens/ens.go
@@ -57,7 +57,7 @@ type ENS struct {
 
 func initDriver() {}
 
-func NewDriver(nodeID, endpoint string) *ENS {
+func NewDriver(nodeID, endpoint string, serviceType utils.ServiceType) *ENS {
 
 	initDriver()
 	tmpENS := &ENS{}
@@ -66,9 +66,10 @@ func NewDriver(nodeID, endpoint string) *ENS {
 	NewGlobalConfig()
 
 	tmpENS.idServer = NewIdentityServer()
-	if GlobalConfigVar.ControllerService {
+	if serviceType&utils.Controller != 0 {
 		tmpENS.controllerServer = NewControllerServer()
-	} else {
+	}
+	if serviceType&utils.Node != 0 {
 		tmpENS.nodeServer = NewNodeServer()
 	}
 	return tmpENS
@@ -142,11 +143,6 @@ func NewGlobalConfig() {
 		detachBeforeAttach = true
 	}
 
-	controllerServerType := false
-	if os.Getenv(utils.ServiceType) == utils.ProvisionerService {
-		controllerServerType = true
-	}
-
 	GlobalConfigVar = GlobalConfig{
 		KClient:                      kubeClient,
 		InstanceID:                   instanceID,
@@ -155,7 +151,6 @@ func NewGlobalConfig() {
 		RegionID:                     regionID,
 		EnableAttachDetachController: attachDetachController,
 		DetachBeforeAttach:           detachBeforeAttach,
-		ControllerService:            controllerServerType,
 	}
 }
 
@@ -164,7 +159,6 @@ type GlobalConfig struct {
 	InstanceID         string
 	ClusterID          string
 	DetachBeforeAttach bool
-	ControllerService  bool
 
 	EnableDiskPartition          string
 	EnableAttachDetachController string

--- a/pkg/metric/collector.go
+++ b/pkg/metric/collector.go
@@ -45,34 +45,32 @@ type CSICollector struct {
 }
 
 // newCSICollector method returns the CSICollector object
-func newCSICollector(metricType string, driverNames []string) error {
+func newCSICollector(driverNames []string) error {
 	if csiCollectorInstance != nil {
 		return nil
 	}
 	collectors := make(map[string]Collector)
-	if metricType == pluginService {
-		enabledDrivers := map[string]struct{}{}
-		for _, d := range driverNames {
-			enabledDrivers[d] = struct{}{}
-		}
-		for _, reg := range registry {
-			enabled := len(reg.RelatedDrivers) == 0
-			for _, d := range reg.RelatedDrivers {
-				if _, ok := enabledDrivers[d]; ok {
-					enabled = true
-					break
-				}
-			}
-			if enabled {
-				collector, err := reg.Factory()
-				if err != nil {
-					return err
-				}
-				collectors[reg.Name] = collector
-			}
-		}
-
+	enabledDrivers := map[string]struct{}{}
+	for _, d := range driverNames {
+		enabledDrivers[d] = struct{}{}
 	}
+	for _, reg := range registry {
+		enabled := len(reg.RelatedDrivers) == 0
+		for _, d := range reg.RelatedDrivers {
+			if _, ok := enabledDrivers[d]; ok {
+				enabled = true
+				break
+			}
+		}
+		if enabled {
+			collector, err := reg.Factory()
+			if err != nil {
+				return err
+			}
+			collectors[reg.Name] = collector
+		}
+	}
+
 	csiCollectorInstance = &CSICollector{Collectors: collectors}
 
 	return nil

--- a/pkg/metric/metric.go
+++ b/pkg/metric/metric.go
@@ -39,9 +39,9 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 // NewMetricHandler method returns a promHttp object
-func NewMetricHandler(serviceType string, driverNames []string) *Handler {
+func NewMetricHandler(driverNames []string) *Handler {
 	//csi collector singleton
-	err := newCSICollector(serviceType, driverNames)
+	err := newCSICollector(driverNames)
 	if err != nil {
 		klog.Errorf("Couldn't create collector: %s", err)
 	}

--- a/pkg/nas/nas.go
+++ b/pkg/nas/nas.go
@@ -37,14 +37,14 @@ type NAS struct {
 	nodeServer       *nodeServer
 }
 
-func NewDriver(meta *metadata.Metadata, endpoint, serviceType string) *NAS {
+func NewDriver(meta *metadata.Metadata, endpoint string, serviceType utils.ServiceType) *NAS {
 	klog.Infof("Driver: %v version: %v", driverName, version.VERSION)
 
 	var d NAS
 	d.endpoint = endpoint
 	d.identityServer = newIdentityServer()
 
-	if serviceType == utils.ProvisionerService {
+	if serviceType&utils.Controller != 0 {
 		config, err := internal.GetControllerConfig(meta)
 		if err != nil {
 			klog.Fatalf("Get nas controller config: %v", err)
@@ -54,14 +54,14 @@ func NewDriver(meta *metadata.Metadata, endpoint, serviceType string) *NAS {
 			klog.Fatalf("Failed to init nas controller server: %v", err)
 		}
 		d.controllerServer = cs
-	} else {
+	}
+	if serviceType&utils.Node != 0 {
 		config, err := internal.GetNodeConfig()
 		if err != nil {
 			klog.Fatalf("Get nas node config: %v", err)
 		}
 		d.nodeServer = newNodeServer(config)
 	}
-
 	return &d
 }
 

--- a/pkg/nas/nas_test.go
+++ b/pkg/nas/nas_test.go
@@ -2,12 +2,13 @@ package nas
 
 import (
 	"fmt"
+	"testing"
+
 	"github.com/jarcoal/httpmock"
 	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/cloud/metadata"
 	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/options"
 	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/utils"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 const (
@@ -54,7 +55,7 @@ func TestNewDriverProvisioner(t *testing.T) {
 	prepareNasTestFakeK8sContext()
 	prepareFakeRegionEnvVar(t)
 
-	driver := NewDriver(metadata.NewMetadata(), "", utils.ProvisionerService)
+	driver := NewDriver(metadata.NewMetadata(), "", utils.Controller)
 	assert.NotNil(t, driver)
 }
 
@@ -83,7 +84,7 @@ func TestNewDriverPlugin(t *testing.T) {
 	prepareNasTestFakeK8sContext()
 	prepareNodeConfigEnvVars(t)
 
-	driver := NewDriver(metadata.NewMetadata(), "", utils.PluginService)
+	driver := NewDriver(metadata.NewMetadata(), "", utils.Node)
 	assert.NotNil(t, driver)
 }
 


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup
/kind feature
/kind deprecation

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Every driver supports enable/disable node or controller service, with unified interface.

deprecate SERVICE_TYPE env
deprecate -run-as-controller flags
introduce -run-controller-service and -run-node-service, allowing controller and node service to be enabled/disabled independently.


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
new -run-controller-service and -run-node-service flags are introduced, -run-as-controller and SERVICE_TYPE env are deprecated.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
