### PR TITLE
Fix volume setup for rund 2.0

### DIFF
--- a/pkg/nas/nodeserver.go
+++ b/pkg/nas/nodeserver.go
@@ -354,7 +354,7 @@ func (ns *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 			return nil, status.Errorf(codes.Internal, "(rund2.0) failed to setup vol_data.json: %v", err)
 		}
 		if notMounted {
-			err := ns.mounter.Mount("tmpfs", mountPath, "tmpfs", []string{"size=1m"})
+			err := ns.mounter.Mount("tmpfs", mountPath, "tmpfs", []string{"ro"})
 			if err != nil {
 				return nil, status.Errorf(codes.Internal, "(rund2.0) failed to mount tmpfs: %v", err)
 			}

--- a/pkg/nas/utils.go
+++ b/pkg/nas/utils.go
@@ -269,7 +269,7 @@ func GetFsIDByCpfsServer(server string) string {
 }
 
 // rund-csi 2.0
-func saveVolumeData(opt *Options, mountPath string) {
+func saveVolumeData(opt *Options, mountPath string) error {
 	// save volume data to json file
 	volumeData := map[string]string{}
 	volumeData["csi.alibabacloud.com/version"] = opt.Vers
@@ -286,9 +286,7 @@ func saveVolumeData(opt *Options, mountPath string) {
 	if strings.HasSuffix(mountPath, "/") {
 		fileName = filepath.Join(filepath.Dir(filepath.Dir(mountPath)), utils.VolDataFileName)
 	}
-	if err := utils.AppendJSONData(fileName, volumeData); err != nil {
-		log.Warnf("NodePublishVolume: append nas volume spec to %s with error: %s", fileName, err.Error())
-	}
+	return utils.AppendJSONData(fileName, volumeData)
 }
 
 func cleanupMountpoint(mounter mountutils.Interface, mountPath string) (err error) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

#### What this PR does / why we need it:

As vol_data.json could be recreated by kubelet when mounter.SetUpAt is executed twice, csi should always try to update it when NodePublishVolume.


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
