### PR TITLE
disk: DescribeDisks auto batching

### DIFF
--- a/pkg/cloud/throttle/throttle.go
+++ b/pkg/cloud/throttle/throttle.go
@@ -1,0 +1,133 @@
+package throttle
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync/atomic"
+	"time"
+
+	alierrors "github.com/aliyun/alibaba-cloud-sdk-go/sdk/errors"
+	"k8s.io/klog/v2"
+	"k8s.io/utils/clock"
+)
+
+type throttlingError struct {
+	err error
+}
+
+func (e throttlingError) Error() string {
+	return fmt.Sprintf("OpenAPI is throttling: %v", e.err)
+}
+
+func (t throttlingError) Unwrap() error {
+	return t.err
+}
+
+type throttlingContext struct {
+	probing chan struct{}
+
+	lastThrottling time.Time
+	retryDelay     time.Duration
+}
+
+type Throttler struct {
+	initDelay time.Duration
+	maxDelay  time.Duration
+
+	clk clock.Clock
+
+	current atomic.Pointer[throttlingContext]
+}
+
+func NewThrottler(clk clock.Clock, initDelay, maxDelay time.Duration) *Throttler {
+	return &Throttler{
+		initDelay: initDelay,
+		maxDelay:  maxDelay,
+		clk:       clk,
+	}
+}
+
+// Throttle will call f and retry after delay when Throttling error code is returned.
+// If one Throttling error is observed, all subsequent requests will be delayed.
+// A random delayed request will be used to probe whether the throttling has ended.
+// If a non-Throttling response is returned, all delayed requests will be sent out immediately.
+//
+// This works with Alibaba Cloud OpenAPI, which usually enforce a quota every minute.
+// If we use up the quota in the first 10s, we will get Throttling error code in the following 50s.
+func (t *Throttler) Throttle(ctx context.Context, f func() error) error {
+	logger := klog.FromContext(ctx)
+	start := t.clk.Now()
+	for {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		tCtx := t.current.Load()
+		if tCtx != nil {
+			logger.V(3).Info("OpenAPI throttling in effect")
+			select {
+			case <-ctx.Done():
+				return throttlingError{ctx.Err()}
+			case _, ok := <-tCtx.probing:
+				if ok {
+					// Currently throttling, we will probe if the throttling has ended.
+					// Be sure to write or close tCtx.probing to notify others.
+					select {
+					case <-ctx.Done():
+						tCtx.probing <- struct{}{}
+						return throttlingError{ctx.Err()}
+					case <-t.clk.After(tCtx.retryDelay - t.clk.Since(tCtx.lastThrottling)):
+					}
+					logger.V(2).Info("OpenAPI throttling, probing", "retry", tCtx.retryDelay)
+				} else {
+					logger.V(2).Info("OpenAPI no longer throttle", "delay", t.clk.Since(start))
+					tCtx = nil
+				}
+			}
+		}
+
+		err := f()
+
+		var alierr *alierrors.ServerError
+		if err != nil && !errors.As(err, &alierr) {
+			// We are not sure what's wrong, don't change state.
+			if tCtx != nil {
+				// Initiate the next probe immediately.
+				tCtx.probing <- struct{}{}
+			}
+			return err
+		}
+
+		if err == nil || alierr.ErrorCode() != "Throttling" {
+			if tCtx != nil {
+				logger.V(1).Info("OpenAPI throttling ended")
+				close(tCtx.probing)
+				t.current.CompareAndSwap(tCtx, nil)
+			}
+			return err
+		}
+
+		// Throttling detected
+		if tCtx == nil {
+			tCtx = &throttlingContext{
+				lastThrottling: t.clk.Now(),
+				retryDelay:     t.initDelay,
+				probing:        make(chan struct{}, 1),
+			}
+			tCtx.probing <- struct{}{}
+			if t.current.CompareAndSwap(nil, tCtx) {
+				logger.V(1).Info("OpenAPI throttling detected", "requestID", alierr.RequestId())
+			} else {
+				logger.V(3).Info("already throttling", "requestID", alierr.RequestId())
+			}
+		} else {
+			tCtx.lastThrottling = t.clk.Now()
+			tCtx.retryDelay *= 2
+			if tCtx.retryDelay > t.maxDelay {
+				tCtx.retryDelay = t.maxDelay
+			}
+			tCtx.probing <- struct{}{}
+			logger.V(2).Info("still throttling", "retry", tCtx.retryDelay, "requestID", alierr.RequestId())
+		}
+	}
+}

--- a/pkg/cloud/throttle/throttle_test.go
+++ b/pkg/cloud/throttle/throttle_test.go
@@ -1,0 +1,176 @@
+package throttle
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	alierrors "github.com/aliyun/alibaba-cloud-sdk-go/sdk/errors"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/klog/v2"
+	klogtest "k8s.io/klog/v2/test"
+	testclock "k8s.io/utils/clock/testing"
+)
+
+var ErrThrottling error = alierrors.NewServerError(400, `{"Code": "Throttling"}`, "")
+
+func TestThrottlingStress(t *testing.T) {
+	klogtest.InitKlog(t).Set("logtostderr", "true")
+
+	var throttling atomic.Bool
+	var reqCount [16]atomic.Uint64
+	var apiCount atomic.Uint64
+	f := func() error {
+		apiCount.Add(1)
+		if throttling.Load() {
+			return ErrThrottling
+		} else {
+			return nil
+		}
+	}
+
+	clk := testclock.NewFakeClock(time.Now())
+	throttler := NewThrottler(clk, 1*time.Second, 8*time.Second)
+	ctx, cancel := context.WithCancel(context.Background())
+
+	wg := sync.WaitGroup{}
+	wg.Add(len(reqCount))
+	for i := range reqCount {
+		go func() {
+			ctx := klog.NewContext(ctx, klog.Background().WithValues("worker", i))
+			for {
+				reqCount[i].Add(1)
+				err := throttler.Throttle(ctx, f)
+				if err != nil {
+					// Throttling error will not be exposed to the caller
+					assert.ErrorIs(t, err, context.Canceled)
+					break
+				}
+			}
+			wg.Done()
+		}()
+	}
+
+	allHasReq := func(count uint64) bool {
+		for i := range reqCount {
+			if reqCount[i].Load() < count {
+				return false
+			}
+		}
+		return true
+	}
+	totalCount := func() uint64 {
+		var c uint64
+		for i := range reqCount {
+			c += reqCount[i].Load()
+		}
+		return c
+	}
+
+	for !allHasReq(16) {
+		time.Sleep(time.Millisecond)
+	}
+
+	throttling.Store(true)
+	time.Sleep(time.Millisecond * 10)
+
+	c1 := totalCount()
+	a1 := apiCount.Load()
+	for range 16 {
+		clk.Step(time.Second)
+		time.Sleep(time.Millisecond * 10)
+	}
+	c2 := totalCount()
+	a2 := apiCount.Load()
+	// Expect 4 probe, but not return to caller
+	assert.Equal(t, c1, c2)
+	assert.Equal(t, 4, int(a2-a1))
+
+	throttling.Store(false)
+	clk.Step(time.Second * 20)
+
+	for !allHasReq(c2 + 32) {
+		time.Sleep(time.Millisecond)
+	}
+
+	cancel()
+	wg.Wait()
+}
+
+func TestThrottleErrorPassThrough(t *testing.T) {
+	clk := testclock.NewFakeClock(time.Now())
+	throttler := NewThrottler(clk, time.Second*1, time.Second*10)
+
+	testErr := func(t *testing.T, expectedErr error) {
+		f := func() error {
+			return expectedErr
+		}
+		err := throttler.Throttle(context.Background(), f)
+		assert.Same(t, expectedErr, err)
+	}
+
+	t.Run("unknown", func(t *testing.T) {
+		testErr(t, errors.New("unknown error"))
+	})
+	t.Run("server error", func(t *testing.T) {
+		testErr(t, alierrors.NewServerError(400, `{"Code": "Test"}`, ""))
+	})
+}
+
+func TestCancelAtDelay(t *testing.T) {
+	clk := testclock.NewFakeClock(time.Now())
+	throttler := NewThrottler(clk, time.Second*1, time.Second*10)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	wg := sync.WaitGroup{}
+	wg.Add(2)
+	for range 2 {
+		// One should block at probing delay, another should block on reading tCtx.probing
+		go func() {
+			err := throttler.Throttle(ctx, func() error {
+				return ErrThrottling
+			})
+			assert.ErrorIs(t, err, context.Canceled)
+			wg.Done()
+		}()
+	}
+	time.Sleep(time.Millisecond * 10)
+	cancel()
+	wg.Wait()
+
+	go func() {
+		time.Sleep(time.Millisecond * 10)
+		clk.Step(time.Second)
+	}()
+	// Another request should still go through, canceling should not break throttler state.
+	err := throttler.Throttle(context.Background(), func() error { return nil })
+	assert.NoError(t, err)
+}
+
+func TestUnknownErrorOnProbing(t *testing.T) {
+	clk := testclock.NewFakeClock(time.Now())
+	throttler := NewThrottler(clk, time.Second*1, time.Second*10)
+
+	errUnknown := errors.New("unknown error")
+	var errRet atomic.Pointer[error]
+	errRet.Store(&ErrThrottling)
+	go func() {
+		err := throttler.Throttle(context.Background(), func() error { return *errRet.Load() })
+		assert.Equal(t, err, errUnknown)
+	}()
+
+	time.Sleep(time.Millisecond * 10)
+	errRet.Store(&errUnknown)
+	clk.Step(time.Second)
+
+	// initiate next probe immediately
+	go func() {
+		time.Sleep(time.Millisecond * 10)
+		clk.Step(time.Microsecond)
+	}()
+	err := throttler.Throttle(context.Background(), func() error { return nil })
+	assert.NoError(t, err)
+}

