### PR TITLE
disk: only adapt partition for mount volumes

### DIFF
--- a/pkg/disk/cloud.go
+++ b/pkg/disk/cloud.go
@@ -151,10 +151,6 @@ func (ad *DiskAttachDetach) findDevice(ctx context.Context, diskID, serial strin
 		}
 		// continue and retry finding device
 	}
-	device, err = ad.dev.adaptDevicePartition(device)
-	if err != nil {
-		return "", fmt.Errorf("got device %s by diff, but adapt partition failed: %v", device, err)
-	}
 	return device, nil
 }
 

--- a/pkg/disk/device_manager.go
+++ b/pkg/disk/device_manager.go
@@ -124,6 +124,9 @@ func (m *DeviceManager) adaptDevicePartition(rootDevicePath string) (string, err
 	if !m.EnableDiskPartition {
 		return rootDevicePath, nil
 	}
+	if !m.EnableDiskPartition {
+		return rootDevicePath, nil
+	}
 	devName, err := m.deviceName(rootDevicePath)
 	if err != nil {
 		return "", fmt.Errorf("get device name for %s failed: %w", rootDevicePath, err)
@@ -149,6 +152,13 @@ func (m *DeviceManager) adaptDevicePartition(rootDevicePath string) (string, err
 	return partitionDevicePath, nil
 }
 
+// GetDeviceByVolumeID returns the device path for the given volume ID.
+// If applicable, the device path will point to a partition.
+//
+// Only call this function if the volume is a mount volume (not block volume).
+// If you are not sure, call [DeviceManager.GetRootBlockByVolumeID] then call
+// [DeviceManager.adaptDevicePartition] afterwards.
+//
 // GetDeviceByVolumeID Assume the serial is the volume ID without "d-" prefix.
 //
 // Deprecated: use GetDeviceBySerial and pass in the serial returned by ECS OpenAPI.
@@ -173,10 +183,6 @@ func (m *DeviceManager) WaitDevice(ctx context.Context, serial string) (string, 
 	if err != nil {
 		return "", err
 	}
-	if !m.EnableDiskPartition {
-		return path, nil
-	}
-
 	partition, err := m.adaptDevicePartition(path)
 	if err != nil {
 		return "", fmt.Errorf("serial %s resolved to device %s, but adapt partition failed: %w", serial, path, err)

--- a/pkg/disk/device_manager_test.go
+++ b/pkg/disk/device_manager_test.go
@@ -102,9 +102,10 @@ func testingManager(t *testing.T) *DeviceManager {
 	err = os.MkdirAll(devPath, 0o755)
 	assert.NoError(t, err)
 	return &DeviceManager{
-		DevTmpFS:   &fakeDevTmpFS{DevicePath: devPath},
-		DevicePath: devPath,
-		SysfsPath:  filepath.Join(dir, "sys"),
+		DevTmpFS:            &fakeDevTmpFS{DevicePath: devPath},
+		DevicePath:          devPath,
+		SysfsPath:           filepath.Join(dir, "sys"),
+		EnableDiskPartition: true,
 	}
 }
 

--- a/pkg/disk/utils.go
+++ b/pkg/disk/utils.go
@@ -783,6 +783,8 @@ func checkDeviceAvailable(mountinfoPath, devicePath, volumeID, targetPath string
 }
 
 // GetVolumeDeviceName get device name
+//
+// Only call this function if the volume is a mount volume (not block volume).
 func GetVolumeDeviceName(diskID string) (string, error) {
 	device, err := DefaultDeviceManager.GetDeviceByVolumeID(diskID)
 	if err == nil {


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Make attachDisk returns the root device, then adapt partition in a unified place, and only for mount volumes. Allow block volume should not be affected by partitions.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Block volume is allowed to contain partition table now.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
