### PR TITLE
disk: use xattr to check if the disk is managed by us

### DIFF
--- a/pkg/disk/bdf.go
+++ b/pkg/disk/bdf.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 	"syscall"
@@ -409,10 +410,14 @@ var isVFInstance = false
 // IsVFNode returns whether the current node is vf
 func IsVFNode() bool {
 	vfOnce.Do(func() {
-		is_bdf := os.Getenv("IS_BDF")
-		if is_bdf == "true" {
-			isVF = true
-			isVFInstance = true
+		is_bdf_str, ok := os.LookupEnv("IS_BDF")
+		if ok {
+			is_bdf, err := strconv.ParseBool(is_bdf_str)
+			if err != nil {
+				log.Fatalf("[IsVFNode] parse IS_BDF=%s: %v", is_bdf_str, err)
+			}
+			isVF = is_bdf
+			isVFInstance = is_bdf
 		} else {
 			output, err := ExecCheckOutput("lspci", "-D")
 			if err != nil {

--- a/pkg/disk/device_manager_test.go
+++ b/pkg/disk/device_manager_test.go
@@ -108,14 +108,14 @@ func testingManager(t *testing.T) *DeviceManager {
 func TestGetDeviceBySerialNotFound(t *testing.T) {
 	m := testingManager(t)
 	_, err := m.getDeviceBySerial("mydiskserial")
-	assert.Equal(t, err, ErrNotFound)
+	assert.Equal(t, err, os.ErrNotExist)
 
 	// ignore block that has no serial
 	err = os.MkdirAll(filepath.Join(m.SysfsPath, "block/loop0"), 0o755)
 	assert.NoError(t, err)
 
 	_, err = m.getDeviceBySerial("mydiskserial")
-	assert.Equal(t, err, ErrNotFound)
+	assert.Equal(t, err, os.ErrNotExist)
 }
 
 func setupVirtIOBlockDevice(t *testing.T, sysfsPath string) string {

--- a/pkg/disk/nodeserver.go
+++ b/pkg/disk/nodeserver.go
@@ -32,11 +32,11 @@ import (
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	csicommon "github.com/kubernetes-csi/drivers/pkg/csi-common"
-	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/cloud"
 	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/cloud/metadata"
 	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/utils"
 	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/utils/rund/directvolume"
 	log "github.com/sirupsen/logrus"
+	"golang.org/x/sys/unix"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	v1 "k8s.io/api/core/v1"
@@ -131,6 +131,12 @@ const (
 var (
 	// BLOCKVOLUMEPREFIX block volume mount prefix
 	BLOCKVOLUMEPREFIX = filepath.Join(utils.KubeletRootDir, "/plugins/kubernetes.io/csi/volumeDevices/publish")
+
+	// DiskXattrName xattr is applied on the block device file to indicate that it is managed by the CSI driver.
+	// Value is the disk ID.
+	// Linux only support trusted namespace xattr in tmpfs before kernel v6.6,
+	// but setting trusted xaattr requires CAP_SYS_ADMIN capability, we may use user namespace instead in unit tests.
+	DiskXattrName = "trusted.csi-managed-disk"
 )
 
 // QueryResponse response struct for query server
@@ -142,7 +148,7 @@ type QueryResponse struct {
 	runtime    string
 }
 
-func getVolumeCount(node *v1.Node, c cloud.ECSInterface, m metadata.MetadataProvider) (int, error) {
+func parseVolumeCountEnv() (int, error) {
 	volumeNum := os.Getenv("MAX_VOLUMES_PERNODE")
 	if volumeNum != "" {
 		num, err := strconv.Atoi(volumeNum)
@@ -154,14 +160,8 @@ func getVolumeCount(node *v1.Node, c cloud.ECSInterface, m metadata.MetadataProv
 		}
 		log.Infof("MAX_VOLUMES_PERNODE is set to (from env): %d", num)
 		return num, nil
-	} else {
-		num, err := getVolumeCountFromOpenAPI(node, c, m)
-		if err != nil {
-			return 0, fmt.Errorf("MAX_VOLUMES_PERNODE not set and failed to get volume count: %w", err)
-		}
-		log.Infof("MAX_VOLUMES_PERNODE is set to (from OpenAPI): %d", num)
-		return num, nil
 	}
+	return 0, nil
 }
 
 // NewNodeServer creates node server
@@ -699,6 +699,20 @@ func (ns *nodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVol
 	return &csi.NodeStageVolumeResponse{}, nil
 }
 
+func addDiskXattr(diskID string) (err error) {
+	defer func() {
+		if errors.Is(err, os.ErrNotExist) {
+			log.Infof("addDiskXattr: disk %s not found, skip", diskID)
+			err = nil
+		}
+	}()
+	device, err := GetVolumeDeviceName(diskID)
+	if err != nil {
+		return
+	}
+	return unix.Setxattr(device, DiskXattrName, []byte(diskID), 0)
+}
+
 // target format: /var/lib/kubelet/plugins/kubernetes.io/csi/pv/pv-disk-1e7001e0-c54a-11e9-8f89-00163e0e78a0/globalmount
 func (ns *nodeServer) NodeUnstageVolume(ctx context.Context, req *csi.NodeUnstageVolumeRequest) (*csi.NodeUnstageVolumeResponse, error) {
 	log.Infof("NodeUnstageVolume:: Starting to Unmount volume, volumeId: %s, target: %v", req.VolumeId, req.StagingTargetPath)
@@ -783,6 +797,11 @@ func (ns *nodeServer) NodeUnstageVolume(ctx context.Context, req *csi.NodeUnstag
 		}
 	}
 
+	err := addDiskXattr(req.VolumeId)
+	if err != nil {
+		log.Errorf("NodeUnstageVolume: addDiskXattr %s failed: %v", req.VolumeId, err)
+	}
+
 	// Do detach if ADController disable
 	if !GlobalConfigVar.ADControllerEnable {
 		// if DetachDisabled is set to true, return
@@ -806,17 +825,28 @@ func (ns *nodeServer) NodeUnstageVolume(ctx context.Context, req *csi.NodeUnstag
 }
 
 func (ns *nodeServer) NodeGetInfo(ctx context.Context, req *csi.NodeGetInfoRequest) (*csi.NodeGetInfoResponse, error) {
+	maxVolumesNum, err := parseVolumeCountEnv()
+	if err != nil {
+		return nil, err
+	}
+
 	nodeName := os.Getenv(kubeNodeName)
 	if nodeName == "" {
 		log.Fatalf("NodeGetInfo: KUBE_NODE_NAME must be set")
 	}
-	node, err := GlobalConfigVar.ClientSet.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
-	if err != nil {
-		return nil, fmt.Errorf("failed to get node: %w", err)
+	var node *v1.Node
+	getNode := func() (*v1.Node, error) {
+		var err error
+		node, err = GlobalConfigVar.ClientSet.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
+		return node, err
 	}
 
 	c := updateEcsClient(GlobalConfigVar.EcsClient)
-	maxVolumesNum, err := getVolumeCount(node, c, ns.metadata)
+	if maxVolumesNum == 0 {
+		maxVolumesNum, err = getVolumeCountFromOpenAPI(getNode, c, ns.metadata, DefaultDeviceManager)
+	} else {
+		node, err = getNode()
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/utils/io/io_darwin.go
+++ b/pkg/utils/io/io_darwin.go
@@ -2,6 +2,14 @@
 
 package io
 
-import "golang.org/x/sys/unix"
+import (
+	"errors"
+
+	"golang.org/x/sys/unix"
+)
 
 const O_PATH = unix.O_DIRECTORY | unix.O_RDONLY
+
+func IsXattrNotFound(err error) bool {
+	return errors.Is(err, unix.ENOATTR)
+}

--- a/pkg/utils/io/io_linux.go
+++ b/pkg/utils/io/io_linux.go
@@ -2,6 +2,14 @@
 
 package io
 
-import "golang.org/x/sys/unix"
+import (
+	"errors"
+
+	"golang.org/x/sys/unix"
+)
 
 const O_PATH = unix.O_PATH
+
+func IsXattrNotFound(err error) bool {
+	return errors.Is(err, unix.ENODATA)
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

to fix the issue that when DISK_AD_CONTROLLER is enabled and disk is detaching, MaxVolumesPerNode may be smaller than expected

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
fixed that when DISK_AD_CONTROLLER is enabled and disk is detaching, MaxVolumesPerNode may be smaller than expected
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
