### PR TITLE
disk: refactor create disk

### DIFF
--- a/pkg/cloud/ecsinterface.go
+++ b/pkg/cloud/ecsinterface.go
@@ -3,6 +3,7 @@ package cloud
 import "github.com/aliyun/alibaba-cloud-sdk-go/services/ecs"
 
 type ECSInterface interface {
+	CreateDisk(request *ecs.CreateDiskRequest) (response *ecs.CreateDiskResponse, err error)
 	DescribeAvailableResource(request *ecs.DescribeAvailableResourceRequest) (response *ecs.DescribeAvailableResourceResponse, err error)
 	DeleteDisk(request *ecs.DeleteDiskRequest) (response *ecs.DeleteDiskResponse, err error)
 	DescribeRegions(request *ecs.DescribeRegionsRequest) (response *ecs.DescribeRegionsResponse, err error)

--- a/pkg/cloud/ecsmock.go
+++ b/pkg/cloud/ecsmock.go
@@ -34,6 +34,21 @@ func (m *MockECSInterface) EXPECT() *MockECSInterfaceMockRecorder {
 	return m.recorder
 }
 
+// CreateDisk mocks base method.
+func (m *MockECSInterface) CreateDisk(request *ecs.CreateDiskRequest) (*ecs.CreateDiskResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateDisk", request)
+	ret0, _ := ret[0].(*ecs.CreateDiskResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateDisk indicates an expected call of CreateDisk.
+func (mr *MockECSInterfaceMockRecorder) CreateDisk(request interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateDisk", reflect.TypeOf((*MockECSInterface)(nil).CreateDisk), request)
+}
+
 // DeleteDisk mocks base method.
 func (m *MockECSInterface) DeleteDisk(request *ecs.DeleteDiskRequest) (*ecs.DeleteDiskResponse, error) {
 	m.ctrl.T.Helper()

--- a/pkg/disk/category.go
+++ b/pkg/disk/category.go
@@ -35,6 +35,8 @@ type CategoryDesc struct {
 	Size                  SizeRange
 	PerformanceLevel      map[PerformanceLevel]PerformanceLevelDesc
 	InstantAccessSnapshot bool
+	ProvisionedIops       bool
+	Bursting              bool
 }
 
 var AllCategories = map[Category]CategoryDesc{
@@ -58,6 +60,8 @@ var AllCategories = map[Category]CategoryDesc{
 	DiskESSDAuto: {
 		Size:                  SizeRange{Min: 1, Max: 65536},
 		InstantAccessSnapshot: true,
+		ProvisionedIops:       true,
+		Bursting:              true,
 	},
 	DiskESSDEntry: {
 		Size: SizeRange{Min: 10, Max: 65536},

--- a/pkg/disk/category.go
+++ b/pkg/disk/category.go
@@ -1,0 +1,82 @@
+package disk
+
+type Category string
+type PerformanceLevel string
+
+const (
+	DiskCommon     Category = "cloud"
+	DiskEfficiency Category = "cloud_efficiency"
+	DiskSSD        Category = "cloud_ssd"
+	DiskESSD       Category = "cloud_essd"
+	DiskESSDAuto   Category = "cloud_auto"
+	DiskESSDEntry  Category = "cloud_essd_entry"
+
+	DiskPPerf            Category = "cloud_pperf"
+	DiskSPerf            Category = "cloud_sperf"
+	DiskSharedSSD        Category = "san_ssd"
+	DiskSharedEfficiency Category = "san_efficiency"
+
+	PERFORMANCE_LEVEL0 PerformanceLevel = "PL0"
+	PERFORMANCE_LEVEL1 PerformanceLevel = "PL1"
+	PERFORMANCE_LEVEL2 PerformanceLevel = "PL2"
+	PERFORMANCE_LEVEL3 PerformanceLevel = "PL3"
+)
+
+type SizeRange struct {
+	Min int64
+	Max int64
+}
+
+type PerformanceLevelDesc struct {
+	Size SizeRange
+}
+
+type CategoryDesc struct {
+	Size                  SizeRange
+	PerformanceLevel      map[PerformanceLevel]PerformanceLevelDesc
+	InstantAccessSnapshot bool
+}
+
+var AllCategories = map[Category]CategoryDesc{
+	DiskCommon: {},
+	DiskEfficiency: {
+		Size: SizeRange{Min: 20, Max: 65536},
+	},
+	DiskSSD: {
+		Size: SizeRange{Min: 20, Max: 65536},
+	},
+	DiskESSD: {
+		Size: SizeRange{Min: 20, Max: 65536},
+		PerformanceLevel: map[PerformanceLevel]PerformanceLevelDesc{
+			PERFORMANCE_LEVEL0: {Size: SizeRange{Min: 1, Max: 65536}},
+			PERFORMANCE_LEVEL1: {Size: SizeRange{Min: 20, Max: 65536}},
+			PERFORMANCE_LEVEL2: {Size: SizeRange{Min: 461, Max: 65536}},
+			PERFORMANCE_LEVEL3: {Size: SizeRange{Min: 1261, Max: 65536}},
+		},
+		InstantAccessSnapshot: true,
+	},
+	DiskESSDAuto: {
+		Size:                  SizeRange{Min: 1, Max: 65536},
+		InstantAccessSnapshot: true,
+	},
+	DiskESSDEntry: {
+		Size: SizeRange{Min: 10, Max: 65536},
+	},
+
+	// Deprecated shared disk
+	DiskSharedSSD:        {},
+	DiskSharedEfficiency: {},
+
+	// Only available in private cloud
+	DiskPPerf: {},
+	DiskSPerf: {},
+}
+
+func GetSizeRange(category Category, pl PerformanceLevel) SizeRange {
+	desc := AllCategories[category]
+	limit := desc.Size
+	if plDesc, ok := desc.PerformanceLevel[pl]; ok {
+		limit = plDesc.Size
+	}
+	return limit
+}

--- a/pkg/disk/cloud.go
+++ b/pkg/disk/cloud.go
@@ -889,7 +889,7 @@ func createDisk(diskName, snapshotID string, requestGB int, diskVol *diskVolumeA
 		if dType == DiskESSDAuto {
 			newReq := generateNewRequest(createDiskRequest)
 			createDiskRequest.ClientToken = fmt.Sprintf("token:%s/%s/%s/%s/%d/%t", diskName, dType, diskVol.RegionID, diskVol.ZoneID, diskVol.ProvisionedIops, diskVol.BurstingEnabled)
-			if diskVol.ProvisionedIops != -1 {
+			if diskVol.ProvisionedIops > 0 {
 				newReq.ProvisionedIops = requests.NewInteger(diskVol.ProvisionedIops)
 			}
 			newReq.BurstingEnabled = requests.NewBoolean(diskVol.BurstingEnabled)

--- a/pkg/disk/cloud_test.go
+++ b/pkg/disk/cloud_test.go
@@ -182,3 +182,22 @@ func TestListSnapshotsInvalidToken(t *testing.T) {
 	_, _, err := listSnapshots(client, "test-disk", "my-cluster", "invalid-token", 0)
 	assert.Error(t, err)
 }
+
+func TestClientToken(t *testing.T) {
+	// we should keep the token stable across versions
+	assert.Equal(t, "n:disk-dcd6fdde-8c1e-45eb-8ec7-786a8b2e0b61", clientToken("disk-dcd6fdde-8c1e-45eb-8ec7-786a8b2e0b61"))
+	// only ASCII characters are allowed
+	assert.Equal(t, "h:LGH7vCPQbR31I47I1eCW7g", clientToken("disk-磁盘名称-1"))
+
+	// the length should be <= 64
+	assert.Equal(t, "n:01234567890123456789012345678901234567890123456789012345678901",
+		clientToken("01234567890123456789012345678901234567890123456789012345678901"))
+	assert.Equal(t, "h:NDeYXVDChDCom5xYgHLVQA",
+		clientToken("012345678901234567890123456789012345678901234567890123456789012"))
+}
+
+func BenchmarkClientToken(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		clientToken("disk-dcd6fdde-8c1e-45eb-8ec7-786a8b2e0b61")
+	}
+}

--- a/pkg/disk/constants.go
+++ b/pkg/disk/constants.go
@@ -1,9 +1,5 @@
 package disk
 
-import (
-	"fmt"
-)
-
 const (
 
 	// ESSD_PERFORMANCE_LEVEL is storage class
@@ -99,26 +95,6 @@ const (
 
 	// DiskHighAvail tag
 	DiskHighAvail = "available"
-	// DiskCommon common disk type
-	DiskCommon = "cloud"
-	// DiskEfficiency efficiency disk type
-	DiskEfficiency = "cloud_efficiency"
-	// DiskSSD ssd disk type
-	DiskSSD = "cloud_ssd"
-	// DiskESSD essd disk type
-	DiskESSD = "cloud_essd"
-	// DiskESSDAuto  essd autopl disk type
-	DiskESSDAuto = "cloud_auto"
-	// DiskESSDEntry  essd entry disk type
-	DiskESSDEntry = "cloud_essd_entry"
-	// DiskHighPerformance
-	DiskPPerf = "cloud_pperf"
-	// DiskStandPerformance
-	DiskSPerf = "cloud_sperf"
-	// DiskSharedSSD shared sdd disk type
-	DiskSharedSSD = "san_ssd"
-	// DiskSharedEfficiency shared efficiency disk type
-	DiskSharedEfficiency = "san_efficiency"
 	// MBSIZE tag
 	MBSIZE = 1024 * 1024
 	// GBSIZE tag
@@ -164,30 +140,6 @@ const (
 	EXT3_FSTYPE         = "ext3"
 	XFS_FSTYPE          = "xfs"
 
-	DISK_PERFORMANCE_LEVEL0 = "PL0"
-	DISK_PERFORMANCE_LEVEL1 = "PL1"
-	DISK_PERFORMANCE_LEVEL2 = "PL2"
-	DISK_PERFORMANCE_LEVEL3 = "PL3"
-
 	SNAPSHOT_MAX_RETENTION_DAYS = 65536
 	SNAPSHOT_MIN_RETENTION_DAYS = 1
-
-	DISK_CLOUD_EFFICIENT_MIN_CAPACITY    = 20
-	DISK_CLOUD_SSD_MIN_CAPACITY          = 20
-	DISK_CLOUD_ESSD_PL0_MIN_CAPACITY     = 1
-	DISK_CLOUD_ESSD_PL1_MIN_CAPACITY     = 20
-	DISK_CLOUD_ESSD_PL2_MIN_CAPACITY     = 461
-	DISK_CLOUD_ESSD_PL3_MIN_CAPACITY     = 1261
-	DISK_CLOUD_ESSD_AUTO_PL_MIN_CAPACITY = 1
 )
-
-var DiskCapacityMapping = map[string]int{
-	DiskEfficiency: DISK_CLOUD_EFFICIENT_MIN_CAPACITY,
-	DiskSSD:        DISK_CLOUD_SSD_MIN_CAPACITY,
-	fmt.Sprintf("%s.%s", DiskESSD, DISK_PERFORMANCE_LEVEL0): DISK_CLOUD_ESSD_PL0_MIN_CAPACITY,
-	fmt.Sprintf("%s.%s", DiskESSD, DISK_PERFORMANCE_LEVEL1): DISK_CLOUD_ESSD_PL1_MIN_CAPACITY,
-	fmt.Sprintf("%s.%s", DiskESSD, DISK_PERFORMANCE_LEVEL2): DISK_CLOUD_ESSD_PL2_MIN_CAPACITY,
-	fmt.Sprintf("%s.%s", DiskESSD, DISK_PERFORMANCE_LEVEL3): DISK_CLOUD_ESSD_PL3_MIN_CAPACITY,
-	DiskESSDAuto: DISK_CLOUD_ESSD_AUTO_PL_MIN_CAPACITY,
-	DiskESSD:     DISK_CLOUD_ESSD_PL1_MIN_CAPACITY,
-}

--- a/pkg/disk/utils.go
+++ b/pkg/disk/utils.go
@@ -761,7 +761,6 @@ func getDiskVolumeOptions(req *csi.CreateVolumeRequest) (*diskVolumeArgs, error)
 		}
 	}
 
-	diskVolArgs.ProvisionedIops = -1
 	value, ok = volOptions[PROVISIONED_IOPS_KEY]
 	if ok {
 		iValue, err := strconv.Atoi(value)

--- a/pkg/disk/utils_test.go
+++ b/pkg/disk/utils_test.go
@@ -55,12 +55,12 @@ func TestIsFileExisting(t *testing.T) {
 func TestValidateDiskType(t *testing.T) {
 	examples := []struct {
 		opts   map[string]string
-		result []string
+		result []Category
 	}{
-		{result: []string{"cloud_ssd", "cloud_efficiency"}},
+		{result: []Category{"cloud_ssd", "cloud_efficiency"}},
 		{opts: map[string]string{"type": "a,b,c"}, result: nil},
-		{opts: map[string]string{"type": "available"}, result: []string{"cloud_ssd", "cloud_efficiency"}},
-		{opts: map[string]string{"type": "cloud_ssd,cloud_essd"}, result: []string{"cloud_ssd", "cloud_essd"}},
+		{opts: map[string]string{"type": "available"}, result: []Category{"cloud_ssd", "cloud_efficiency"}},
+		{opts: map[string]string{"type": "cloud_ssd,cloud_essd"}, result: []Category{"cloud_ssd", "cloud_essd"}},
 	}
 	for _, example := range examples {
 		actualResult, _ := validateDiskType(example.opts)

--- a/pkg/disk/utils_test.go
+++ b/pkg/disk/utils_test.go
@@ -631,6 +631,9 @@ func TestParseTagsInvalid(t *testing.T) {
 
 func TestGetDiskVolumeOptions(t *testing.T) {
 	req := &csi.CreateVolumeRequest{
+		CapacityRange: &csi.CapacityRange{
+			RequiredBytes: 20*GBSIZE - 100,
+		},
 		Parameters: map[string]string{
 			"zoneId":     "cn-beijing-i",
 			"diskTags/a": "b",
@@ -640,4 +643,5 @@ func TestGetDiskVolumeOptions(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "cn-beijing-i", opts.ZoneID)
 	assert.Equal(t, map[string]string{"a": "b"}, opts.DiskTags)
+	assert.Equal(t, int64(20), opts.RequestGB)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

**disk: aggregate category metadata into one file**

We will not forget something when adding new category.


**disk: refactor create disk**

Use hash of diskName as client token to ensure only one disk is created for one PVC.
If we see IdempotentParameterMismatch, fall back to DescribeDisks to fetch existing disk.

When CreateDisk fails, it records the client token only for some case, but we don't know which.
If we use a new token for retry, we are risking creating duplicated disks.
If we reuse the same token. the retry may fail for IdempotentParameterMismatch.
So fetching the existing disk and checking it ourselves seems to be the only choice.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

Replaces #876

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
The client token generation algorithm changed. There is a very small chance that a duplicated disk will be created for a PVC.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
