### PR TITLE
disk: support for EED

### DIFF
--- a/pkg/common/constants.go
+++ b/pkg/common/constants.go
@@ -1,5 +1,9 @@
 package common
 
+const (
+	ECSInstanceIDTopologyKey = "alibabacloud.com/ecs-instance-id"
+)
+
 // constants of keys in volume parameters
 const (
 	// PVCNameKey contains name of the PVC for which is a volume provisioned.

--- a/pkg/disk/category.go
+++ b/pkg/disk/category.go
@@ -16,6 +16,9 @@ const (
 	DiskSharedSSD        Category = "san_ssd"
 	DiskSharedEfficiency Category = "san_efficiency"
 
+	DiskEEDStandard Category = "elastic_ephemeral_disk_standard"
+	DiskEEDPremium  Category = "elastic_ephemeral_disk_premium"
+
 	PERFORMANCE_LEVEL0 PerformanceLevel = "PL0"
 	PERFORMANCE_LEVEL1 PerformanceLevel = "PL1"
 	PERFORMANCE_LEVEL2 PerformanceLevel = "PL2"
@@ -37,6 +40,8 @@ type CategoryDesc struct {
 	InstantAccessSnapshot bool
 	ProvisionedIops       bool
 	Bursting              bool
+	// Cannot be attached to another instance once it is attached.
+	SingleInstance bool
 }
 
 var AllCategories = map[Category]CategoryDesc{
@@ -65,6 +70,14 @@ var AllCategories = map[Category]CategoryDesc{
 	},
 	DiskESSDEntry: {
 		Size: SizeRange{Min: 10, Max: 65536},
+	},
+	DiskEEDStandard: {
+		Size:           SizeRange{Min: 64, Max: 8192},
+		SingleInstance: true,
+	},
+	DiskEEDPremium: {
+		Size:           SizeRange{Min: 64, Max: 8192},
+		SingleInstance: true,
 	},
 
 	// Deprecated shared disk

--- a/pkg/disk/nodeserver.go
+++ b/pkg/disk/nodeserver.go
@@ -33,6 +33,7 @@ import (
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	csicommon "github.com/kubernetes-csi/drivers/pkg/csi-common"
 	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/cloud/metadata"
+	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/common"
 	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/utils"
 	utilsio "github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/utils/io"
 	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/utils/rund/directvolume"
@@ -885,7 +886,8 @@ func (ns *nodeServer) NodeGetInfo(ctx context.Context, req *csi.NodeGetInfoReque
 		// make sure that the driver works on this particular zone only
 		AccessibleTopology: &csi.Topology{
 			Segments: map[string]string{
-				TopologyZoneKey: metadata.MustGet(ns.metadata, metadata.ZoneID),
+				TopologyZoneKey:                 metadata.MustGet(ns.metadata, metadata.ZoneID),
+				common.ECSInstanceIDTopologyKey: metadata.MustGet(ns.metadata, metadata.InstanceID),
 			},
 		},
 	}, nil

--- a/pkg/disk/utils.go
+++ b/pkg/disk/utils.go
@@ -1109,6 +1109,13 @@ func volumeCreate(attempt createAttempt, diskID string, volSizeBytes int64, volu
 			},
 		})
 	}
+	if attempt.Instance != "" {
+		accessibleTopology = append(accessibleTopology, &csi.Topology{
+			Segments: map[string]string{
+				common.ECSInstanceIDTopologyKey: attempt.Instance,
+			},
+		})
+	}
 	if attempt.Category != "" {
 		// Add PV Label
 		if attempt.Category == DiskESSD && attempt.PerformanceLevel == "" {
@@ -1191,7 +1198,10 @@ func staticVolumeCreate(req *csi.CreateVolumeRequest, snapshotID string) (*csi.V
 		}
 	}
 
-	attempt := createAttempt{Category(disk.Category), PerformanceLevel(disk.PerformanceLevel)}
+	attempt := createAttempt{
+		Category(disk.Category), PerformanceLevel(disk.PerformanceLevel),
+		"", // We have no instanceID for virtual-kubelet. if user really use EED with VK, he should delete the PVC with Pod
+	}
 	return volumeCreate(attempt, diskID, volSizeBytes, volumeContext, disk.ZoneId, src), nil
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

disk: support for EED

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

EED only supports WaitForFirstConsumer volumeBindingMode. It will be bound to a single node on CreateVolume.
EED only requires binding after first attach, but we cannot modify the PV affinity after creation.

If VK creates an EED, we cannot prevent the next pod using it from being scheduled to ECS. So the only valid use-case with EED and VK is ephemeral volume.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Support for Elastic Ephemeral Disk (EED)
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
