### PR TITLE
helm: nas driver no longer needs /mnt

### DIFF
--- a/deploy/chart/templates/controller.yaml
+++ b/deploy/chart/templates/controller.yaml
@@ -336,9 +336,6 @@ spec:
               name: addon-token
               readOnly: true
 {{- end }}
-            - mountPath: /mnt
-              mountPropagation: Bidirectional
-              name: host-mnt
             - mountPath: /host/etc
               name: etc
           resources:
@@ -427,10 +424,6 @@ spec:
         - name: etc
           hostPath:
             path: /etc
-            type: ""
-        - name: host-mnt
-          hostPath:
-            path: /mnt
             type: ""
 {{- if .Values.deploy.ack }}
         - name: addon-token

--- a/deploy/chart/templates/plugin.yaml
+++ b/deploy/chart/templates/plugin.yaml
@@ -186,9 +186,6 @@ spec:
               name: cgroupv1-blkio
             - mountPath: /etc/csi-plugin/config
               name: csi-plugin-cm
-            - name: host-mnt
-              mountPath: /mnt
-              mountPropagation: "Bidirectional"
 {{- if $nodePool.csi.local.enabled }}
         - name: local-csi-plugin
           securityContext:
@@ -264,7 +261,7 @@ spec:
               readOnly: true
             - name: host-mnt
               mountPath: /mnt
-              mountPropagation: "Bidirectional"
+              mountPropagation: HostToContainer
 {{- end }}
       volumes:
 {{- if $nodePool.csi.oss.enabled }}
@@ -288,6 +285,10 @@ spec:
           secret:
             defaultMode: 420
             secretName: csi-local-plugin-cert
+        - name: host-mnt
+          hostPath:
+            path: /mnt
+            type: DirectoryOrCreate
 {{- end }}
         - name: registration-dir
           hostPath:
@@ -325,10 +326,6 @@ spec:
         - name: ossconnectordir
           hostPath:
             path: /usr/
-        - name: host-mnt
-          hostPath:
-            path: /mnt
-            type: DirectoryOrCreate
         - name: csi-plugin-cm
           configMap:
             name: csi-plugin


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

remove hostPath /mnt from controller. It is no longer needed since 33875a5bf3 (refactor nas plugin and support accesspoint).

local driver still needs this for quota path.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

/cc @tydra-wang 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
