### PR TITLE
disk: cleanup old globalmount mounts

### DIFF
--- a/pkg/disk/cleanup.go
+++ b/pkg/disk/cleanup.go
@@ -1,0 +1,89 @@
+package disk
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+
+	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/utils"
+	log "github.com/sirupsen/logrus"
+	"golang.org/x/sys/unix"
+)
+
+func cleanupOneGlobalMount(path string) error {
+	pGlobalMount := filepath.Join(path, "globalmount")
+	if err := unix.Unmount(pGlobalMount, 0); err != nil {
+		if !errors.Is(err, unix.EINVAL) && !errors.Is(err, unix.ENOENT) { // EINVAL: not a mount point
+			return fmt.Errorf("unmount %s failed: %w", pGlobalMount, err)
+		}
+	}
+
+	if err := unix.Rmdir(pGlobalMount); err != nil {
+		if !errors.Is(err, unix.ENOENT) {
+			return fmt.Errorf("remove %s failed: %w", pGlobalMount, err)
+		}
+	}
+
+	pVolData := filepath.Join(path, "vol_data.json")
+	if err := unix.Unlink(pVolData); err != nil {
+		if !errors.Is(err, unix.ENOENT) {
+			return fmt.Errorf("remove %s failed: %w", pVolData, err)
+		}
+	}
+
+	if err := unix.Rmdir(path); err != nil {
+		return fmt.Errorf("remove %s failed: %w", path, err)
+	}
+
+	log.Infof("cleanupOldGlobalMount: %s removed", path)
+	return nil
+}
+
+var cleanupOldGlobalMountTriggered atomic.Bool
+
+func TriggerCleanupOldGlobalMount() {
+	triggered := cleanupOldGlobalMountTriggered.Swap(true)
+	if !triggered {
+		go doCleanupOldGlobalMount()
+	}
+}
+
+func doCleanupOldGlobalMount() {
+	if len(os.Getenv("SKIP_OLD_GLOBALMOUNT_CLEANUP")) > 0 {
+		return
+	}
+	oldGlobalMountPath := filepath.Join(utils.KubeletRootDir, "plugins/kubernetes.io/csi/pv")
+	if _, err := os.Stat(oldGlobalMountPath); err != nil {
+		return
+	}
+
+	dirs, err := os.ReadDir(oldGlobalMountPath)
+	if err != nil {
+		log.Errorf("cleanupOldGlobalMount: read %s failed: %v", oldGlobalMountPath, err)
+		return
+	}
+	hasError := false
+	for _, dir := range dirs {
+		if !dir.IsDir() {
+			hasError = true
+			log.Errorf("cleanupOldGlobalMount: %s is not a directory", dir.Name())
+			continue
+		}
+		err := cleanupOneGlobalMount(filepath.Join(oldGlobalMountPath, dir.Name()))
+		if err != nil {
+			log.Errorf("cleanupOldGlobalMount: %v", err)
+			hasError = true
+		}
+	}
+	if hasError {
+		return
+	}
+
+	err = unix.Rmdir(oldGlobalMountPath)
+	if err != nil {
+		log.Errorf("cleanupOldGlobalMount: remove %s failed: %v", oldGlobalMountPath, err)
+	}
+	log.Infof("cleanupOldGlobalMount: %s removed, finished", oldGlobalMountPath)
+}

--- a/pkg/disk/nodeserver.go
+++ b/pkg/disk/nodeserver.go
@@ -518,6 +518,12 @@ func (ns *nodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVol
 	targetPath := req.StagingTargetPath
 	// targetPath format: /var/lib/kubelet/plugins/kubernetes.io/csi/pv/pv-disk-1e7001e0-c54a-11e9-8f89-00163e0e78a0/globalmount
 
+	if strings.HasPrefix(targetPath, filepath.Join(utils.KubeletRootDir, "/plugins/kubernetes.io/csi", driverName)) {
+		// if we see the new globalmount path, we must have upgraded the kubelet
+		// so we can safely cleanup the old globalmount path
+		TriggerCleanupOldGlobalMount()
+	}
+
 	isBlock := req.GetVolumeCapability().GetBlock() != nil
 	if isBlock {
 		targetPath = filepath.Join(targetPath, req.VolumeId)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug


<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

These old mountpoints can block volumes cleanup.
We do the cleanup at NodeStageVolume, so that the cleanup is performed once the v1.24 kubelet is upgraded and up.
Or if no volume is mounted, the cleanup is performed at first volume mount.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
old volume mount path from v1.22 kubelet is automatically cleaned up
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
