### PR TITLE
disk: serial detach ad-slot

### DIFF
--- a/pkg/disk/cloud.go
+++ b/pkg/disk/cloud.go
@@ -70,8 +70,8 @@ func attachDisk(ctx context.Context, tenantUserUID, diskID, nodeID string, isSha
 		return "", status.Errorf(codes.NotFound, "AttachDisk: csi can't find disk: %s in region: %s, Please check if the cloud disk exists, if the region is correct, or if the csi permissions are correct", diskID, GlobalConfigVar.Region)
 	}
 
-	slot := GlobalConfigVar.AttachDetachSlots.GetSlotFor(nodeID)
-	if err := slot.AquireAttach(ctx); err != nil {
+	slot := GlobalConfigVar.AttachDetachSlots.GetSlotFor(nodeID).Attach()
+	if err := slot.Aquire(ctx); err != nil {
 		return "", status.Errorf(codes.Aborted, "AttachDisk: get ad-slot for disk %s failed: %v", diskID, err)
 	}
 	defer slot.Release()
@@ -430,8 +430,8 @@ func detachDisk(ctx context.Context, ecsClient *ecs.Client, diskID, nodeID strin
 		return nil
 	}
 	// NodeStageVolume/NodeUnstageVolume should be called by sequence
-	slot := GlobalConfigVar.AttachDetachSlots.GetSlotFor(nodeID)
-	if err := slot.AquireDetach(ctx); err != nil {
+	slot := GlobalConfigVar.AttachDetachSlots.GetSlotFor(nodeID).Detach()
+	if err := slot.Aquire(ctx); err != nil {
 		return status.Errorf(codes.Aborted, "DetachDisk: get ad-slot for disk %s failed: %v", diskID, err)
 	}
 	defer slot.Release()

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -6,7 +6,29 @@ import (
 )
 
 const (
-	DiskADController    featuregate.Feature = "DiskADController"
+	// Do disk attach/detach at controller, not node.
+	// Historically, disks don't have serial number, so we need to attach/detach disks at node
+	// to identify which device is the just attached disk.
+	// If all your disks are created after 2020-06-10, you can enable this safely.
+	// See: https://www.alibabacloud.com/help/en/ecs/user-guide/query-the-serial-number-of-a-disk
+	//
+	// Enable this at controller first, wait for the rollout to finish, then enable this at node.
+	DiskADController featuregate.Feature = "DiskADController"
+
+	// Attach multiple disks to the same node in parallel.
+	// ECS don't allow parallel attach/detach to a node by default.
+	// Enable this if you need faster attach, and only if your UID is whitelisted (by open a ticket),
+	// or you have the supportConcurrencyAttach=true tag on your ECS instance.
+	//
+	// Only effective when DiskADController is also enabled.
+	DiskParallelAttach featuregate.Feature = "DiskParallelAttach"
+
+	// Detach multiple disks from the same node in parallel.
+	// ECS does not allow parallel detach from a node currently. This feature gate is reserved for future use.
+	//
+	// Only effective when DiskADController is also enabled.
+	DiskParallelDetach featuregate.Feature = "DiskParallelDetach"
+
 	UpdatedOssfsVersion featuregate.Feature = "UpdatedOssfsVersion"
 	RundCSIProtocol3    featuregate.Feature = "RundCSIProtocol3"
 )
@@ -14,7 +36,9 @@ const (
 var (
 	FunctionalMutableFeatureGate = featuregate.NewFeatureGate()
 	defaultDiskFeatureGate       = map[featuregate.Feature]featuregate.FeatureSpec{
-		DiskADController: {Default: false, PreRelease: featuregate.Alpha},
+		DiskADController:   {Default: false, PreRelease: featuregate.Alpha},
+		DiskParallelAttach: {Default: false, PreRelease: featuregate.Alpha},
+		DiskParallelDetach: {Default: false, PreRelease: featuregate.Alpha},
 	}
 	defaultOSSFeatureGate = map[featuregate.Feature]featuregate.FeatureSpec{
 		UpdatedOssfsVersion: {Default: false, PreRelease: featuregate.Alpha},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

When parallel attach is enabled on ECS, parallel detach is still not supported. 
We should synchronize only detach operations for performance.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
new feature gate DiskParallelAttach for users who enabled ECS concurrency attach
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
