### PR TITLE
disk/ListSnapshots: refactor to comply with CSI

### DIFF
--- a/pkg/cloud/ecsinterface.go
+++ b/pkg/cloud/ecsinterface.go
@@ -10,4 +10,5 @@ type ECSInterface interface {
 	DescribeInstanceTypes(request *ecs.DescribeInstanceTypesRequest) (response *ecs.DescribeInstanceTypesResponse, err error)
 	DescribeDisks(request *ecs.DescribeDisksRequest) (response *ecs.DescribeDisksResponse, err error)
 	ResizeDisk(request *ecs.ResizeDiskRequest) (response *ecs.ResizeDiskResponse, err error)
+	DescribeSnapshots(request *ecs.DescribeSnapshotsRequest) (response *ecs.DescribeSnapshotsResponse, err error)
 }

--- a/pkg/cloud/ecsmock.go
+++ b/pkg/cloud/ecsmock.go
@@ -124,6 +124,21 @@ func (mr *MockECSInterfaceMockRecorder) DescribeRegions(request interface{}) *go
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeRegions", reflect.TypeOf((*MockECSInterface)(nil).DescribeRegions), request)
 }
 
+// DescribeSnapshots mocks base method.
+func (m *MockECSInterface) DescribeSnapshots(request *ecs.DescribeSnapshotsRequest) (*ecs.DescribeSnapshotsResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DescribeSnapshots", request)
+	ret0, _ := ret[0].(*ecs.DescribeSnapshotsResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DescribeSnapshots indicates an expected call of DescribeSnapshots.
+func (mr *MockECSInterfaceMockRecorder) DescribeSnapshots(request interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeSnapshots", reflect.TypeOf((*MockECSInterface)(nil).DescribeSnapshots), request)
+}
+
 // ResizeDisk mocks base method.
 func (m *MockECSInterface) ResizeDisk(request *ecs.ResizeDiskRequest) (*ecs.ResizeDiskResponse, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

disk/ListSnapshots: refactor to comply with CSI

workaround that ECS don't support max_entries < 10

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes all CSI-sanity cases of ListSnapshots:
- listsnapshots [controller server] [it] should return appropriate values (no optional values added)
- listsnapshots [controller server] [it] should return empty when the specified snapshot id does not exist
- listsnapshots [controller server] [it] should return snapshots that match the specified source volume id
- listsnapshots [controller server] [it] should return empty when the specified source volume id does not exist
- listsnapshots [controller server] [it] check the presence of new snapshots in the snapshot list
- listsnapshots [controller server] [it] should return next token when a limited number of entries are requested

#### Special notes for your reviewer:

This routine is not important to Kubernetes. But as a CSI driver, we'd better correctly implement it.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
ListSnapshots for disk plugin is re-implemented to comply with CSI. (no changes for Kubernetes users)
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
