### PR TITLE
remove mounter.EnsureFolder()

### DIFF
--- a/pkg/disk/nodeserver.go
+++ b/pkg/disk/nodeserver.go
@@ -280,7 +280,7 @@ func (ns *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 			return nil, status.Error(codes.Internal, err.Error())
 		}
 	} else {
-		if err := ns.mounter.EnsureFolder(targetPath); err != nil {
+		if err := os.MkdirAll(targetPath, 0755); err != nil {
 			klog.Errorf("NodePublishVolume: create volume %s path %s error: %v", req.VolumeId, targetPath, err)
 			return nil, status.Error(codes.Internal, err.Error())
 		}
@@ -630,7 +630,7 @@ func (ns *nodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVol
 		fsType = mnt.FsType
 	}
 	mountOptions := collectMountOptions(fsType, options)
-	if err := ns.mounter.EnsureFolder(targetPath); err != nil {
+	if err := os.MkdirAll(targetPath, 0755); err != nil {
 		return nil, status.Error(defaultErrCode, err.Error())
 	}
 
@@ -1009,7 +1009,7 @@ func (ns *nodeServer) mountDeviceToGlobal(capability *csi.VolumeCapability, volu
 		fsType = mnt.FsType
 	}
 	mountOptions := collectMountOptions(fsType, options)
-	if err := ns.mounter.EnsureFolder(sourcePath); err != nil {
+	if err := os.MkdirAll(sourcePath, 0755); err != nil {
 		return status.Error(codes.Internal, err.Error())
 	}
 
@@ -1460,7 +1460,7 @@ func (ns *nodeServer) ensurePathExistsAndCheckMounted(volumeId, targetPath strin
 			return false, status.Error(codes.Internal, err.Error())
 		}
 	} else {
-		if err := ns.mounter.EnsureFolder(targetPath); err != nil {
+		if err := os.MkdirAll(targetPath, 0755); err != nil {
 			klog.Errorf("NodeStageVolume: create volume %s path %s error: %v", volumeId, targetPath, err)
 			return false, status.Error(codes.Internal, err.Error())
 		}

--- a/pkg/ens/nodeserver.go
+++ b/pkg/ens/nodeserver.go
@@ -147,7 +147,7 @@ func (ns *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 		return &csi.NodePublishVolumeResponse{}, nil
 	}
 
-	if err := ns.mounter.EnsureFolder(targetPath); err != nil {
+	if err := os.MkdirAll(targetPath, 0755); err != nil {
 		klog.Errorf("NodePublishVolume: create volume %s path %s error: %v", req.VolumeId, targetPath, err)
 		return nil, status.Error(codes.Internal, err.Error())
 	}
@@ -312,7 +312,7 @@ func (ns *nodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVol
 			return nil, status.Error(codes.Internal, err.Error())
 		}
 	} else {
-		if err := ns.mounter.EnsureFolder(targetPath); err != nil {
+		if err := os.MkdirAll(targetPath, 0755); err != nil {
 			klog.Errorf("NodeStageVolume: create volume %s path %s error: %v", req.VolumeId, targetPath, err)
 			return nil, status.Error(codes.Internal, err.Error())
 		}
@@ -426,7 +426,7 @@ func (ns *nodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVol
 		fsType = mnt.FsType
 	}
 	mountOptions := collectMountOptions(fsType, options)
-	if err := ns.mounter.EnsureFolder(targetPath); err != nil {
+	if err := os.MkdirAll(targetPath, 0755); err != nil {
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 
@@ -556,7 +556,7 @@ func (ns *nodeServer) mountDeviceToGlobal(capability *csi.VolumeCapability, volu
 		fsType = mnt.FsType
 	}
 	mountOptions := collectMountOptions(fsType, options)
-	if err := ns.mounter.EnsureFolder(sourcePath); err != nil {
+	if err := os.MkdirAll(sourcePath, 0755); err != nil {
 		return status.Error(codes.Internal, err.Error())
 	}
 

--- a/pkg/utils/mounter.go
+++ b/pkg/utils/mounter.go
@@ -48,8 +48,6 @@ type MountPoint struct { // nolint: golint
 
 // Mounter is responsible for formatting and mounting volumes
 type Mounter interface {
-	// If the folder doesn't exist, it will call 'mkdir -p'
-	EnsureFolder(target string) error
 	// If the block doesn't exist, create it
 	EnsureBlock(target string) error
 	// Format formats the source with the given filesystem type
@@ -75,29 +73,6 @@ type mounter struct {
 // NewMounter returns a new mounter instance
 func NewMounter() Mounter {
 	return &mounter{}
-}
-
-func (m *mounter) EnsureFolder(target string) error {
-
-	if fi, err := os.Stat(target); err == nil && fi.IsDir() {
-		return nil
-	}
-	mdkirCmd := "mkdir"
-	_, err := exec.LookPath(mdkirCmd)
-	if err != nil {
-		if err == exec.ErrNotFound {
-			return fmt.Errorf("%q executable not found in $PATH", mdkirCmd)
-		}
-		return err
-	}
-
-	mkdirArgs := []string{"-p", target}
-	//log.Infof("mkdir for folder, the command is %s %v", mdkirCmd, mkdirArgs)
-	_, err = exec.Command(mdkirCmd, mkdirArgs...).CombinedOutput()
-	if err != nil {
-		return fmt.Errorf("mkdir for folder error: %v", err)
-	}
-	return nil
 }
 
 func (m *mounter) EnsureBlock(target string) error {

--- a/pkg/utils/mounter_test.go
+++ b/pkg/utils/mounter_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package utils
 
 import (
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -38,7 +39,7 @@ func TestMount(t *testing.T) {
 	mountErrDir := ".tmp/"
 	mountedDevice := ".mounted/block"
 	testMounter := NewMounter()
-	err := testMounter.EnsureFolder(mountErrDir)
+	err := os.MkdirAll(mountErrDir, 0755)
 	assert.Nil(t, err)
 	err = testMounter.MountBlock(mountedDevice, mountErrDir)
 	assert.NotNil(t, err)


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Replaced with os.MkdirAll(), the behaviour should not change.


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
