### PR TITLE
Upgrade cluster tag key for new created disk and snapshot

### DIFF
--- a/pkg/common/constants.go
+++ b/pkg/common/constants.go
@@ -11,6 +11,9 @@ const (
 	// PVNameKey contains name of the final PV that will be used for the dynamically
 	// provisioned volume
 	PVNameKey = "csi.storage.k8s.io/pv/name"
+
+	// ClusterIDKey contains the cluster id key of the PV cities in
+	ClusterIDKey = "csi.storage.k8s.io/clusterid"
 )
 
 // constants of keys in volume snapshot parameters

--- a/pkg/disk/cloud.go
+++ b/pkg/disk/cloud.go
@@ -813,7 +813,7 @@ func requestAndCreateSnapshot(ecsClient *ecs.Client, params *createSnapshotParam
 		{Key: SNAPSHOTTAGKEY1, Value: "true"},
 	}
 	if GlobalConfigVar.ClusterID != "" {
-		snapshotTags = append(snapshotTags, ecs.CreateSnapshotTag{Key: DISKTAGKEY3, Value: GlobalConfigVar.ClusterID})
+		snapshotTags = append(snapshotTags, ecs.CreateSnapshotTag{Key: common.ClusterIDKey, Value: GlobalConfigVar.ClusterID})
 	}
 	snapshotTags = append(snapshotTags, params.SnapshotTags...)
 	createSnapshotRequest.Tag = &snapshotTags
@@ -1124,11 +1124,12 @@ func getDefaultDiskTags(diskVol *diskVolumeArgs) []ecs.CreateDiskTag {
 	diskTags := []ecs.CreateDiskTag{}
 	tag1 := ecs.CreateDiskTag{Key: DISKTAGKEY1, Value: DISKTAGVALUE1}
 	tag2 := ecs.CreateDiskTag{Key: DISKTAGKEY2, Value: DISKTAGVALUE2}
-	tag3 := ecs.CreateDiskTag{Key: DISKTAGKEY3, Value: GlobalConfigVar.ClusterID}
+	// Remove tag3, release note is required
+	tag4 := ecs.CreateDiskTag{Key: common.ClusterIDKey, Value: GlobalConfigVar.ClusterID}
 	diskTags = append(diskTags, tag1)
 	diskTags = append(diskTags, tag2)
 	if GlobalConfigVar.ClusterID != "" {
-		diskTags = append(diskTags, tag3)
+		diskTags = append(diskTags, tag4)
 	}
 	// if switch is setting in sc, assign the tag to disk tags
 	if diskVol.DelAutoSnap != "" {
@@ -1220,6 +1221,7 @@ func listSnapshots(ecsClient cloud.ECSInterface, diskID, clusterID, nextToken st
 	if clusterID != "" {
 		describeRequest.Tag = &[]ecs.DescribeSnapshotsTag{
 			{Key: DISKTAGKEY3, Value: clusterID},
+			{Key: common.ClusterIDKey, Value: clusterID},
 		}
 	}
 	describeRequest.NextToken = token

--- a/pkg/disk/utils.go
+++ b/pkg/disk/utils.go
@@ -579,6 +579,7 @@ func parseTags(params map[string]string) (map[string]string, error) {
 	if v := params[common.PVCNamespaceKey]; v != "" {
 		seenTags[common.PVCNamespaceTag] = v
 	}
+	seenTags[common.ClusterIDKey] = GlobalConfigVar.ClusterID
 	return seenTags, nil
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind api-change
/kind cleanup

#### What this PR does / why we need it:
csi-provisioner now supports multiple types CO, rendering the "ack" tag name unsuitable for identifying resources it creates.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
