### PR TITLE
metric: disk hang alert and some cleanup

### DIFF
--- a/pkg/metric/common.go
+++ b/pkg/metric/common.go
@@ -42,19 +42,10 @@ const (
 	diskDefaultsLantencyThreshold           = 10
 	diskDefaultsCapacityPercentageThreshold = 85
 	nfsDefaultsCapacityPercentageThreshold  = 85
-	float64EqualityThreshold                = 1e-9
-	diskStatsFileName                       = "diskstats"
 	nfsStatsFileName                        = "/proc/self/mountstats"
 	latencyTooHigh                          = "LatencyTooHigh"
 	capacityNotEnough                       = "NotEnoughDiskSpace"
 	ioHang                                  = "IOHang"
-)
-
-const (
-	// PluginService represents the csi-plugin type.
-	pluginService = "plugin"
-	// ProvisionerService represents the csi-provisioner type.
-	provisionerService = "provisioner"
 )
 
 const (

--- a/pkg/metric/nfs_stat_collector.go
+++ b/pkg/metric/nfs_stat_collector.go
@@ -351,7 +351,7 @@ func (p *nfsStatCollector) updateNfsInfoMap(thisPvNfsInfoMap map[string]nfsInfo,
 		lastInfo, ok := (*lastPvNfsInfoMap)[pv]
 		// add and modify
 		if !ok || thisInfo.VolDataPath != lastInfo.VolDataPath {
-			pvcNamespace, pvcName, serverName, err := getPvcByPvName(p.clientSet, p.crdClient, pv)
+			pvcNamespace, pvcName, serverName, err := getNasPvcByPvName(p.clientSet, p.crdClient, pv)
 			if err != nil {
 				continue
 			}

--- a/pkg/metric/proc_diskstats.go
+++ b/pkg/metric/proc_diskstats.go
@@ -1,0 +1,126 @@
+package metric
+
+import (
+	"sync"
+	"time"
+
+	"github.com/prometheus/procfs"
+	"github.com/prometheus/procfs/blockdevice"
+	"k8s.io/utils/clock"
+)
+
+type statHistoryEntry struct {
+	// The time at which the stats were collected.
+	time time.Time
+	// The stats collected.
+	stats []blockdevice.Diskstats
+}
+
+type ProcDiskStats struct {
+	bdev blockdevice.FS
+
+	history   []statHistoryEntry
+	historyMu sync.RWMutex
+	// a disk is considered to be hung if there is I/O in flight but no progress made in at least this duration.
+	HungDuration time.Duration
+
+	clk clock.PassiveClock
+}
+
+func NewDefaultProcDiskStats() (*ProcDiskStats, error) {
+	return NewProcDiskStats(procfs.DefaultMountPoint, clock.RealClock{})
+}
+
+func NewProcDiskStats(procMountPoint string, clk clock.PassiveClock) (*ProcDiskStats, error) {
+	fs, err := blockdevice.NewFS(procMountPoint, "/") // we do not use sys mount
+	if err != nil {
+		return nil, err
+	}
+	return &ProcDiskStats{
+		bdev: fs,
+		clk:  clk,
+	}, nil
+}
+
+func (s *ProcDiskStats) GetStats() ([]blockdevice.Diskstats, error) {
+	stat, err := s.bdev.ProcDiskstats()
+	if err != nil {
+		return nil, err
+	}
+	if s.HungDuration <= 0 {
+		return stat, nil
+	}
+
+	now := s.clk.Now()
+	nextEntry := statHistoryEntry{
+		time:  now,
+		stats: stat,
+	}
+
+	s.historyMu.Lock()
+	defer s.historyMu.Unlock()
+	his := s.history
+	if len(his) == 0 {
+		s.history = []statHistoryEntry{nextEntry}
+		return stat, nil
+	}
+	if now.Sub(his[len(his)-1].time) < 1*time.Second {
+		// avoid store too many history
+		return stat, nil
+	}
+
+	for len(his) > 1 && now.Sub(his[1].time) > s.HungDuration {
+		his = his[1:]
+	}
+	his = append(his, nextEntry)
+	s.history = his
+	return stat, nil
+}
+
+func (s *ProcDiskStats) GetHungDisks() []blockdevice.Info {
+	s.historyMu.RLock()
+	his := s.history
+	s.historyMu.RUnlock()
+
+	if len(his) < 2 {
+		return nil
+	}
+	last := his[len(his)-1]
+	first := his[0]
+	if last.time.Sub(first.time) < s.HungDuration {
+		return nil // not enough history yet
+	}
+	firstMap := make(map[blockdevice.Info]*blockdevice.IOStats, len(first.stats))
+	for i, d := range first.stats {
+		firstMap[d.Info] = &first.stats[i].IOStats
+	}
+
+	var hung []blockdevice.Info
+	for _, d1 := range last.stats {
+		if d1.IOsInProgress == 0 {
+			continue // currently no IO request
+		}
+		d0, ok := firstMap[d1.Info]
+		if !ok {
+			continue
+		}
+
+		// bio based drivers are increasing ReadIOs at the beginning of IO in old kernel,
+		// not at the completion. Fortunately, nvme or virtIO are blk_mq based.
+		// see https://lore.kernel.org/all/20230223091226.1135678-1-yukuai1@huaweicloud.com/
+		if d1.ReadIOs != d0.ReadIOs || d1.WriteIOs != d0.WriteIOs || d1.DiscardIOs != d0.DiscardIOs ||
+			d1.IOsInProgress < d0.IOsInProgress {
+			continue // IO made progress, not hung
+		}
+
+		// At least hungDuration has passed during IO or there are IOs across the two samples.
+		// Note: IOsTotalTicks may only increase at IO completion in old kernel,
+		// So it may not change during IO hang. Keep it here for faster hung detection in new kernel.
+		// see https://lore.kernel.org/all/20220217064247.4041435-1-zhangwensheng5@huawei.com/
+		if time.Duration(d1.IOsTotalTicks-d0.IOsTotalTicks)*time.Millisecond > s.HungDuration ||
+			d0.IOsInProgress > 0 {
+			hung = append(hung, d1.Info)
+		}
+	}
+	return hung
+}

--- a/pkg/metric/proc_diskstats_test.go
+++ b/pkg/metric/proc_diskstats_test.go
@@ -1,0 +1,143 @@
+package metric
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	testingclock "k8s.io/utils/clock/testing"
+)
+
+func newTestingProcDiskStats(t *testing.T) (*ProcDiskStats, *testingclock.FakeClock, string) {
+	clk := testingclock.NewFakeClock(time.Now())
+	proc := filepath.Join(t.TempDir(), "proc")
+	os.Mkdir(proc, 0755)
+	s, err := NewProcDiskStats(proc, clk)
+	assert.NoError(t, err)
+	return s, clk, proc
+}
+
+const (
+	statLineA          = " 253       0 vda 18909 5492 4137980 55982 1262487 495033 17866563 3957744 0 207976 4016266 0 0 0 0 42182 2539 52991 2932647 0\n"
+	statLineA_NormalIO = " 253       0 vda 18909 5492 4137980 55982 1262487 495033 17866563 3957744 1 207977 4016266 0 0 0 0 42182 2539 52991 2932647 0\n"
+	statLineA_Complete = " 253       0 vda 18910 5492 4137980 55982 1262487 495033 17866563 3957744 1 207979 4016266 0 0 0 0 42182 2539 52991 2932647 0\n"
+	statLineB          = " 253      16 vdb 433 0 101464 1471 0 0 0 0 0 444 1471 0 0 0 0 0 0 1345 0 0\n"
+	statLineB_hung     = " 253      16 vdb 433 0 101464 1471 0 0 0 0 1 16444 1471 0 0 0 0 0 0 1345 0 0\n"
+)
+
+func writeStatLines(t *testing.T, proc string, lines ...string) {
+	content := strings.Join(lines, "")
+	assert.NoError(t, os.WriteFile(filepath.Join(proc, "diskstats"), []byte(content), 0644))
+}
+
+// no history saved, just pass through
+func TestProcDiskStats_Disabled(t *testing.T) {
+	s, _, proc := newTestingProcDiskStats(t)
+	writeStatLines(t, proc, statLineB)
+
+	_, err := s.GetStats()
+	assert.NoError(t, err)
+	assert.Empty(t, s.history)
+	assert.Empty(t, s.GetHungDisks())
+}
+
+func TestProcDiskStats_GetStats(t *testing.T) {
+	s, clk, proc := newTestingProcDiskStats(t)
+	s.HungDuration = 15 * time.Second
+	writeStatLines(t, proc, statLineB)
+
+	_, err := s.GetStats()
+	assert.NoError(t, err)
+
+	// DropTooClose
+	clk.Step(1 * time.Millisecond)
+	_, err = s.GetStats()
+	assert.NoError(t, err)
+	assert.Len(t, s.history, 1)
+
+	// Save stats
+	// index: 0 1 2 3 4
+	//  time: 0 2 4 6 8
+	for i := 2; i < 5; i++ {
+		clk.Step(2 * time.Second)
+		_, err = s.GetStats()
+		assert.NoError(t, err)
+		assert.Len(t, s.history, i)
+		assert.Empty(t, s.GetHungDisks()) // not enough history
+	}
+
+	// DropTooOld
+	clk.Step(14 * time.Second)
+	_, err = s.GetStats()
+	assert.NoError(t, err)
+	assert.Len(t, s.history, 3)       // save stat at 6, 8, 22
+	assert.Empty(t, s.GetHungDisks()) // no IO, not hung
+
+	clk.Step(20 * time.Second)
+	_, err = s.GetStats()
+	assert.NoError(t, err)
+	assert.Len(t, s.history, 2)       // save stat at 22, 42
+	assert.Empty(t, s.GetHungDisks()) // no IO, not hung
+}
+
+func TestProcDiskStats_GetHungDisks(t *testing.T) {
+	cases := []struct {
+		name   string
+		before []string
+		after  []string
+		hung   []string
+	}{
+		{
+			name:   "normal IO",
+			before: []string{statLineA},
+			after:  []string{statLineA_NormalIO},
+		}, {
+			name:   "complete",
+			before: []string{statLineA_NormalIO},
+			after:  []string{statLineA_Complete},
+		}, {
+			name:   "new device",
+			before: []string{},
+			after:  []string{statLineA_NormalIO},
+		}, {
+			name:   "disappear device",
+			before: []string{statLineA_NormalIO},
+			after:  []string{},
+		}, {
+			name:   "hung",
+			before: []string{statLineB},
+			after:  []string{statLineB_hung},
+			hung:   []string{"vdb"},
+		}, {
+			name:   "hung old kernel",
+			before: []string{statLineB_hung},
+			after:  []string{statLineB_hung},
+			hung:   []string{"vdb"},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			s, clk, proc := newTestingProcDiskStats(t)
+			s.HungDuration = 15 * time.Second
+
+			writeStatLines(t, proc, c.before...)
+			_, err := s.GetStats()
+			assert.NoError(t, err)
+
+			clk.Step(20 * time.Second)
+			writeStatLines(t, proc, c.after...)
+			_, err = s.GetStats()
+			assert.NoError(t, err)
+
+			// Check hung disks
+			hung := s.GetHungDisks()
+			assert.Len(t, hung, len(c.hung))
+			for _, d := range hung {
+				assert.Contains(t, c.hung, d.DeviceName)
+			}
+		})
+	}
+}

--- a/pkg/metric/utils.go
+++ b/pkg/metric/utils.go
@@ -2,14 +2,11 @@ package metric
 
 import (
 	"bufio"
-	"bytes"
 	"context"
 	"crypto/sha256"
 	"errors"
 	"fmt"
-	"io"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -102,155 +99,6 @@ func findVolJSON(rootDir string) ([]string, error) {
 	return filepath.Glob(filepath.Join(rootDir, "*", csiMountKeyWords, "*", volDataFile))
 }
 
-// ExecCheckOutput check output
-func execCheckOutput(cmd string, args ...string) (io.Reader, error) {
-	c := exec.Command(cmd, args...)
-	stdout := bytes.NewBuffer(nil)
-	stderr := bytes.NewBuffer(nil)
-	c.Stdout = stdout
-	c.Stderr = stderr
-	if err := c.Run(); err != nil {
-		return nil, errors.New("cmd:" + cmd + ", stdout: " + stdout.String() + ", stderr: " + stderr.String() + ", err: " + err.Error())
-	}
-
-	return stdout, nil
-}
-
-// FindLines parse lines
-func findLines(reader io.Reader, keyword string) []string {
-	var matched []string
-	scanner := bufio.NewScanner(reader)
-	for scanner.Scan() {
-		line := scanner.Text()
-		if strings.Contains(line, keyword) {
-			matched = append(matched, line)
-		}
-	}
-	return matched
-}
-
-// IsVFNode returns whether the current node is vf
-func isVFNode() bool {
-	vfOnce.Do(func() {
-		output, err := execCheckOutput("lspci", "-D")
-		if err != nil {
-			klog.Fatalf("[IsVFNode] lspci -D: %v", err)
-		}
-		// 0000:4b:00.0 SCSI storage controller: Device 1ded:1001
-		matched := findLines(output, "storage controller")
-		if len(matched) == 0 {
-			klog.Error("[IsVFNode] not found storage controller")
-		}
-		for _, line := range matched {
-			// 1ded: is alibaba cloud
-			if !strings.Contains(line, "1ded:") && !strings.Contains(line, "Alibaba") {
-				continue
-			}
-			bdf := strings.SplitN(line, " ", 2)[0]
-			if !strings.HasSuffix(bdf, ".0") {
-				continue
-			}
-			output, err = execCheckOutput("lspci", "-s", bdf, "-v")
-			if err != nil {
-				klog.Fatalf("[IsVFNode] lspic -s %s -v: %v", bdf, err)
-			}
-			// Capabilities: [110] Single Root I/O Virtualization (SR-IOV)
-			matched = findLines(output, "Single Root I/O Virtualization")
-			if len(matched) > 0 {
-				isVF = true
-				break
-			}
-		}
-	})
-	return isVF
-}
-
-func getDeviceSerial(serial string) (device string) {
-	serialFiles, err := filepath.Glob("/sys/block/*/serial")
-	if err != nil {
-		klog.Infof("List device serial failed: %v", err)
-		return ""
-	}
-
-	for _, serialFile := range serialFiles {
-		body, err := os.ReadFile(serialFile)
-		if err != nil {
-			klog.Errorf("Read serial(%s): %v", serialFile, err)
-			continue
-		}
-		if strings.TrimSpace(string(body)) == serial {
-			return filepath.Join("/dev", filepath.Base(filepath.Dir(serialFile)))
-		}
-	}
-	return ""
-}
-
-// GetDeviceByVolumeID First try to find the device by serial
-// If cannot find the device using the serial number, get device by volumeID, link file should be like:
-// /dev/disk/by-id/virtio-wz9cu3ctp6aj1iagco4h -> ../../vdc
-func getDeviceByVolumeID(pvName, volumeID string) (device string, err error) {
-	// this is danger in Bdf mode
-	// when bdf hang resolved, use this in all types
-	if !isVFNode() {
-		device = getDeviceSerial(strings.TrimPrefix(volumeID, "d-"))
-		if device != "" {
-			return device, nil
-		}
-	}
-
-	if device, err = getDeviceBySymlink(volumeID); err != nil {
-		device, err = utils.GetNvmeDeviceByVolumeID(volumeID)
-		if err != nil {
-			return "", fmt.Errorf("getDeviceByVolumeID failed: %v", err)
-		}
-		return device, nil
-	}
-	return device, nil
-}
-
-func getDeviceBySymlink(volumeID string) (string, error) {
-	byIDPath := "/dev/disk/by-id/"
-	volumeLinkName := strings.Replace(volumeID, "d-", "virtio-", -1)
-	volumeLinPath := filepath.Join(byIDPath, volumeLinkName)
-
-	stat, err := os.Lstat(volumeLinPath)
-	if err != nil {
-		if os.IsNotExist(err) {
-			// in some os, link file is not begin with virtio-,
-			// but diskPart will always be part of link file.
-			isSearched := false
-			files, _ := os.ReadDir(byIDPath)
-			diskPart := strings.Replace(volumeID, "d-", "", -1)
-			for _, f := range files {
-				if strings.Contains(f.Name(), diskPart) {
-					volumeLinPath = filepath.Join(byIDPath, f.Name())
-					stat, _ = os.Lstat(volumeLinPath)
-					isSearched = true
-					break
-				}
-			}
-			if !isSearched {
-				return "", fmt.Errorf("volumeID link path %q not found", volumeLinPath)
-			}
-		} else {
-			return "", fmt.Errorf("error getting stat of %q: %v", volumeLinPath, err)
-		}
-	}
-
-	if stat.Mode()&os.ModeSymlink != os.ModeSymlink {
-		return "", fmt.Errorf("volumeID link file %q found, but was not a symlink", volumeLinPath)
-	}
-	// Find the target, resolving to an absolute path
-	// For example, /dev/disk/by-id/virtio-wz9cu3ctp6aj1iagco4h -> ../../vdc
-	resolved, err := filepath.EvalSymlinks(volumeLinPath)
-	if err != nil {
-		return "", fmt.Errorf("error reading target of symlink %q: %v", volumeLinPath, err)
-	}
-	if !strings.HasPrefix(resolved, "/dev") {
-		return "", fmt.Errorf("resolved symlink for %q was unexpected: %q", volumeLinPath, resolved)
-	}
-	return resolved, nil
-}
 func listDirectory(rootPath string) ([]string, error) {
 	var fileLists []string
 	files, err := os.ReadDir(rootPath)

--- a/pkg/metric/utils.go
+++ b/pkg/metric/utils.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"math"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -263,10 +262,6 @@ func listDirectory(rootPath string) ([]string, error) {
 		fileLists = append(fileLists, f.Name())
 	}
 	return fileLists, nil
-}
-
-func almostEqualFloat64(a, b float64) bool {
-	return math.Abs(a-b) <= float64EqualityThreshold
 }
 
 func parseLantencyThreshold(s string, defaults float64) (float64, error) {

--- a/pkg/metric/utils.go
+++ b/pkg/metric/utils.go
@@ -47,18 +47,18 @@ func readFirstLines(path string) ([]string, error) {
 	return lineStrArray, scanner.Err()
 }
 
-func getPvcByPvNameByDisk(clientSet *kubernetes.Clientset, pvName string) (string, string, error) {
+func getDiskPvcByPvName(clientSet *kubernetes.Clientset, pvName string) (*apicorev1.ObjectReference, error) {
 	pv, err := clientSet.CoreV1().PersistentVolumes().Get(context.Background(), pvName, apismetav1.GetOptions{})
 	if err != nil {
-		return "", "", err
+		return nil, err
 	}
 	if pv.Status.Phase == apicorev1.VolumeBound {
-		return pv.Spec.ClaimRef.Namespace, pv.Spec.ClaimRef.Name, nil
+		return pv.Spec.ClaimRef, nil
 	}
-	return "", "", errors.New("pvName:" + pv.Name + " status is not bound.")
+	return nil, errors.New("pvName:" + pv.Name + " status is not bound.")
 }
 
-func getPvcByPvName(clientSet *kubernetes.Clientset, cnfsClient dynamic.Interface, pvName string) (string, string, string, error) {
+func getNasPvcByPvName(clientSet *kubernetes.Clientset, cnfsClient dynamic.Interface, pvName string) (string, string, string, error) {
 	pv, err := clientSet.CoreV1().PersistentVolumes().Get(context.Background(), pvName, apismetav1.GetOptions{})
 	if err != nil {
 		return "", "", "", err

--- a/vendor/github.com/prometheus/procfs/blockdevice/stats.go
+++ b/vendor/github.com/prometheus/procfs/blockdevice/stats.go
@@ -1,0 +1,476 @@
+// Copyright 2018 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package blockdevice
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/prometheus/procfs/internal/fs"
+	"github.com/prometheus/procfs/internal/util"
+)
+
+// Info contains identifying information for a block device such as a disk drive.
+type Info struct {
+	MajorNumber uint32
+	MinorNumber uint32
+	DeviceName  string
+}
+
+// IOStats models the iostats data described in the kernel documentation.
+// - https://www.kernel.org/doc/Documentation/iostats.txt,
+// - https://www.kernel.org/doc/Documentation/block/stat.txt
+// - https://www.kernel.org/doc/Documentation/ABI/testing/procfs-diskstats
+type IOStats struct {
+	// ReadIOs is the number of reads completed successfully.
+	ReadIOs uint64
+	// ReadMerges is the number of reads merged.  Reads and writes
+	// which are adjacent to each other may be merged for efficiency.
+	ReadMerges uint64
+	// ReadSectors is the total number of sectors read successfully.
+	ReadSectors uint64
+	// ReadTicks is the total number of milliseconds spent by all reads.
+	ReadTicks uint64
+	// WriteIOs is the total number of writes completed successfully.
+	WriteIOs uint64
+	// WriteMerges is the number of reads merged.
+	WriteMerges uint64
+	// WriteSectors is the total number of sectors written successfully.
+	WriteSectors uint64
+	// WriteTicks is the total number of milliseconds spent by all writes.
+	WriteTicks uint64
+	// IOsInProgress is number of I/Os currently in progress.
+	IOsInProgress uint64
+	// IOsTotalTicks is the number of milliseconds spent doing I/Os.
+	// This field increases so long as IosInProgress is nonzero.
+	IOsTotalTicks uint64
+	// WeightedIOTicks is the weighted number of milliseconds spent doing I/Os.
+	// This can also be used to estimate average queue wait time for requests.
+	WeightedIOTicks uint64
+	// DiscardIOs is the total number of discards completed successfully.
+	DiscardIOs uint64
+	// DiscardMerges is the number of discards merged.
+	DiscardMerges uint64
+	// DiscardSectors is the total number of sectors discarded successfully.
+	DiscardSectors uint64
+	// DiscardTicks is the total number of milliseconds spent by all discards.
+	DiscardTicks uint64
+	// FlushRequestsCompleted is the total number of flush request completed successfully.
+	FlushRequestsCompleted uint64
+	// TimeSpentFlushing is the total number of milliseconds spent flushing.
+	TimeSpentFlushing uint64
+}
+
+// Diskstats combines the device Info and IOStats.
+type Diskstats struct {
+	Info
+	IOStats
+	// IoStatsCount contains the number of io stats read. For kernel versions 5.5+,
+	// there should be 20 fields read. For kernel versions 4.18+,
+	// there should be 18 fields read. For earlier kernel versions this
+	// will be 14 because the discard values are not available.
+	IoStatsCount int
+}
+
+// BlockQueueStats models the queue files that are located in the sysfs tree for each block device
+// and described in the kernel documentation:
+// https://www.kernel.org/doc/Documentation/block/queue-sysfs.txt
+// https://www.kernel.org/doc/html/latest/block/queue-sysfs.html
+type BlockQueueStats struct {
+	// AddRandom is the status of a disk entropy (1 is on, 0 is off).
+	AddRandom uint64
+	// Dax indicates whether the device supports Direct Access (DAX) (1 is on, 0 is off).
+	DAX uint64
+	// DiscardGranularity is the size of internal allocation of the device in bytes, 0 means device
+	// does not support the discard functionality.
+	DiscardGranularity uint64
+	// DiscardMaxHWBytes is the hardware maximum number of bytes that can be discarded in a single operation,
+	// 0 means device does not support the discard functionality.
+	DiscardMaxHWBytes uint64
+	// DiscardMaxBytes is the software maximum number of bytes that can be discarded in a single operation.
+	DiscardMaxBytes uint64
+	// HWSectorSize is the sector size of the device, in bytes.
+	HWSectorSize uint64
+	// IOPoll indicates if polling is enabled (1 is on, 0 is off).
+	IOPoll uint64
+	// IOPollDelay indicates how polling will be performed, -1 for classic polling, 0 for hybrid polling,
+	// with greater than 0 the kernel will put process issuing IO to sleep for this amount of time in
+	// microseconds before entering classic polling.
+	IOPollDelay int64
+	// IOTimeout is the request timeout in milliseconds.
+	IOTimeout uint64
+	// IOStats indicates if iostats accounting is used for the disk (1 is on, 0 is off).
+	IOStats uint64
+	// LogicalBlockSize is the logical block size of the device, in bytes.
+	LogicalBlockSize uint64
+	// MaxHWSectorsKB is the maximum number of kilobytes supported in a single data transfer.
+	MaxHWSectorsKB uint64
+	// MaxIntegritySegments is the max limit of integrity segments as set by block layer which a hardware controller
+	// can handle.
+	MaxIntegritySegments uint64
+	// MaxSectorsKB is the maximum number of kilobytes that the block layer will allow for a filesystem request.
+	MaxSectorsKB uint64
+	// MaxSegments is the number of segments on the device.
+	MaxSegments uint64
+	// MaxSegmentsSize is the maximum segment size of the device.
+	MaxSegmentSize uint64
+	// MinimumIOSize is the smallest preferred IO size reported by the device.
+	MinimumIOSize uint64
+	// NoMerges shows the lookup logic involved with IO merging requests in the block layer. 0 all merges are
+	// enabled, 1 only simple one hit merges are tried, 2 no merge algorithms will be tried.
+	NoMerges uint64
+	// NRRequests is the number of how many requests may be allocated in the block layer for read or write requests.
+	NRRequests uint64
+	// OptimalIOSize is the optimal IO size reported by the device.
+	OptimalIOSize uint64
+	// PhysicalBlockSize is the physical block size of device, in bytes.
+	PhysicalBlockSize uint64
+	// ReadAHeadKB is the maximum number of kilobytes to read-ahead for filesystems on this block device.
+	ReadAHeadKB uint64
+	// Rotational indicates if the device is of rotational type or non-rotational type.
+	Rotational uint64
+	// RQAffinity indicates affinity policy of device, if 1 the block layer will migrate request completions to the
+	// cpu “group” that originally submitted the request, if 2 forces the completion to run on the requesting cpu.
+	RQAffinity uint64
+	// SchedulerList contains list of available schedulers for this block device.
+	SchedulerList []string
+	// SchedulerCurrent is the current scheduler for this block device.
+	SchedulerCurrent string
+	// WriteCache shows the type of cache for block device, "write back" or "write through".
+	WriteCache string
+	// WriteSameMaxBytes is the number of bytes the device can write in a single write-same command.
+	// A value of ‘0’ means write-same is not supported by this device.
+	WriteSameMaxBytes uint64
+	// WBTLatUSec is the target minimum read latency, 0 means feature is disables.
+	WBTLatUSec int64
+	// ThrottleSampleTime is the time window that blk-throttle samples data, in millisecond. Optional
+	// exists only if CONFIG_BLK_DEV_THROTTLING_LOW is enabled.
+	ThrottleSampleTime *uint64
+	// Zoned indicates if the device is a zoned block device and the zone model of the device if it is indeed zoned.
+	// Possible values are: none, host-aware, host-managed for zoned block devices.
+	Zoned string
+	// NRZones indicates the total number of zones of the device, always zero for regular block devices.
+	NRZones uint64
+	// ChunksSectors for RAID is the size in 512B sectors of the RAID volume stripe segment,
+	// for zoned host device is the size in 512B sectors.
+	ChunkSectors uint64
+	// FUA indicates whether the device supports Force Unit Access for write requests.
+	FUA uint64
+	// MaxDiscardSegments is the maximum number of DMA entries in a discard request.
+	MaxDiscardSegments uint64
+	// WriteZeroesMaxBytes the maximum number of bytes that can be zeroed at once.
+	// The value 0 means that REQ_OP_WRITE_ZEROES is not supported.
+	WriteZeroesMaxBytes uint64
+}
+
+// DeviceMapperInfo models the devicemapper files that are located in the sysfs tree for each block device
+// and described in the kernel documentation:
+// https://www.kernel.org/doc/Documentation/ABI/testing/sysfs-block-dm
+type DeviceMapperInfo struct {
+	// Name is the string containing mapped device name.
+	Name string
+	// RqBasedSeqIOMergeDeadline determines how long (in microseconds) a request that is a reasonable merge
+	// candidate can be queued on the request queue.
+	RqBasedSeqIOMergeDeadline uint64
+	// Suspended indicates if the device is suspended (1 is on, 0 is off).
+	Suspended uint64
+	// UseBlkMQ indicates if the device is using the request-based blk-mq I/O path mode (1 is on, 0 is off).
+	UseBlkMQ uint64
+	// UUID is the DM-UUID string or empty string if DM-UUID is not set.
+	UUID string
+}
+
+// UnderlyingDevices models the list of devices that this device is built from.
+type UnderlyingDeviceInfo struct {
+	// DeviceNames is the list of devices names
+	DeviceNames []string
+}
+
+const (
+	procDiskstatsPath   = "diskstats"
+	procDiskstatsFormat = "%d %d %s %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d"
+	sysBlockPath        = "block"
+	sysBlockStatFormat  = "%d %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d"
+	sysBlockQueue       = "queue"
+	sysBlockDM          = "dm"
+	sysUnderlyingDev    = "slaves"
+)
+
+// FS represents the pseudo-filesystems proc and sys, which provides an
+// interface to kernel data structures.
+type FS struct {
+	proc *fs.FS
+	sys  *fs.FS
+}
+
+// NewDefaultFS returns a new blockdevice fs using the default mountPoints for proc and sys.
+// It will error if either of these mount points can't be read.
+func NewDefaultFS() (FS, error) {
+	return NewFS(fs.DefaultProcMountPoint, fs.DefaultSysMountPoint)
+}
+
+// NewFS returns a new blockdevice fs using the given mountPoints for proc and sys.
+// It will error if either of these mount points can't be read.
+func NewFS(procMountPoint string, sysMountPoint string) (FS, error) {
+	if strings.TrimSpace(procMountPoint) == "" {
+		procMountPoint = fs.DefaultProcMountPoint
+	}
+	procfs, err := fs.NewFS(procMountPoint)
+	if err != nil {
+		return FS{}, err
+	}
+	if strings.TrimSpace(sysMountPoint) == "" {
+		sysMountPoint = fs.DefaultSysMountPoint
+	}
+	sysfs, err := fs.NewFS(sysMountPoint)
+	if err != nil {
+		return FS{}, err
+	}
+	return FS{&procfs, &sysfs}, nil
+}
+
+// ProcDiskstats reads the diskstats file and returns
+// an array of Diskstats (one per line/device).
+func (fs FS) ProcDiskstats() ([]Diskstats, error) {
+	file, err := os.Open(fs.proc.Path(procDiskstatsPath))
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+	return parseProcDiskstats(file)
+}
+
+func parseProcDiskstats(r io.Reader) ([]Diskstats, error) {
+	var (
+		diskstats []Diskstats
+		scanner   = bufio.NewScanner(r)
+		err       error
+	)
+	for scanner.Scan() {
+		d := &Diskstats{}
+		d.IoStatsCount, err = fmt.Sscanf(scanner.Text(), procDiskstatsFormat,
+			&d.MajorNumber,
+			&d.MinorNumber,
+			&d.DeviceName,
+			&d.ReadIOs,
+			&d.ReadMerges,
+			&d.ReadSectors,
+			&d.ReadTicks,
+			&d.WriteIOs,
+			&d.WriteMerges,
+			&d.WriteSectors,
+			&d.WriteTicks,
+			&d.IOsInProgress,
+			&d.IOsTotalTicks,
+			&d.WeightedIOTicks,
+			&d.DiscardIOs,
+			&d.DiscardMerges,
+			&d.DiscardSectors,
+			&d.DiscardTicks,
+			&d.FlushRequestsCompleted,
+			&d.TimeSpentFlushing,
+		)
+		// The io.EOF error can be safely ignored because it just means we read fewer than
+		// the full 20 fields.
+		if err != nil && !errors.Is(err, io.EOF) {
+			return diskstats, err
+		}
+		if d.IoStatsCount >= 14 {
+			diskstats = append(diskstats, *d)
+		}
+	}
+	return diskstats, scanner.Err()
+}
+
+// SysBlockDevices lists the device names from /sys/block/<dev>.
+func (fs FS) SysBlockDevices() ([]string, error) {
+	deviceDirs, err := os.ReadDir(fs.sys.Path(sysBlockPath))
+	if err != nil {
+		return nil, err
+	}
+	devices := []string{}
+	for _, deviceDir := range deviceDirs {
+		devices = append(devices, deviceDir.Name())
+	}
+	return devices, nil
+}
+
+// SysBlockDeviceStat returns stats for the block device read from /sys/block/<device>/stat.
+// The number of stats read will be 15 if the discard stats are available (kernel 4.18+)
+// and 11 if they are not available.
+func (fs FS) SysBlockDeviceStat(device string) (IOStats, int, error) {
+	bytes, err := os.ReadFile(fs.sys.Path(sysBlockPath, device, "stat"))
+	if err != nil {
+		return IOStats{}, 0, err
+	}
+	return parseSysBlockDeviceStat(bytes)
+}
+
+func parseSysBlockDeviceStat(data []byte) (IOStats, int, error) {
+	stat := IOStats{}
+	count, err := fmt.Sscanf(strings.TrimSpace(string(data)), sysBlockStatFormat,
+		&stat.ReadIOs,
+		&stat.ReadMerges,
+		&stat.ReadSectors,
+		&stat.ReadTicks,
+		&stat.WriteIOs,
+		&stat.WriteMerges,
+		&stat.WriteSectors,
+		&stat.WriteTicks,
+		&stat.IOsInProgress,
+		&stat.IOsTotalTicks,
+		&stat.WeightedIOTicks,
+		&stat.DiscardIOs,
+		&stat.DiscardMerges,
+		&stat.DiscardSectors,
+		&stat.DiscardTicks,
+		&stat.FlushRequestsCompleted,
+		&stat.TimeSpentFlushing,
+	)
+	// An io.EOF error is ignored because it just means we read fewer than the full 15 fields.
+	if errors.Is(err, io.EOF) {
+		return stat, count, nil
+	}
+	return stat, count, err
+}
+
+// SysBlockDeviceQueueStats returns stats for /sys/block/xxx/queue where xxx is a device name.
+func (fs FS) SysBlockDeviceQueueStats(device string) (BlockQueueStats, error) {
+	stat := BlockQueueStats{}
+	// Files with uint64 fields
+	for file, p := range map[string]*uint64{
+		"add_random":             &stat.AddRandom,
+		"dax":                    &stat.DAX,
+		"discard_granularity":    &stat.DiscardGranularity,
+		"discard_max_hw_bytes":   &stat.DiscardMaxHWBytes,
+		"discard_max_bytes":      &stat.DiscardMaxBytes,
+		"hw_sector_size":         &stat.HWSectorSize,
+		"io_poll":                &stat.IOPoll,
+		"io_timeout":             &stat.IOTimeout,
+		"iostats":                &stat.IOStats,
+		"logical_block_size":     &stat.LogicalBlockSize,
+		"max_hw_sectors_kb":      &stat.MaxHWSectorsKB,
+		"max_integrity_segments": &stat.MaxIntegritySegments,
+		"max_sectors_kb":         &stat.MaxSectorsKB,
+		"max_segments":           &stat.MaxSegments,
+		"max_segment_size":       &stat.MaxSegmentSize,
+		"minimum_io_size":        &stat.MinimumIOSize,
+		"nomerges":               &stat.NoMerges,
+		"nr_requests":            &stat.NRRequests,
+		"optimal_io_size":        &stat.OptimalIOSize,
+		"physical_block_size":    &stat.PhysicalBlockSize,
+		"read_ahead_kb":          &stat.ReadAHeadKB,
+		"rotational":             &stat.Rotational,
+		"rq_affinity":            &stat.RQAffinity,
+		"write_same_max_bytes":   &stat.WriteSameMaxBytes,
+		"nr_zones":               &stat.NRZones,
+		"chunk_sectors":          &stat.ChunkSectors,
+		"fua":                    &stat.FUA,
+		"max_discard_segments":   &stat.MaxDiscardSegments,
+		"write_zeroes_max_bytes": &stat.WriteZeroesMaxBytes,
+	} {
+		val, err := util.ReadUintFromFile(fs.sys.Path(sysBlockPath, device, sysBlockQueue, file))
+		if err != nil {
+			return BlockQueueStats{}, err
+		}
+		*p = val
+	}
+	// Files with int64 fields
+	for file, p := range map[string]*int64{
+		"io_poll_delay": &stat.IOPollDelay,
+		"wbt_lat_usec":  &stat.WBTLatUSec,
+	} {
+		val, err := util.ReadIntFromFile(fs.sys.Path(sysBlockPath, device, sysBlockQueue, file))
+		if err != nil {
+			return BlockQueueStats{}, err
+		}
+		*p = val
+	}
+	// Files with string fields
+	for file, p := range map[string]*string{
+		"write_cache": &stat.WriteCache,
+		"zoned":       &stat.Zoned,
+	} {
+		val, err := util.SysReadFile(fs.sys.Path(sysBlockPath, device, sysBlockQueue, file))
+		if err != nil {
+			return BlockQueueStats{}, err
+		}
+		*p = val
+	}
+	scheduler, err := util.SysReadFile(fs.sys.Path(sysBlockPath, device, sysBlockQueue, "scheduler"))
+	if err != nil {
+		return BlockQueueStats{}, err
+	}
+	var schedulers []string
+	xs := strings.Split(scheduler, " ")
+	for _, s := range xs {
+		if strings.HasPrefix(s, "[") && strings.HasSuffix(s, "]") {
+			s = s[1 : len(s)-1]
+			stat.SchedulerCurrent = s
+		}
+		schedulers = append(schedulers, s)
+	}
+	stat.SchedulerList = schedulers
+	// optional
+	throttleSampleTime, err := util.ReadUintFromFile(fs.sys.Path(sysBlockPath, device, sysBlockQueue, "throttle_sample_time"))
+	if err == nil {
+		stat.ThrottleSampleTime = &throttleSampleTime
+	}
+	return stat, nil
+}
+
+func (fs FS) SysBlockDeviceMapperInfo(device string) (DeviceMapperInfo, error) {
+	info := DeviceMapperInfo{}
+	// Files with uint64 fields
+	for file, p := range map[string]*uint64{
+		"rq_based_seq_io_merge_deadline": &info.RqBasedSeqIOMergeDeadline,
+		"suspended":                      &info.Suspended,
+		"use_blk_mq":                     &info.UseBlkMQ,
+	} {
+		val, err := util.ReadUintFromFile(fs.sys.Path(sysBlockPath, device, sysBlockDM, file))
+		if err != nil {
+			return DeviceMapperInfo{}, err
+		}
+		*p = val
+	}
+	// Files with string fields
+	for file, p := range map[string]*string{
+		"name": &info.Name,
+		"uuid": &info.UUID,
+	} {
+		val, err := util.SysReadFile(fs.sys.Path(sysBlockPath, device, sysBlockDM, file))
+		if err != nil {
+			return DeviceMapperInfo{}, err
+		}
+		*p = val
+	}
+	return info, nil
+}
+
+func (fs FS) SysBlockDeviceUnderlyingDevices(device string) (UnderlyingDeviceInfo, error) {
+	underlyingDir, err := os.Open(fs.sys.Path(sysBlockPath, device, sysUnderlyingDev))
+	if err != nil {
+		return UnderlyingDeviceInfo{}, err
+	}
+	underlying, err := underlyingDir.Readdirnames(0)
+	if err != nil {
+		return UnderlyingDeviceInfo{}, err
+	}
+	return UnderlyingDeviceInfo{DeviceNames: underlying}, nil
+
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -223,6 +223,7 @@ github.com/prometheus/common/version
 # github.com/prometheus/procfs v0.12.0
 ## explicit; go 1.19
 github.com/prometheus/procfs
+github.com/prometheus/procfs/blockdevice
 github.com/prometheus/procfs/internal/fs
 github.com/prometheus/procfs/internal/util
 # github.com/sirupsen/logrus v1.9.0


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

##### metric/disk: refactor and add more reliable I/O hang alert

This add back I/O hang alert removed by commit 656877777b5dd98a8d8e3c9594cdc1e7b0306d75.

The previous implementation is prone to false positive if an IO is started just before we collect stats.
In this version, we ensure there is no progress for at least 30s before alert.

This patch also switch to prometheus package for parsing /proc/diskstats, and avoids hard codes magic indices everywhere.

Fix the metrics `{read,write}_time_milliseconds_total` to be really milliseconds (they are in seconds before). Also fix the metric help text.

Fix that metrics `{capacity_bytes,inodes}_{available,total,used}` should be gauge instead of counter.

##### metric/disk: use pvc ref from pv in event

should reduce the number of args, and also pass along PVC UID

##### metric/disk: remove unnessesary find disk logic

just get the device number from mountpoint

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

The first 4 commits are already in #1044, please start reviewing from the 5th commit.

/hold
merge this after #1044

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Disk IOHang event is added back.
{read,write}_time_milliseconds_total metrics changed to use millisecond as unit.
{capacity_bytes,inodes}_{available,total,used}` metrics changed to gauge
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