--- a/pkg/disk/batcher/interface.go
+++ b/pkg/disk/batcher/interface.go
@@ -1,0 +1,8 @@
+// batcher package allows for batching of requests to the cloud provider
+package batcher
+
+import "context"
+
+type Batcher[T any] interface {
+	Describe(ctx context.Context, id string) (*T, error)
+}

--- a/pkg/disk/batcher/low_latency.go
+++ b/pkg/disk/batcher/low_latency.go
@@ -1,0 +1,189 @@
+package batcher
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"slices"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/disk/desc"
+	"k8s.io/klog/v2"
+	"k8s.io/utils/clock"
+)
+
+type getResponse[T any] struct {
+	res T
+	err error
+}
+
+type getRequest[T any] struct {
+	ctx        context.Context
+	id         string
+	time       time.Time
+	resultChan chan getResponse[T]
+}
+
+type LowLatency[T any] struct {
+	ecsClient desc.Client[T]
+	// remove this once we have a ecsClient that can refresh its credentials
+	PollHook func() desc.Client[T]
+
+	requestChan chan *getRequest[*T]
+
+	tokens tokenBucket
+	clk    clock.WithTicker
+}
+
+// NewLowLatency creates a batcher that has low latency when traffic is low, while maintaining high efficiency when traffic is high.
+//
+// The more frequent incoming requests are, the longer each request will wait to allow batching.
+// The waiting time is capped at perRequest.
+// The average interval of outgoing batched request traffic is also perRequest, allowing some burst.
+//
+// If the batch is fully filled, the request is issued immediately, skipping any remaining wait period, and is not limited by perRequest.
+// Concurrent outgoing requests are possible if there are too many incomming requests.
+func NewLowLatency[T any](ecsClient desc.Client[T], clk clock.WithTicker, perRequest time.Duration, burst int) *LowLatency[T] {
+	return &LowLatency[T]{
+		ecsClient:   ecsClient,
+		requestChan: make(chan *getRequest[*T]),
+		tokens: tokenBucket{
+			limit: burst, perToken: perRequest,
+		},
+		clk: clk,
+	}
+}
+
+func (w *LowLatency[T]) Describe(ctx context.Context, id string) (*T, error) {
+	resultChan := make(chan getResponse[*T], 1) // in case this wait is canceled, don't block descBatch()
+	w.requestChan <- &getRequest[*T]{
+		ctx:        ctx,
+		id:         id,
+		resultChan: resultChan,
+	}
+	select {
+	case resp := <-resultChan:
+		return resp.res, resp.err
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+}
+
+type tokenBucket struct {
+	zeroAt time.Time
+
+	limit    int
+	perToken time.Duration
+}
+
+func (tb *tokenBucket) tokenAt(t time.Time) float64 {
+	elapsed := t.Sub(tb.zeroAt)
+	token := float64(elapsed) / float64(tb.perToken)
+	if token > float64(tb.limit) {
+		token = float64(tb.limit)
+	}
+	return token
+}
+
+func (tb *tokenBucket) takeAt(t time.Time) {
+	elapsed := t.Sub(tb.zeroAt)
+	if elapsed >= time.Duration(tb.limit)*tb.perToken {
+		tb.zeroAt = t.Add(-time.Duration(tb.limit-1) * tb.perToken)
+	} else {
+		tb.zeroAt = tb.zeroAt.Add(tb.perToken)
+		if tb.zeroAt.After(t) {
+			tb.zeroAt = t
+		}
+	}
+}
+
+func (w *LowLatency[T]) Run(ctx context.Context) {
+	var timeout <-chan time.Time
+	batchSize := w.ecsClient.BatchSize()
+	requests := make(map[string][]*getRequest[*T], batchSize)
+	logger := klog.FromContext(ctx).WithValues("type", w.ecsClient.Type())
+
+	descBatch := func(t time.Time) {
+		w.tokens.takeAt(t)
+		go w.descBatch(logger, t, requests)
+		requests = make(map[string][]*getRequest[*T], batchSize)
+		timeout = nil
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			sendToAll(requests, getResponse[*T]{err: fmt.Errorf("batcher terminating: %w", ctx.Err())})
+			return
+		case r := <-w.requestChan:
+			klog.FromContext(r.ctx).V(5).Info("enqueued batcher", "type", w.ecsClient.Type())
+			t := w.clk.Now()
+			r.time = t
+			requests[r.id] = append(requests[r.id], r)
+			if len(requests) == batchSize {
+				logger.V(4).Info("batch full", "n", batchSize)
+				descBatch(t)
+			} else if timeout == nil {
+				// add some artificial delay for better batching
+				// the less tokens left, the more we wait
+				tokens := w.tokens.tokenAt(t)
+				d := time.Duration(math.Pow(0.5, tokens) * float64(w.tokens.perToken))
+				timeout = w.clk.After(d)
+				logger.V(4).Info("batch waiting", "timeout", d)
+			}
+		case t := <-timeout:
+			logger.V(4).Info("batch timeout", "n", len(requests))
+			descBatch(t)
+		}
+	}
+}
+
+func (w *LowLatency[T]) descBatch(logger logr.Logger, t time.Time, requests map[string][]*getRequest[*T]) {
+	thisBatch := make([]string, 0, len(requests))
+	for id, reqs := range requests {
+		if slices.ContainsFunc(reqs, func(r *getRequest[*T]) bool {
+			return r.ctx.Err() == nil
+		}) {
+			thisBatch = append(thisBatch, id)
+		}
+	}
+	if len(thisBatch) == 0 {
+		return
+	}
+
+	if w.PollHook != nil {
+		w.ecsClient = w.PollHook()
+	}
+
+	resp, err := w.ecsClient.Describe(thisBatch)
+	if err != nil {
+		sendToAll(requests, getResponse[*T]{err: err})
+		return
+	}
+	firstTime := t
+	for _, r := range resp.Resources {
+		id := w.ecsClient.GetID(&r)
+		for _, req := range requests[id] {
+			if req.time.Before(firstTime) {
+				firstTime = req.time
+			}
+			klog.FromContext(req.ctx).V(4).Info("got resource", "type", w.ecsClient.Type(),
+				"wait", t.Sub(req.time), "requestID", resp.RequestID)
+			req.resultChan <- getResponse[*T]{res: &r}
+		}
+		delete(requests, id)
+	}
+	// Not found
+	sendToAll(requests, getResponse[*T]{})
+	logger.V(3).Info("got batch", "n", len(thisBatch),
+		"requestID", resp.RequestID, "duration", w.clk.Since(t), "wait", t.Sub(firstTime))
+}
+
+func sendToAll[T any](requests map[string][]*getRequest[*T], resp getResponse[*T]) {
+	for _, reqs := range requests {
+		for _, req := range reqs {
+			req.resultChan <- resp
+		}
+	}
+}

