### PR TITLE
disk: skip read xattr for files other than block device

### DIFF
--- a/pkg/disk/nodeserver.go
+++ b/pkg/disk/nodeserver.go
@@ -34,6 +34,7 @@ import (
 	csicommon "github.com/kubernetes-csi/drivers/pkg/csi-common"
 	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/cloud/metadata"
 	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/utils"
+	utilsio "github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/utils/io"
 	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/utils/rund/directvolume"
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/sys/unix"
@@ -847,7 +848,7 @@ func (ns *nodeServer) NodeGetInfo(ctx context.Context, req *csi.NodeGetInfoReque
 
 	c := updateEcsClient(GlobalConfigVar.EcsClient)
 	if maxVolumesNum == 0 {
-		maxVolumesNum, err = getVolumeCountFromOpenAPI(getNode, c, ns.metadata, DefaultDeviceManager)
+		maxVolumesNum, err = getVolumeCountFromOpenAPI(getNode, c, ns.metadata, utilsio.RealDevTmpFS{})
 	} else {
 		node, err = getNode()
 	}

--- a/pkg/utils/io/device.go
+++ b/pkg/utils/io/device.go
@@ -2,12 +2,20 @@ package io
 
 import (
 	"errors"
+	"os"
+	"path/filepath"
 
 	"golang.org/x/sys/unix"
 )
 
+const DevicePath = "/dev"
+
 type DevTmpFS interface {
 	DevFor(path string) (uint32, uint32, error)
+}
+
+type DiskLister interface {
+	ListDisks() ([]string, error)
 }
 
 type RealDevTmpFS struct {
@@ -25,4 +33,21 @@ func (RealDevTmpFS) DevFor(path string) (uint32, uint32, error) {
 	}
 	rdev := uint64(stat.Rdev)
 	return unix.Major(rdev), unix.Minor(rdev), nil
+}
+
+// List all paths under /dev that looks like a disk.
+func (RealDevTmpFS) ListDisks() ([]string, error) {
+	devices, err := os.ReadDir(DevicePath)
+	if err != nil {
+		return nil, err
+	}
+	var disks []string
+	for _, entry := range devices {
+		t := entry.Type()
+		if t&os.ModeDevice != 0 && t&os.ModeCharDevice == 0 {
+			// only consider block devices
+			disks = append(disks, filepath.Join(DevicePath, entry.Name()))
+		}
+	}
+	return disks, nil
 }


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

should reduce false warnings about unable to read xattr

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

```
time="2024-08-06T20:34:04+08:00" level=warning msg="getVolumeCount: failed to get xattr of core, assuming not managed by us: operation not supported"
time="2024-08-06T20:34:04+08:00" level=warning msg="getVolumeCount: failed to get xattr of fd, assuming not managed by us: operation not supported"
time="2024-08-06T20:34:04+08:00" level=warning msg="getVolumeCount: failed to get xattr of initctl, assuming not managed by us: no such file or directory"
time="2024-08-06T20:34:04+08:00" level=warning msg="getVolumeCount: failed to get xattr of log, assuming not managed by us: no such file or directory"
time="2024-08-06T20:34:04+08:00" level=warning msg="getVolumeCount: failed to get xattr of stderr, assuming not managed by us: operation not supported"
time="2024-08-06T20:34:04+08:00" level=warning msg="getVolumeCount: failed to get xattr of stdout, assuming not managed by us: operation not supported"
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