--- a/pkg/disk/batcher/low_latency_test.go
+++ b/pkg/disk/batcher/low_latency_test.go
@@ -1,0 +1,155 @@
+package batcher
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/aliyun/alibaba-cloud-sdk-go/services/ecs"
+	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/disk/desc"
+	testdesc "github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/disk/desc/testing"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/utils/clock"
+	testclock "k8s.io/utils/clock/testing"
+)
+
+func TestZeroBucketIsFilled(t *testing.T) {
+	bucket := tokenBucket{
+		limit: 8, perToken: 2 * time.Second,
+	}
+	assert.Equal(t, 8., bucket.tokenAt(time.Now()))
+}
+
+func TestBucketTake(t *testing.T) {
+	bucket := tokenBucket{
+		limit: 8, perToken: 2 * time.Second,
+	}
+	now := time.Now()
+	bucket.takeAt(now)
+	assert.Equal(t, 7., bucket.tokenAt(now))
+
+	bucket.takeAt(now)
+	assert.Equal(t, 6., bucket.tokenAt(now))
+
+	assert.Equal(t, 6.5, bucket.tokenAt(now.Add(time.Second)))
+	assert.Equal(t, 8., bucket.tokenAt(now.Add(100*time.Second)))
+
+	for range 10 {
+		bucket.takeAt(now)
+	}
+	// bucket is empty, cannot be negative
+	assert.Equal(t, 0., bucket.tokenAt(now))
+}
+
+func setup(t *testing.T) (client *testdesc.FakeClient, clk *testclock.FakeClock, batcher *LowLatency[ecs.Disk]) {
+	client = &testdesc.FakeClient{}
+	clk = testclock.NewFakeClock(time.Now())
+	batcher = NewLowLatency(client, clk, 2*time.Second, 8)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	go batcher.Run(ctx)
+
+	return client, clk, batcher
+}
+
+func TestCancel(t *testing.T) {
+	t.Parallel()
+	client, clk, batcher := setup(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err := batcher.Describe(ctx, "d-test")
+	assert.ErrorIs(t, err, context.Canceled)
+
+	time.Sleep(100 * time.Millisecond)
+	clk.Step(10 * time.Second)
+	time.Sleep(100 * time.Millisecond)
+	assert.Len(t, client.Requests, 0) // no requests were made
+}
+
+func TestBasic(t *testing.T) {
+	t.Parallel()
+	client, clk, batcher := setup(t)
+	client.Disks.Store("d-test", &ecs.Disk{
+		DiskId:   "d-test",
+		DiskName: "mydisk",
+	})
+
+	var disk *ecs.Disk
+	wg := sync.WaitGroup{}
+	wg.Add(3)
+	go func() {
+		var err error
+		disk, err = batcher.Describe(context.Background(), "d-test")
+		assert.NoError(t, err)
+		assert.Equal(t, "mydisk", disk.DiskName)
+		wg.Done()
+	}()
+	for range 2 {
+		go func() {
+			disk, err := batcher.Describe(context.Background(), "d-test-not-found")
+			assert.NoError(t, err)
+			assert.Nil(t, disk)
+			wg.Done()
+		}()
+	}
+	time.Sleep(100 * time.Millisecond)
+	assert.Nil(t, disk)             // not returned yet
+	clk.Step(10 * time.Millisecond) // expected wait time for first request is 2/(2^8) seconds
+
+	wg.Wait()
+	assert.Len(t, client.Requests, 1)
+	assert.Len(t, client.Requests[0], 2) // deduplicate requests
+}
+
+func TestImmediateFullBatch(t *testing.T) {
+	t.Parallel()
+	client, _, batcher := setup(t)
+
+	res := make(chan *ecs.Disk)
+	for i := range client.BatchSize() {
+		diskID := fmt.Sprintf("d-disk-%d", i)
+		go func() {
+			disk, err := batcher.Describe(context.Background(), diskID)
+			assert.NoError(t, err)
+			res <- disk
+		}()
+	}
+
+	for range client.BatchSize() {
+		disk := <-res
+		assert.Nil(t, disk)
+	}
+
+	// only one request was made (batch), even clk is not stepped
+	assert.Len(t, client.Requests, 1)
+	assert.Len(t, client.Requests[0], client.BatchSize())
+}
+
+var ErrFake = errors.New("fake error")
+
+type failingClient struct {
+	testdesc.FakeClient
+}
+
+func (c *failingClient) Describe(ids []string) (desc.Response[ecs.Disk], error) {
+	return desc.Response[ecs.Disk]{}, ErrFake
+}
+
+func TestFailures(t *testing.T) {
+	t.Parallel()
+	client := &failingClient{}
+	batcher := NewLowLatency(client, clock.RealClock{}, 2*time.Second, 10)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	go batcher.Run(ctx)
+
+	disk, err := batcher.Describe(context.Background(), "d-test")
+	assert.ErrorIs(t, err, ErrFake)
+	assert.Nil(t, disk)
+}

--- a/pkg/disk/cloud.go
+++ b/pkg/disk/cloud.go
@@ -114,7 +114,7 @@ func (ad *DiskAttachDetach) attachDisk(ctx context.Context, diskID, nodeID strin
 				return "", status.Errorf(codes.Aborted, "AttachDisk: Can't attach disk %s to instance %s: %v", diskID, disk.InstanceId, err)
 			}
 
-			if err := waitForSharedDiskInStatus(ctx, 10, time.Second*3, diskID, nodeID, DiskStatusDetached, ecsClient); err != nil {
+			if err := ad.waitForDiskDetached(ctx, diskID, nodeID); err != nil {
 				return "", err
 			}
 		}
@@ -178,7 +178,7 @@ func (ad *DiskAttachDetach) attachDisk(ctx context.Context, diskID, nodeID strin
 		// Step 2: wait for Detach
 		if disk.Status != DiskStatusAvailable {
 			klog.Infof("AttachDisk: Wait for disk %s is detached", diskID)
-			if err := waitForDiskInStatus(ctx, 15, time.Second*3, diskID, DiskStatusAvailable, ecsClient); err != nil {
+			if err := ad.waitForDiskDetached(ctx, diskID, nodeID); err != nil {
 				return "", err
 			}
 		}
@@ -218,14 +218,8 @@ func (ad *DiskAttachDetach) attachDisk(ctx context.Context, diskID, nodeID strin
 
 	// Step 4: wait for disk attached
 	klog.Infof("AttachDisk: Waiting for Disk %s is Attached to instance %s with RequestId: %s", diskID, nodeID, response.RequestId)
-	if isSharedDisk {
-		if err := waitForSharedDiskInStatus(ctx, 20, time.Second*3, diskID, nodeID, DiskStatusAttached, ecsClient); err != nil {
-			return "", err
-		}
-	} else {
-		if err := waitForDiskInStatus(ctx, 20, time.Second*3, diskID, DiskStatusInuse, ecsClient); err != nil {
-			return "", err
-		}
+	if err := ad.waitForDiskAttached(ctx, diskID, nodeID); err != nil {
+		return "", err
 	}
 
 	// step 5: diff device with previous files under /dev
@@ -334,7 +328,7 @@ func (ad *DiskAttachDetach) attachSharedDisk(ctx context.Context, diskID, nodeID
 
 	// Step 4: wait for disk attached
 	klog.Infof("AttachSharedDisk: Waiting for Disk %s is Attached to instance %s with RequestId: %s", diskID, nodeID, response.RequestId)
-	if err := waitForSharedDiskInStatus(ctx, 20, time.Second*3, diskID, nodeID, DiskStatusAttached, ecsClient); err != nil {
+	if err := ad.waitForDiskAttached(ctx, diskID, nodeID); err != nil {
 		return "", err
 	}
 
@@ -356,15 +350,7 @@ func (ad *DiskAttachDetach) detachMultiAttachDisk(ctx context.Context, ecsClient
 		return false, nil
 	}
 
-	isDetached := true
-	for _, attachment := range disk.Attachments.Attachment {
-		if attachment.InstanceId == nodeID {
-			isDetached = false
-			break
-		}
-	}
-
-	if !isDetached {
+	if waitstatus.IsInstanceAttached(disk, nodeID) {
 		klog.Infof("DetachSharedDisk: Starting to Detach Disk %s from node %s", diskID, nodeID)
 		detachDiskRequest := ecs.CreateDetachDiskRequest()
 		detachDiskRequest.DiskId = disk.DiskId
@@ -380,46 +366,9 @@ func (ad *DiskAttachDetach) detachMultiAttachDisk(ctx context.Context, ecsClient
 		}
 
 		// check disk detach
-		for i := 0; i < 25; i++ {
-			tmpDisk, err := findDiskByID(diskID, ecsClient)
-			if err != nil {
-				errMsg := fmt.Sprintf("DetachSharedDisk: Detaching Disk %s with describe error: %s", diskID, err.Error())
-				klog.Errorf(errMsg)
-				return true, status.Error(codes.Aborted, errMsg)
-			}
-			if tmpDisk == nil {
-				klog.Warningf("DetachSharedDisk: DiskId %s is not found", diskID)
-				break
-			}
-			// Detach Finish
-			if tmpDisk.Status == DiskStatusAvailable {
-				break
-			}
-			if tmpDisk.Status == DiskStatusAttaching {
-				klog.Infof("DetachSharedDisk: DiskId %s is attaching to: %s", diskID, tmpDisk.InstanceId)
-				break
-			}
-			// 判断是否还包含此节点ID；
-			isDetached = true
-			for _, attachment := range tmpDisk.Attachments.Attachment {
-				if attachment.InstanceId == nodeID {
-					isDetached = false
-					break
-				}
-			}
-			if isDetached {
-				break
-			}
-			if i == 24 {
-				errMsg := fmt.Sprintf("DetachSharedDisk: Detaching Disk %s with timeout", diskID)
-				klog.Errorf(errMsg)
-				return true, status.Error(codes.Aborted, errMsg)
-			}
-			select {
-			case <-ctx.Done():
-				return true, status.Errorf(codes.Aborted, "DetachSharedDisk: canceling waiting for disk %s detach: %v", diskID, ctx.Err())
-			case <-time.After(2000 * time.Millisecond):
-			}
+		err = ad.waitForDiskDetached(ctx, diskID, nodeID)
+		if err != nil {
+			return true, status.Errorf(codes.Aborted, "DetachSharedDisk: Detaching Disk %s failed: %v", diskID, err)
 		}
 		klog.Infof("DetachSharedDisk: Volume: %s Success to detach disk %s from Instance %s, RequestId: %s", diskID, disk.DiskId, disk.InstanceId, response.RequestId)
 	} else {
@@ -439,14 +388,9 @@ func (ad *DiskAttachDetach) detachDisk(ctx context.Context, ecsClient *ecs.Clien
 		klog.Infof("DetachDisk: Detach Disk %s from node %s describe and find disk not exist", diskID, nodeID)
 		return nil
 	}
-	beforeAttachTime := disk.AttachedTime
 
-	if disk.InstanceId == "" {
-		klog.Infof("DetachDisk: Skip Detach, disk %s have not detachable instance", diskID)
-		return nil
-	}
-	if disk.InstanceId != nodeID {
-		klog.Infof("DetachDisk: Skip Detach for volume: %s, disk %s is attached to other instance: %s current instance: %s", diskID, disk.DiskId, disk.InstanceId, nodeID)
+	if !waitstatus.IsInstanceAttached(disk, nodeID) {
+		klog.Infof("DetachDisk: Skip Detach, disk %s is not attached on instance %s", diskID, nodeID)
 		return nil
 	}
 	// NodeStageVolume/NodeUnstageVolume should be called by sequence
@@ -491,51 +435,9 @@ func (ad *DiskAttachDetach) detachDisk(ctx context.Context, ecsClient *ecs.Clien
 	}
 
 	// check disk detach
-	for i := 0; i < 25; i++ {
-		tmpDisk, err := findDiskByID(diskID, ecsClient)
-		if err != nil {
-			errMsg := fmt.Sprintf("DetachDisk: Detaching Disk %s with describe error: %s", diskID, err.Error())
-			klog.Errorf(errMsg)
-			return status.Error(codes.Aborted, errMsg)
-		}
-		if tmpDisk == nil {
-			klog.Warningf("DetachDisk: DiskId %s is not found", diskID)
-			break
-		}
-		if tmpDisk.InstanceId == "" {
-			klog.Infof("DetachDisk: Disk %s has empty instanceId, detach finished", diskID)
-			break
-		}
-		// Attached by other Instance
-		if tmpDisk.InstanceId != nodeID {
-			klog.Infof("DetachDisk: DiskId %s is attached by other instance %s, not as before %s", diskID, tmpDisk.InstanceId, nodeID)
-			break
-		}
-		// Detach Finish
-		if tmpDisk.Status == DiskStatusAvailable {
-			break
-		}
-		// Disk is InUse in same host, but is attached again.
-		if tmpDisk.Status == DiskStatusInuse {
-			if beforeAttachTime != tmpDisk.AttachedTime {
-				klog.Infof("DetachDisk: DiskId %s is attached again, old AttachTime: %s, new AttachTime: %s", diskID, beforeAttachTime, tmpDisk.AttachedTime)
-				break
-			}
-		}
-		if tmpDisk.Status == DiskStatusAttaching {
-			klog.Infof("DetachDisk: DiskId %s is attaching to: %s", diskID, tmpDisk.InstanceId)
-			break
-		}
-		if i == 24 {
-			errMsg := fmt.Sprintf("DetachDisk: Detaching Disk %s with timeout", diskID)
-			klog.Errorf(errMsg)
-			return status.Error(codes.Aborted, errMsg)
-		}
-		select {
-		case <-ctx.Done():
-			return status.Errorf(codes.Aborted, "DetachDisk: canceling waiting for disk %s detach: %v", diskID, ctx.Err())
-		case <-time.After(2000 * time.Millisecond):
-		}
+	err = ad.waitForDiskDetached(ctx, diskID, nodeID)
+	if err != nil {
+		return status.Errorf(codes.Aborted, "DetachDisk: Detaching Disk %s failed: %v", diskID, err)
 	}
 	klog.Infof("DetachDisk: Volume: %s Success to detach disk %s from Instance %s, RequestId: %s", diskID, disk.DiskId, disk.InstanceId, response.RequestId)
 	return nil
@@ -626,72 +528,31 @@ func tagDiskAsK8sAttached(diskID string, ecsClient *ecs.Client) {
 	klog.Infof("tagDiskAsK8sAttached:: add tag to disk: %s", diskID)
 }
 
-func waitForSharedDiskInStatus(ctx context.Context, retryCount int, interval time.Duration, diskID, nodeID string, expectStatus string, ecsClient *ecs.Client) error {
-	for i := 0; i < retryCount; i++ {
-		select {
-		case <-ctx.Done():
-			return status.Errorf(codes.Aborted, "waitForSharedDiskInStatus: canceling waiting for disk %s in status %s: %v", diskID, expectStatus, ctx.Err())
-		case <-time.After(interval):
-		}
-		disk, err := findDiskByID(diskID, ecsClient)
-		if err != nil {
-			return err
-		}
-		if disk == nil {
-			return status.Errorf(codes.Aborted, "waitForSharedDiskInStatus: disk not exist: %s", diskID)
-		}
-		if expectStatus == DiskStatusAttached {
-			for _, attachment := range disk.Attachments.Attachment {
-				if attachment.InstanceId == nodeID {
-					return nil
-				}
-			}
-		} else if expectStatus == DiskStatusDetached {
-			isDetached := true
-			for _, attachment := range disk.Attachments.Attachment {
-				if attachment.InstanceId == nodeID {
-					isDetached = false
-				}
-			}
-			if isDetached {
-				return nil
-			}
-		}
-
-		for _, instance := range disk.MountInstances.MountInstance {
-			if expectStatus == DiskStatusAttached {
-				if instance.InstanceId == nodeID {
-					return nil
-				}
-			} else if expectStatus == DiskStatusDetached {
-				if instance.InstanceId != nodeID {
-					return nil
-				}
-			}
-		}
+func (ad *DiskAttachDetach) waitForDiskAttached(ctx context.Context, diskID, nodeID string) error {
+	disk, err := ad.waiter.WaitFor(ctx, diskID, func(disk *ecs.Disk) bool {
+		return waitstatus.IsInstanceAttached(disk, nodeID)
+	})
+	if err != nil {
+		return err
 	}
-	return status.Errorf(codes.Aborted, "WaitForSharedDiskInStatus: after %d times of check, disk %s is still not attached", retryCount, diskID)
+	if disk == nil {
+		return fmt.Errorf("waitForDiskAttached: disk %s not found", diskID)
+	}
+	return nil
 }
 
-func waitForDiskInStatus(ctx context.Context, retryCount int, interval time.Duration, diskID string, expectedStatus string, ecsClient *ecs.Client) error {
-	for i := 0; i < retryCount; i++ {
-		select {
-		case <-ctx.Done():
-			return status.Errorf(codes.Aborted, "WaitForDiskInStatus: canceling waiting for disk %s in status %s: %v", diskID, expectedStatus, ctx.Err())
-		case <-time.After(interval):
-		}
-		disk, err := findDiskByID(diskID, ecsClient)
-		if err != nil {
-			return err
-		}
-		if disk == nil {
-			return status.Errorf(codes.Aborted, "WaitForDiskInStatus: disk not exist: %s", diskID)
-		}
-		if disk.Status == expectedStatus {
-			return nil
-		}
+func (ad *DiskAttachDetach) waitForDiskDetached(ctx context.Context, diskID, nodeID string) error {
+	disk, err := ad.waiter.WaitFor(ctx, diskID, func(disk *ecs.Disk) bool {
+		return !waitstatus.IsInstanceAttached(disk, nodeID)
+	})
+	if err != nil {
+		return err
 	}
-	return status.Errorf(codes.Aborted, "WaitForDiskInStatus: after %d times of check, disk %s is still not in expected status %v", retryCount, diskID, expectedStatus)
+	if disk == nil {
+		klog.Infof("waitForDiskDetached: disk %s not found", diskID)
+		return nil
+	}
+	return nil
 }
 
 func findDiskByID(diskID string, ecsClient *ecs.Client) (*ecs.Disk, error) {

--- a/pkg/disk/controllerserver.go
+++ b/pkg/disk/controllerserver.go
@@ -89,6 +89,9 @@ func NewControllerServer(csiCfg utils.Config) csi.ControllerServer {
 		ad: DiskAttachDetach{
 			waiter:  waiter,
 			batcher: batcher,
+
+			attachThrottler: defaultThrottler(),
+			detachThrottler: defaultThrottler(),
 		},
 	}
 	detachConcurrency := 1

--- a/pkg/disk/controllerserver.go
+++ b/pkg/disk/controllerserver.go
@@ -83,10 +83,12 @@ var delVolumeSnap sync.Map
 
 // NewControllerServer is to create controller server
 func NewControllerServer(csiCfg utils.Config) csi.ControllerServer {
+	waiter, batcher := newBatcher(false)
 	c := &controllerServer{
 		recorder: utils.NewEventRecorder(),
 		ad: DiskAttachDetach{
-			waiter: newDiskStatusWaiter(false),
+			waiter:  waiter,
+			batcher: batcher,
 		},
 	}
 	detachConcurrency := 1

--- a/pkg/disk/controllerserver.go
+++ b/pkg/disk/controllerserver.go
@@ -128,7 +128,8 @@ var storageClassZonePos = map[string]int{}
 
 // provisioner: create/delete disk
 func (cs *controllerServer) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest) (*csi.CreateVolumeResponse, error) {
-	klog.Infof("CreateVolume: Starting CreateVolume, %s, %v", req.Name, req)
+	logger := klog.FromContext(ctx)
+	logger.V(2).Info("starting")
 
 	// Step 1: check parameters
 	snapshotID := ""

--- a/pkg/disk/controllerserver.go
+++ b/pkg/disk/controllerserver.go
@@ -31,6 +31,7 @@ import (
 	"github.com/aliyun/alibaba-cloud-sdk-go/services/ecs"
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/common"
+	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/features"
 	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/utils"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -46,6 +47,7 @@ import (
 // controller server try to create/delete volumes/snapshots
 type controllerServer struct {
 	recorder record.EventRecorder
+	ad       DiskAttachDetach
 	common.GenericControllerServer
 }
 
@@ -80,10 +82,24 @@ var veasp = struct {
 var delVolumeSnap sync.Map
 
 // NewControllerServer is to create controller server
-func NewControllerServer() csi.ControllerServer {
+func NewControllerServer(csiCfg utils.Config) csi.ControllerServer {
 	c := &controllerServer{
 		recorder: utils.NewEventRecorder(),
+		ad: DiskAttachDetach{
+			waiter: newDiskStatusWaiter(false),
+		},
 	}
+	detachConcurrency := 1
+	attachConcurrency := 1
+	if features.FunctionalMutableFeatureGate.Enabled(features.DiskParallelDetach) {
+		detachConcurrency = csiCfg.GetInt("disk-detach-concurrency", "DISK_DETACH_CONCURRENCY", 5)
+		klog.InfoS("Disk parallel detach enabled", "concurrency", detachConcurrency)
+	}
+	if features.FunctionalMutableFeatureGate.Enabled(features.DiskParallelAttach) {
+		attachConcurrency = csiCfg.GetInt("disk-attach-concurrency", "DISK_ATTACH_CONCURRENCY", 32)
+		klog.InfoS("Disk parallel attach enabled", "concurrency", attachConcurrency)
+	}
+	c.ad.slots = NewSlots(detachConcurrency, attachConcurrency)
 	return c
 }
 
@@ -251,7 +267,7 @@ func (cs *controllerServer) DeleteVolume(ctx context.Context, req *csi.DeleteVol
 			}
 		}
 		if disk.Status == DiskStatusInuse && canDetach {
-			err := detachDisk(ctx, ecsClient, req.VolumeId, disk.InstanceId)
+			err := cs.ad.detachDisk(ctx, ecsClient, req.VolumeId, disk.InstanceId)
 			if err != nil {
 				newErrMsg := utils.FindSuggestionByErrorMessage(err.Error(), utils.DiskDelete)
 				klog.Errorf("DeleteVolume: detach disk: %s from node: %s with error: %s", req.VolumeId, disk.InstanceId, newErrMsg)
@@ -338,7 +354,7 @@ func (cs *controllerServer) ControllerPublishVolume(ctx context.Context, req *cs
 		}
 	}
 	if isMultiAttach {
-		_, err := attachSharedDisk(ctx, req.VolumeId, req.NodeId)
+		_, err := cs.ad.attachSharedDisk(ctx, req.VolumeId, req.NodeId)
 		if err != nil {
 			klog.Errorf("ControllerPublishVolume: attach shared disk: %s to node: %s with error: %s", req.VolumeId, req.NodeId, err.Error())
 			return nil, err
@@ -366,7 +382,7 @@ func (cs *controllerServer) ControllerPublishVolume(ctx context.Context, req *cs
 		isSingleInstance = AllCategories[Category(value)].SingleInstance
 	}
 
-	_, err := attachDisk(ctx, req.VolumeId, req.NodeId, isSharedDisk, isSingleInstance, false)
+	_, err := cs.ad.attachDisk(ctx, req.VolumeId, req.NodeId, isSharedDisk, isSingleInstance, false)
 	if err != nil {
 		klog.Errorf("ControllerPublishVolume: attach disk: %s to node: %s with error: %s", req.VolumeId, req.NodeId, err.Error())
 		return nil, err
@@ -379,7 +395,7 @@ func (cs *controllerServer) ControllerPublishVolume(ctx context.Context, req *cs
 func (cs *controllerServer) ControllerUnpublishVolume(ctx context.Context, req *csi.ControllerUnpublishVolumeRequest) (*csi.ControllerUnpublishVolumeResponse, error) {
 	// Describe Disk Info
 	ecsClient := updateEcsClient(GlobalConfigVar.EcsClient)
-	isMultiAttach, err := detachMultiAttachDisk(ctx, ecsClient, req.VolumeId, req.NodeId)
+	isMultiAttach, err := cs.ad.detachMultiAttachDisk(ctx, ecsClient, req.VolumeId, req.NodeId)
 	if isMultiAttach && err != nil {
 		klog.Errorf("ControllerUnpublishVolume: detach multiAttach disk: %s from node: %s with error: %s", req.VolumeId, req.NodeId, err.Error())
 		return nil, err
@@ -400,7 +416,7 @@ func (cs *controllerServer) ControllerUnpublishVolume(ctx context.Context, req *
 	}
 
 	klog.Infof("ControllerUnpublishVolume: detach disk: %s from node: %s", req.VolumeId, req.NodeId)
-	err = detachDisk(ctx, ecsClient, req.VolumeId, req.NodeId)
+	err = cs.ad.detachDisk(ctx, ecsClient, req.VolumeId, req.NodeId)
 	if err != nil {
 		klog.Errorf("ControllerUnpublishVolume: detach disk: %s from node: %s with error: %s", req.VolumeId, req.NodeId, err.Error())
 		return nil, err

--- a/pkg/disk/desc/describe.go
+++ b/pkg/disk/desc/describe.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/requests"
 	"github.com/aliyun/alibaba-cloud-sdk-go/services/ecs"
+	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 const batchSize = 100
@@ -45,6 +46,29 @@ func (c Disk) Describe(ids []string) (Response[ecs.Disk], error) {
 	}
 	ret.RequestID = resp.RequestId
 	ret.Resources = resp.Disks.Disk
+
+	if len(ret.Resources) < len(ids) {
+		// Maybe we have some shared disks?
+		gotIDs := make(sets.Set[string], len(ret.Resources))
+		for _, disk := range ret.Resources {
+			gotIDs.Insert(disk.DiskId)
+		}
+		var sharedIDs []string
+		for _, id := range ids {
+			if !gotIDs.Has(id) {
+				sharedIDs = append(sharedIDs, id)
+			}
+		}
+		if len(sharedIDs) > 0 {
+			req.DiskIds = encodeIDs(sharedIDs)
+			req.EnableShared = requests.NewBoolean(true)
+			resp, err := c.Client.DescribeDisks(req)
+			if err != nil {
+				return ret, err
+			}
+			ret.Resources = append(ret.Resources, resp.Disks.Disk...)
+		}
+	}
 	return ret, nil
 }
 

--- a/pkg/disk/desc/testing/fake.go
+++ b/pkg/disk/desc/testing/fake.go
@@ -1,0 +1,36 @@
+package testing
+
+import (
+	"sync"
+
+	"github.com/aliyun/alibaba-cloud-sdk-go/services/ecs"
+	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/disk/desc"
+)
+
+type FakeClient struct {
+	Disks    sync.Map
+	Requests [][]string
+}
+
+func (c *FakeClient) Describe(ids []string) (desc.Response[ecs.Disk], error) {
+	c.Requests = append(c.Requests, ids)
+	resp := desc.Response[ecs.Disk]{}
+	for _, id := range ids {
+		if disk, ok := c.Disks.Load(id); ok {
+			resp.Resources = append(resp.Resources, *disk.(*ecs.Disk))
+		}
+	}
+	return resp, nil
+}
+
+func (c *FakeClient) GetID(resource *ecs.Disk) string {
+	return resource.DiskId
+}
+
+func (c *FakeClient) Type() string {
+	return "fakeDisk"
+}
+
+func (c *FakeClient) BatchSize() int {
+	return 100
+}

--- a/pkg/disk/disk.go
+++ b/pkg/disk/disk.go
@@ -26,6 +26,7 @@ import (
 	"github.com/aliyun/alibaba-cloud-sdk-go/services/ecs"
 	snapClientset "github.com/kubernetes-csi/external-snapshotter/client/v8/clientset/versioned"
 	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/cloud/metadata"
+	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/cloud/throttle"
 	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/common"
 	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/disk/batcher"
 	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/disk/desc"
@@ -257,4 +258,8 @@ func newBatcher(fromNode bool) (waitstatus.StatusWaiter[ecs.Disk], batcher.Batch
 	go b.Run(ctx)
 
 	return waiter, b
+}
+
+func defaultThrottler() *throttle.Throttler {
+	return throttle.NewThrottler(clock.RealClock{}, 1*time.Second, 10*time.Second)
 }

--- a/pkg/disk/disk.go
+++ b/pkg/disk/disk.go
@@ -27,6 +27,7 @@ import (
 	snapClientset "github.com/kubernetes-csi/external-snapshotter/client/v8/clientset/versioned"
 	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/cloud/metadata"
 	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/common"
+	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/disk/batcher"
 	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/disk/desc"
 	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/disk/waitstatus"
 	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/features"
@@ -238,13 +239,16 @@ func GlobalConfigSet(m metadata.MetadataProvider) utils.Config {
 	return csiCfg
 }
 
-func newDiskStatusWaiter(fromNode bool) waitstatus.StatusWaiter[ecs.Disk] {
+func newBatcher(fromNode bool) (waitstatus.StatusWaiter[ecs.Disk], batcher.Batcher[ecs.Disk]) {
 	client := desc.Disk{Client: GlobalConfigVar.EcsClient}
+	ctx := context.Background()
 	interval := 1 * time.Second
 	if fromNode {
 		interval = 2 * time.Second // We have many nodes, use longer interval to avoid throttling
 	}
 	waiter := waitstatus.NewBatched(client, clock.RealClock{}, interval, 3*time.Second)
-	go waiter.Run(context.Background())
-	return waiter
+	go waiter.Run(ctx)
+	b := batcher.NewLowLatency(client, clock.RealClock{}, 1*time.Second, 8)
+	go b.Run(ctx)
+	return waiter, b
 }

--- a/pkg/disk/nodeserver.go
+++ b/pkg/disk/nodeserver.go
@@ -219,6 +219,9 @@ func NewNodeServer(m metadata.MetadataProvider) csi.NodeServer {
 			batcher: batcher,
 			// if ADController is not enabled, we need serial attach to recognize old disk
 			slots: NewSlots(1, 1),
+
+			attachThrottler: defaultThrottler(),
+			detachThrottler: defaultThrottler(),
 		},
 		locks: utils.NewVolumeLocks(),
 		GenericNodeServer: common.GenericNodeServer{

--- a/pkg/disk/nodeserver.go
+++ b/pkg/disk/nodeserver.go
@@ -206,6 +206,7 @@ func NewNodeServer(m metadata.MetadataProvider) csi.NodeServer {
 		klog.Fatalf("Failed to initialize pod cgroup: %v", err)
 	}
 
+	waiter, batcher := newBatcher(true)
 	return &nodeServer{
 		metadata:     m,
 		mounter:      utils.NewMounter(),
@@ -214,7 +215,8 @@ func NewNodeServer(m metadata.MetadataProvider) csi.NodeServer {
 		podCGroup:    podCgroup,
 		clientSet:    GlobalConfigVar.ClientSet,
 		ad: DiskAttachDetach{
-			waiter: newDiskStatusWaiter(true),
+			waiter:  waiter,
+			batcher: batcher,
 			// if ADController is not enabled, we need serial attach to recognize old disk
 			slots: NewSlots(1, 1),
 		},

--- a/pkg/disk/nodeserver.go
+++ b/pkg/disk/nodeserver.go
@@ -63,13 +63,15 @@ type nodeServer struct {
 	common.GenericNodeServer
 }
 
+// Disk status returned in ecs.DescribeDisks
 const (
-	// DiskStatusInuse disk inuse status
-	DiskStatusInuse = "In_use"
-	// DiskStatusAttaching disk attaching status
+	DiskStatusInuse     = "In_use"
 	DiskStatusAttaching = "Attaching"
-	// DiskStatusAvailable disk available status
+	DiskStatusDetaching = "Detaching"
 	DiskStatusAvailable = "Available"
+)
+
+const (
 	// DiskStatusAttached disk attached status
 	DiskStatusAttached = "attached"
 	// DiskStatusDetached disk detached status

--- a/pkg/disk/waitstatus/batched.go
+++ b/pkg/disk/waitstatus/batched.go
@@ -1,0 +1,166 @@
+package waitstatus
+
+import (
+	"context"
+	"slices"
+	"time"
+
+	"k8s.io/klog/v2"
+	"k8s.io/utils/clock"
+)
+
+type waitResponse[T any] struct {
+	res T
+	err error
+}
+
+type waitRequest[T any] struct {
+	ctx        context.Context
+	id         string
+	pred       StatusPredicate[T]
+	resultChan chan waitResponse[T]
+}
+
+type Batched[T any] struct {
+	ecsClient ECSDescribeResources[T]
+
+	requestChan chan *waitRequest[*T]
+	requests    map[string][]*waitRequest[*T]
+	idQueue     []string
+
+	clk clock.WithTicker
+}
+
+func NewBatched[T any](ecsClient ECSDescribeResources[T], clk clock.WithTicker) *Batched[T] {
+	return &Batched[T]{
+		ecsClient:   ecsClient,
+		requestChan: make(chan *waitRequest[*T]),
+		requests:    make(map[string][]*waitRequest[*T]),
+		clk:         clk,
+	}
+}
+
+func (w *Batched[T]) WaitFor(ctx context.Context, id string, pred StatusPredicate[*T]) (*T, error) {
+	resultChan := make(chan waitResponse[*T], 1) // in case this wait is canceled, don't block poll()
+	w.requestChan <- &waitRequest[*T]{
+		ctx:        ctx,
+		id:         id,
+		pred:       pred,
+		resultChan: resultChan,
+	}
+	select {
+	case resp := <-resultChan:
+		return resp.res, resp.err
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+}
+
+func (w *Batched[T]) enqueueRequest(r *waitRequest[*T]) {
+	reqs, ok := w.requests[r.id]
+	w.requests[r.id] = append(reqs, r)
+	if !ok {
+		w.idQueue = append(w.idQueue, r.id)
+	}
+}
+
+func (w *Batched[T]) Run(ctx context.Context) {
+	var pollChan <-chan time.Time
+	var lastPollTime time.Time
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case r := <-w.requestChan:
+			w.enqueueRequest(r)
+			if pollChan == nil {
+				// If this is the first request, poll immediately.
+				// But don't poll again until pollInterval has passed.
+				pollChan = w.clk.After(pollInterval - w.clk.Since(lastPollTime))
+			}
+		case t := <-pollChan:
+			w.idQueue = w.poll(w.idQueue)
+			lastPollTime = t
+			if len(w.requests) == 0 {
+				// no more requests, stop polling
+				pollChan = nil
+			} else {
+				pollChan = w.clk.After(pollInterval)
+			}
+		}
+	}
+}
+
+func (w *Batched[T]) got(id string, resource *T, requestID string) (done bool) {
+	pendingReqs := slices.DeleteFunc(w.requests[id], func(r *waitRequest[*T]) bool {
+		if r.ctx.Err() != nil {
+			return true
+		}
+		logger := klog.FromContext(r.ctx)
+		if resource == nil || r.pred(resource) {
+			logger.V(4).Info("reached desired status", "type", w.ecsClient.Type(), "requestID", requestID)
+			r.resultChan <- waitResponse[*T]{res: resource}
+			return true
+		}
+		logger.V(4).Info("status not reached, re-queue", "type", w.ecsClient.Type(), "requestID", requestID)
+		return false
+	})
+	if len(pendingReqs) == 0 {
+		delete(w.requests, id)
+		return true
+	} else {
+		w.requests[id] = pendingReqs
+		return false
+	}
+}
+
+// poll picks first batchSize waitIDs that are not canceled,
+// polls ECS for their status and notify caller if done,
+// returns the rest IDs for next poll.
+// It removes done requests from w.requests
+func (w *Batched[T]) poll(waitIDs []string) []string {
+	var next []string
+	thisBatch := make([]string, 0, batchSize)
+	for i, id := range waitIDs {
+		reqs := w.requests[id]
+		if slices.ContainsFunc(reqs, func(r *waitRequest[*T]) bool {
+			return r.ctx.Err() == nil
+		}) {
+			thisBatch = append(thisBatch, id)
+		} else {
+			delete(w.requests, id)
+		}
+
+		if len(thisBatch) == batchSize {
+			next = waitIDs[i+1:]
+			break
+		}
+	}
+	if len(thisBatch) == 0 {
+		return nil
+	}
+
+	resp, err := w.ecsClient.Describe(thisBatch)
+	if err != nil {
+		for _, id := range thisBatch {
+			for _, r := range w.requests[id] {
+				r.resultChan <- waitResponse[*T]{err: err}
+			}
+		}
+		return next
+	}
+	resources := make(map[string]*T, len(resp.Resources))
+	for i := range resp.Resources {
+		res := &resp.Resources[i]
+		resources[w.ecsClient.GetID(res)] = res
+	}
+	for _, id := range thisBatch {
+		if !w.got(id, resources[id], resp.RequestID) {
+			next = append(next, id)
+		}
+	}
+	klog.V(3).InfoS("polling batch", "type", w.ecsClient.Type(), "n", len(thisBatch),
+		"interval", pollInterval, "remaining", len(next), "requestID", resp.RequestID)
+	return next
+}

--- a/pkg/disk/waitstatus/batched_test.go
+++ b/pkg/disk/waitstatus/batched_test.go
@@ -2,14 +2,16 @@ package waitstatus
 
 import (
 	"context"
-	"errors"
 	"fmt"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/aliyun/alibaba-cloud-sdk-go/services/ecs"
-	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/disk/desc"
 	testdesc "github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/disk/desc/testing"
 	"github.com/stretchr/testify/assert"
+	"k8s.io/utils/clock"
+	testclock "k8s.io/utils/clock/testing"
 )
 
 func TestPoll(t *testing.T) {
@@ -19,7 +21,11 @@ func TestPoll(t *testing.T) {
 		client.Disks.Store(diskID, disk(diskID, "Available"))
 	}
 
-	waiter := NewBatched(client, nil)
+	waiter := NewBatched(client, clock.RealClock{}, pollInterval, 2*pollInterval)
+	go func() {
+		waiter.processFeedback(<-waiter.feedback)
+	}()
+
 	sentReqs := make([]*waitRequest[*ecs.Disk], 0, 110) // large enough to trigger multiple batches
 	for i := 0; i < cap(sentReqs); i++ {
 		r := &waitRequest[*ecs.Disk]{
@@ -43,7 +49,7 @@ func TestPoll(t *testing.T) {
 	}
 	expectedIDs := waiter.idQueue[101:]     // 100 polled, 1 canceled
 	assert.Equal(t, "d102", expectedIDs[0]) // 1 repeated request
-	ids := waiter.poll(waiter.idQueue)
+	ids := waiter.poll(time.Now(), waiter.idQueue)
 	assert.Equal(t, expectedIDs, ids)
 
 	for i, req := range sentReqs[:102] {
@@ -61,18 +67,12 @@ func TestPoll(t *testing.T) {
 	}
 }
 
-var ErrFake = errors.New("fake error")
-
-type failingClient struct {
-	testdesc.FakeClient
-}
-
-func (c *failingClient) Describe(ids []string) (desc.Response[ecs.Disk], error) {
-	return desc.Response[ecs.Disk]{}, ErrFake
-}
-
 func TestPollError(t *testing.T) {
-	waiter := NewBatched(&failingClient{}, nil)
+	waiter := NewBatched(&failingClient{}, clock.RealClock{}, pollInterval, 2*pollInterval)
+	go func() {
+		waiter.processFeedback(<-waiter.feedback)
+	}()
+
 	req := &waitRequest[*ecs.Disk]{
 		ctx:        context.Background(),
 		id:         "d-test",
@@ -80,7 +80,7 @@ func TestPollError(t *testing.T) {
 		resultChan: make(chan waitResponse[*ecs.Disk], 1),
 	}
 	waiter.enqueueRequest(req)
-	ids := waiter.poll(waiter.idQueue)
+	ids := waiter.poll(time.Now(), waiter.idQueue)
 	assert.Empty(t, ids)
 	res := <-req.resultChan
 	assert.ErrorIs(t, res.err, ErrFake)
@@ -88,7 +88,7 @@ func TestPollError(t *testing.T) {
 }
 
 func TestPollEmpty(t *testing.T) {
-	waiter := NewBatched(&failingClient{}, nil)
+	waiter := NewBatched(&testdesc.FakeClient{}, clock.RealClock{}, pollInterval, 2*pollInterval)
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 	req := &waitRequest[*ecs.Disk]{
@@ -98,7 +98,44 @@ func TestPollEmpty(t *testing.T) {
 		resultChan: make(chan waitResponse[*ecs.Disk], 1),
 	}
 	waiter.enqueueRequest(req)
-	ids := waiter.poll(waiter.idQueue)
+	ids := waiter.poll(time.Now(), waiter.idQueue)
 	assert.Empty(t, ids)
 	assert.Empty(t, waiter.requests)
+}
+
+type noBatchClient struct {
+	testdesc.FakeClient
+}
+
+func (*noBatchClient) BatchSize() int {
+	return 1
+}
+
+func TestWaitTimeUpperBound(t *testing.T) {
+	clk := testclock.NewFakeClock(time.Now())
+	waiter := NewBatched(&noBatchClient{}, clk, 5*time.Second, 7*time.Second)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go waiter.Run(ctx)
+
+	var iter atomic.Int32
+	for i := range 3 {
+		go func() {
+			waiter.WaitFor(ctx, fmt.Sprintf("d-test-%d", i), isNextStatus("Detaching", "i1"))
+			iter.Add(1)
+		}()
+	}
+
+	time.Sleep(10 * time.Millisecond)
+	clk.Step(1 * time.Microsecond)
+	time.Sleep(10 * time.Millisecond)
+	assert.Equal(t, int32(1), iter.Load())
+
+	clk.Step(5 * time.Second)
+	time.Sleep(10 * time.Millisecond)
+	assert.Equal(t, int32(2), iter.Load())
+
+	clk.Step(2 * time.Second)
+	time.Sleep(10 * time.Millisecond)
+	assert.Equal(t, int32(3), iter.Load())
 }

--- a/pkg/disk/waitstatus/batched_test.go
+++ b/pkg/disk/waitstatus/batched_test.go
@@ -1,0 +1,102 @@
+package waitstatus
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/aliyun/alibaba-cloud-sdk-go/services/ecs"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPoll(t *testing.T) {
+	client := &fakeClient{}
+	for i := 0; i < 5; i++ {
+		diskID := fmt.Sprintf("d%d", i)
+		client.disks.Store(diskID, disk(diskID, "Available"))
+	}
+
+	waiter := NewBatched(client, nil)
+	sentReqs := make([]*waitRequest[*ecs.Disk], 0, 110) // large enough to trigger multiple batches
+	for i := 0; i < cap(sentReqs); i++ {
+		r := &waitRequest[*ecs.Disk]{
+			ctx:        context.Background(),
+			id:         fmt.Sprintf("d%d", i),
+			pred:       isNextStatus("Detaching", "i1"),
+			resultChan: make(chan waitResponse[*ecs.Disk], 1),
+		}
+		if i == 2 {
+			// make this request already canceled
+			ctx, cancel := context.WithCancel(context.Background())
+			cancel()
+			r.ctx = ctx
+		}
+		if i == 20 {
+			// make a repeated request
+			r.id = "d30"
+		}
+		waiter.enqueueRequest(r)
+		sentReqs = append(sentReqs, r)
+	}
+	expectedIDs := waiter.idQueue[101:]     // 100 polled, 1 canceled
+	assert.Equal(t, "d102", expectedIDs[0]) // 1 repeated request
+	ids := waiter.poll(waiter.idQueue)
+	assert.Equal(t, expectedIDs, ids)
+
+	for i, req := range sentReqs[:102] {
+		if i == 2 { // this request was canceled
+			continue
+		}
+		resp := <-req.resultChan
+		assert.NoError(t, resp.err)
+		if i < 5 {
+			expectedID := fmt.Sprintf("d%d", i)
+			assert.Equal(t, expectedID, resp.res.DiskId)
+		} else {
+			assert.Nil(t, resp.res)
+		}
+	}
+}
+
+var ErrFake = errors.New("fake error")
+
+type failingClient struct {
+	fakeClient
+}
+
+func (c *failingClient) Describe(ids []string) (DescribeResourceResponse[ecs.Disk], error) {
+	return DescribeResourceResponse[ecs.Disk]{}, ErrFake
+}
+
+func TestPollError(t *testing.T) {
+	waiter := NewBatched(&failingClient{}, nil)
+	req := &waitRequest[*ecs.Disk]{
+		ctx:        context.Background(),
+		id:         "d-test",
+		pred:       isNextStatus("Detaching", "i1"),
+		resultChan: make(chan waitResponse[*ecs.Disk], 1),
+	}
+	waiter.enqueueRequest(req)
+	ids := waiter.poll(waiter.idQueue)
+	assert.Empty(t, ids)
+	res := <-req.resultChan
+	assert.ErrorIs(t, res.err, ErrFake)
+	assert.Nil(t, res.res)
+}
+
+func TestPollEmpty(t *testing.T) {
+	waiter := NewBatched(&failingClient{}, nil)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	req := &waitRequest[*ecs.Disk]{
+		ctx:        ctx,
+		id:         "d-test",
+		pred:       isNextStatus("Detaching", "i1"),
+		resultChan: make(chan waitResponse[*ecs.Disk], 1),
+	}
+	waiter.enqueueRequest(req)
+	ids := waiter.poll(waiter.idQueue)
+	assert.Empty(t, ids)
+	assert.Empty(t, waiter.requests)
+}

--- a/pkg/disk/waitstatus/batched_test.go
+++ b/pkg/disk/waitstatus/batched_test.go
@@ -7,14 +7,16 @@ import (
 	"testing"
 
 	"github.com/aliyun/alibaba-cloud-sdk-go/services/ecs"
+	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/disk/desc"
+	testdesc "github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/disk/desc/testing"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestPoll(t *testing.T) {
-	client := &fakeClient{}
+	client := &testdesc.FakeClient{}
 	for i := 0; i < 5; i++ {
 		diskID := fmt.Sprintf("d%d", i)
-		client.disks.Store(diskID, disk(diskID, "Available"))
+		client.Disks.Store(diskID, disk(diskID, "Available"))
 	}
 
 	waiter := NewBatched(client, nil)
@@ -62,11 +64,11 @@ func TestPoll(t *testing.T) {
 var ErrFake = errors.New("fake error")
 
 type failingClient struct {
-	fakeClient
+	testdesc.FakeClient
 }
 
-func (c *failingClient) Describe(ids []string) (DescribeResourceResponse[ecs.Disk], error) {
-	return DescribeResourceResponse[ecs.Disk]{}, ErrFake
+func (c *failingClient) Describe(ids []string) (desc.Response[ecs.Disk], error) {
+	return desc.Response[ecs.Disk]{}, ErrFake
 }
 
 func TestPollError(t *testing.T) {

--- a/pkg/disk/waitstatus/client.go
+++ b/pkg/disk/waitstatus/client.go
@@ -1,0 +1,70 @@
+package waitstatus
+
+import (
+	"encoding/json"
+
+	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/requests"
+	"github.com/aliyun/alibaba-cloud-sdk-go/services/ecs"
+)
+
+func encodeIDs(ids []string) string {
+	res, err := json.Marshal(ids)
+	if err != nil {
+		panic(err)
+	}
+	return string(res)
+}
+
+type DescribeDisks struct {
+	*ecs.Client
+}
+
+func (c DescribeDisks) Describe(ids []string) (DescribeResourceResponse[ecs.Disk], error) {
+	req := ecs.CreateDescribeDisksRequest()
+	req.DiskIds = encodeIDs(ids)
+	req.PageSize = requests.NewInteger(batchSize)
+
+	ret := DescribeResourceResponse[ecs.Disk]{}
+	resp, err := c.Client.DescribeDisks(req)
+	if err != nil {
+		return ret, err
+	}
+	ret.RequestID = resp.RequestId
+	ret.Resources = resp.Disks.Disk
+	return ret, nil
+}
+
+func (c DescribeDisks) GetID(resource *ecs.Disk) string {
+	return resource.DiskId
+}
+
+func (c DescribeDisks) Type() string {
+	return "disk"
+}
+
+type DescribeSnapshots struct {
+	*ecs.Client
+}
+
+func (c DescribeSnapshots) Describe(ids []string) (DescribeResourceResponse[ecs.Snapshot], error) {
+	req := ecs.CreateDescribeSnapshotsRequest()
+	req.SnapshotIds = encodeIDs(ids)
+	req.PageSize = requests.NewInteger(batchSize)
+
+	ret := DescribeResourceResponse[ecs.Snapshot]{}
+	resp, err := c.Client.DescribeSnapshots(req)
+	if err != nil {
+		return ret, err
+	}
+	ret.RequestID = resp.RequestId
+	ret.Resources = resp.Snapshots.Snapshot
+	return ret, nil
+}
+
+func (c DescribeSnapshots) GetID(resource *ecs.Snapshot) string {
+	return resource.SnapshotId
+}
+
+func (c DescribeSnapshots) Type() string {
+	return "snapshot"
+}

--- a/pkg/disk/waitstatus/interface.go
+++ b/pkg/disk/waitstatus/interface.go
@@ -1,0 +1,50 @@
+package waitstatus
+
+import (
+	"context"
+	"time"
+
+	"github.com/aliyun/alibaba-cloud-sdk-go/services/ecs"
+)
+
+const (
+	pollInterval = 2 * time.Second
+	batchSize    = 100 // DescribeDisks supports up to 100 disk IDs at once
+)
+
+type StatusWaiter[T any] interface {
+	WaitFor(ctx context.Context, id string, pred StatusPredicate[*T]) (*T, error)
+}
+
+// a function that asserts the disk/snapshot should quit waiting
+type StatusPredicate[T any] func(resource T) bool
+
+type DescribeResourceResponse[T any] struct {
+	RequestID string
+	Resources []T
+}
+
+type ECSDescribeResources[T any] interface {
+	Describe(ids []string) (resources DescribeResourceResponse[T], err error)
+	GetID(resource *T) string
+	Type() string
+}
+
+// Utils for implementors of StatusPredicate
+
+func IsInstanceAttached(disk *ecs.Disk, instanceID string) bool {
+	for _, a := range disk.Attachments.Attachment {
+		if a.InstanceId == instanceID {
+			return true
+		}
+	}
+	return false
+}
+
+func SnapshotAvailable(snapshot *ecs.Snapshot) bool {
+	return snapshot.Available
+}
+
+func SnapshotCut(snapshot *ecs.Snapshot) bool {
+	return snapshot.CreationTime != ""
+}

--- a/pkg/disk/waitstatus/interface.go
+++ b/pkg/disk/waitstatus/interface.go
@@ -9,7 +9,6 @@ import (
 
 const (
 	pollInterval = 2 * time.Second
-	batchSize    = 100 // DescribeDisks supports up to 100 disk IDs at once
 )
 
 type StatusWaiter[T any] interface {
@@ -18,17 +17,6 @@ type StatusWaiter[T any] interface {
 
 // a function that asserts the disk/snapshot should quit waiting
 type StatusPredicate[T any] func(resource T) bool
-
-type DescribeResourceResponse[T any] struct {
-	RequestID string
-	Resources []T
-}
-
-type ECSDescribeResources[T any] interface {
-	Describe(ids []string) (resources DescribeResourceResponse[T], err error)
-	GetID(resource *T) string
-	Type() string
-}
 
 // Utils for implementors of StatusPredicate
 

--- a/pkg/disk/waitstatus/interface.go
+++ b/pkg/disk/waitstatus/interface.go
@@ -30,6 +30,11 @@ func IsInstanceAttached(disk *ecs.Disk, instanceID string) bool {
 			return true
 		}
 	}
+	for _, a := range disk.MountInstances.MountInstance {
+		if a.InstanceId == instanceID {
+			return true
+		}
+	}
 	return false
 }
 

--- a/pkg/disk/waitstatus/interface.go
+++ b/pkg/disk/waitstatus/interface.go
@@ -1,3 +1,6 @@
+// waitstatus package provides a simple way to wait for a resource to reach a desired state.
+//
+// It differs from batcher in that this allows specific optimizations like adaptive poll intervals.
 package waitstatus
 
 import (
@@ -12,6 +15,7 @@ const (
 )
 
 type StatusWaiter[T any] interface {
+	// WaitFor waits until the pred returns true for the specified id.
 	WaitFor(ctx context.Context, id string, pred StatusPredicate[*T]) (*T, error)
 }
 

--- a/pkg/disk/waitstatus/interface_test.go
+++ b/pkg/disk/waitstatus/interface_test.go
@@ -1,0 +1,176 @@
+package waitstatus
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/aliyun/alibaba-cloud-sdk-go/services/ecs"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/utils/clock"
+	testclock "k8s.io/utils/clock/testing"
+)
+
+func disk(id, status string, instances ...string) *ecs.Disk {
+	disk := &ecs.Disk{
+		DiskId: id,
+		Status: status,
+	}
+	as := make([]ecs.Attachment, len(instances))
+	for i, instance := range instances {
+		as[i] = ecs.Attachment{
+			InstanceId: instance,
+		}
+	}
+	disk.Attachments.Attachment = as
+	return disk
+}
+
+type fakeClient struct {
+	disks sync.Map
+}
+
+func (c *fakeClient) Describe(ids []string) (DescribeResourceResponse[ecs.Disk], error) {
+	resp := DescribeResourceResponse[ecs.Disk]{}
+	for _, id := range ids {
+		if disk, ok := c.disks.Load(id); ok {
+			resp.Resources = append(resp.Resources, *disk.(*ecs.Disk))
+		}
+	}
+	return resp, nil
+}
+
+func (c *fakeClient) GetID(resource *ecs.Disk) string {
+	return resource.DiskId
+}
+
+func (c *fakeClient) Type() string {
+	return "fakeDisk"
+}
+
+func isNextStatus(previousStatus string, instanceID string) StatusPredicate[*ecs.Disk] {
+	return func(disk *ecs.Disk) bool {
+		found := IsInstanceAttached(disk, instanceID)
+		switch previousStatus {
+		case "Attaching":
+			if found {
+				return true
+			}
+		case "Detaching":
+			if !found {
+				return true
+			}
+		}
+		return disk.Status != previousStatus
+	}
+}
+
+func testEachImpl(t *testing.T, clk clock.WithTicker, f func(*testing.T, *fakeClient, StatusWaiter[ecs.Disk])) {
+	t.Run("batched", func(t *testing.T) {
+		client := &fakeClient{}
+
+		ctx := context.Background()
+		ctx, cancel := context.WithCancel(ctx)
+		t.Cleanup(cancel)
+		batched := NewBatched(client, clk)
+		go batched.Run(ctx)
+
+		f(t, client, batched)
+	})
+	t.Run("simple", func(t *testing.T) {
+		client := &fakeClient{}
+		f(t, client, NewSimple(client, clk))
+	})
+}
+
+func TestWaitForDisks(t *testing.T) {
+	clk := testclock.NewFakeClock(time.Now())
+	testEachImpl(t, clk, func(t *testing.T, client *fakeClient, waiter StatusWaiter[ecs.Disk]) {
+		client.disks.Store("d1", disk("d1", "Attaching"))
+
+		finalDisk := disk("d1", "In_use", "i1")
+		go func() {
+			time.Sleep(100 * time.Millisecond) // for request to be picked up
+			t.Logf("Step for first poll")
+			clk.Step(100 * time.Millisecond)
+			time.Sleep(100 * time.Millisecond) // for the first poll to finish
+
+			client.disks.Store("d1", finalDisk)
+			t.Logf("Step for second poll")
+			clk.Step(pollInterval)
+		}()
+
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		disk, err := waiter.WaitFor(ctx, "d1", isNextStatus("Attaching", "i1"))
+		assert.NoError(t, err)
+		assert.Equal(t, finalDisk, disk)
+	})
+}
+
+func TestWaitForDisksCancel(t *testing.T) {
+	testEachImpl(t, clock.RealClock{}, func(t *testing.T, client *fakeClient, waiter StatusWaiter[ecs.Disk]) {
+		client.disks.Store("d1", disk("d1", "Attaching"))
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		disk, err := waiter.WaitFor(ctx, "d1", isNextStatus("Attaching", "i1"))
+		assert.Equal(t, ctx.Err(), err)
+		assert.Nil(t, disk)
+	})
+}
+
+func TestWaitForDisksUnfound(t *testing.T) {
+	testEachImpl(t, clock.RealClock{}, func(t *testing.T, client *fakeClient, waiter StatusWaiter[ecs.Disk]) {
+		disk, err := waiter.WaitFor(context.Background(), "d1", isNextStatus("Attaching", "i1"))
+		assert.NoError(t, err)
+		assert.Nil(t, disk)
+	})
+}
+
+func TestIsInstanceAttached(t *testing.T) {
+	tests := []struct {
+		name       string
+		disk       *ecs.Disk
+		instanceID string
+		attached   bool
+	}{
+		{
+			name:       "attaching",
+			disk:       disk("d1", "Attaching"),
+			instanceID: "i1",
+			attached:   false,
+		}, {
+			name:       "detaching",
+			disk:       disk("d1", "Detaching", "i1"),
+			instanceID: "i1",
+			attached:   true,
+		}, {
+			name:       "attaching - multi",
+			disk:       disk("d1", "Attaching", "i2"),
+			instanceID: "i1",
+			attached:   false,
+		}, {
+			name:       "detaching - multi",
+			disk:       disk("d1", "Detaching", "i1", "i2"),
+			instanceID: "i1",
+			attached:   true,
+		}, {
+			name:       "attaching - done",
+			disk:       disk("d1", "In_use", "i1"),
+			instanceID: "i1",
+			attached:   true,
+		}, {
+			name:       "detaching - done",
+			disk:       disk("d1", "Available"),
+			instanceID: "i1",
+			attached:   false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.attached, IsInstanceAttached(test.disk, test.instanceID))
+		})
+	}
+}

--- a/pkg/disk/waitstatus/simple.go
+++ b/pkg/disk/waitstatus/simple.go
@@ -4,15 +4,16 @@ import (
 	"context"
 	"errors"
 
+	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/disk/desc"
 	"k8s.io/utils/clock"
 )
 
 type Simple[T any] struct {
-	client ECSDescribeResources[T]
+	client desc.Client[T]
 	clk    clock.WithTicker
 }
 
-func NewSimple[T any](client ECSDescribeResources[T], clk clock.WithTicker) *Simple[T] {
+func NewSimple[T any](client desc.Client[T], clk clock.WithTicker) *Simple[T] {
 	return &Simple[T]{
 		client: client,
 		clk:    clk,

--- a/pkg/disk/waitstatus/simple.go
+++ b/pkg/disk/waitstatus/simple.go
@@ -1,0 +1,46 @@
+package waitstatus
+
+import (
+	"context"
+	"errors"
+
+	"k8s.io/utils/clock"
+)
+
+type Simple[T any] struct {
+	client ECSDescribeResources[T]
+	clk    clock.WithTicker
+}
+
+func NewSimple[T any](client ECSDescribeResources[T], clk clock.WithTicker) *Simple[T] {
+	return &Simple[T]{
+		client: client,
+		clk:    clk,
+	}
+}
+
+func (w *Simple[T]) WaitFor(ctx context.Context, id string, pred StatusPredicate[*T]) (*T, error) {
+	ticker := w.clk.NewTicker(pollInterval)
+	defer ticker.Stop()
+	for {
+		resp, err := w.client.Describe([]string{id})
+		if err != nil {
+			return nil, err
+		}
+		if len(resp.Resources) == 0 {
+			return nil, nil
+		}
+		if len(resp.Resources) > 1 {
+			return nil, errors.New("too many resources returned")
+		}
+		res := &resp.Resources[0]
+		if pred(res) {
+			return res, nil
+		}
+		select {
+		case <-ticker.C():
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+}

--- a/pkg/disk/waitstatus/simple.go
+++ b/pkg/disk/waitstatus/simple.go
@@ -45,3 +45,7 @@ func (w *Simple[T]) WaitFor(ctx context.Context, id string, pred StatusPredicate
 		}
 	}
 }
+
+func (w *Simple[T]) Describe(ctx context.Context, id string) (*T, error) {
+	return w.WaitFor(ctx, id, func(res *T) bool { return true })
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

disk: introduce DiskStatusWaiter

A central place for all disks pending status changes (attaching/detaching).
Waiter will poll disk status in batch and wake up the caller if the status has changed.

The motivation is reducing OpenAPI call count, to avoid triggering throttling, thus improve system throughput.

Also include a simple fallback waiter to support multi-tanent use-case.

Shared disk support is best effort, since we cannot create new shared disks for test now.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
If AD-controller enabled, the number of DescribeDisks requests on a busy cluster will be reduced greatly.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
