### PR TITLE
deploy: cleanup kubelet root dir and add slash to volumeMounts

### DIFF
--- a/deploy/chart/templates/_utils.tpl
+++ b/deploy/chart/templates/_utils.tpl
@@ -51,8 +51,9 @@
 {{- end -}}
 
 {{- define "kubeletDirEnv" -}}
-{{- if ne . "/var/lib/kubelet" -}}
+{{- $d := clean . -}}
+{{- if ne $d "/var/lib/kubelet" -}}
 - name: KUBELET_ROOT_DIR
-  value: {{ . }}
+  value: {{ $d }}
 {{- end -}}
 {{- end -}}

--- a/deploy/chart/templates/plugin.yaml
+++ b/deploy/chart/templates/plugin.yaml
@@ -84,7 +84,7 @@ spec:
           args:
             - "--v=5"
             - "--csi-address=/csi/csi.sock"
-            - {{ printf "--kubelet-registration-path=%s/csi-plugins/%splugin.csi.alibabacloud.com/csi.sock" $nodePool.deploy.kubeletRootDir $key | quote }}
+            - {{ printf "--kubelet-registration-path=%s/csi-plugins/%splugin.csi.alibabacloud.com/csi.sock" (clean $nodePool.deploy.kubeletRootDir) $key | quote }}
           volumeMounts:
             - name: {{$key}}-plugin-dir
               mountPath: /csi
@@ -163,7 +163,8 @@ spec:
               containerPort: 11260
           volumeMounts:
             - name: kubelet-dir
-              mountPath: {{ $nodePool.deploy.kubeletRootDir | quote }}
+              # keep the trailing slash to be compatible with old ACK installations
+              mountPath: {{ print (clean $nodePool.deploy.kubeletRootDir) "/" | quote }}
               mountPropagation: "Bidirectional"
 {{- range $key := tuple "disk" "nas" "oss" }}
   {{- with index $nodePool.csi $key -}}
@@ -264,7 +265,8 @@ spec:
             - name: local-plugin-dir
               mountPath: /csi
             - name: kubelet-dir
-              mountPath: {{ $nodePool.deploy.kubeletRootDir | quote }}
+              # keep the trailing slash to be compatible with old ACK installations
+              mountPath: {{ print (clean $nodePool.deploy.kubeletRootDir) "/" | quote }}
               mountPropagation: "Bidirectional"
             - name: host-dev
               mountPath: /dev
@@ -312,7 +314,7 @@ spec:
 {{- end }}
         - name: registration-dir
           hostPath:
-            path: {{ printf "%s/plugins_registry" $nodePool.deploy.kubeletRootDir | quote }}
+            path: {{ printf "%s/plugins_registry" (clean $nodePool.deploy.kubeletRootDir) | quote }}
             type: DirectoryOrCreate
         - name: container-dir
           hostPath:
@@ -320,13 +322,13 @@ spec:
             type: DirectoryOrCreate
         - name: kubelet-dir
           hostPath:
-            path: {{ $nodePool.deploy.kubeletRootDir | quote }}
+            path: {{ (clean $nodePool.deploy.kubeletRootDir) | quote }}
             type: Directory
 {{- range $key, $val := $nodePool.csi }}
 {{- if $val.enabled }}
         - name: {{ $key }}-plugin-dir
           hostPath:
-            path: {{ printf "%s/csi-plugins/%splugin.csi.alibabacloud.com" $nodePool.deploy.kubeletRootDir $key | quote }}
+            path: {{ printf "%s/csi-plugins/%splugin.csi.alibabacloud.com" (clean $nodePool.deploy.kubeletRootDir) $key | quote }}
             type: DirectoryOrCreate
 {{- end -}}
 {{- end }}


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

ACK has issue merging the new template when upgrading very old installations that has no last-applied-configuration annotations. This will cause duplicated volumeMounts entries, and double the number of bind mount on kubeletRootDir on the host at every csi-plugin restart.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1121 

#### Special notes for your reviewer:

Not relevant to users who only use helm chart.

Net change of the rendered YAML
```diff
--- a/ack/templates/default/csi-plugin.yaml
+++ b/ack/templates/default/csi-plugin.yaml
@@ -327,7 +327,8 @@ spec:
               containerPort: 11260
           volumeMounts:
             - name: kubelet-dir
-              mountPath: "/var/lib/kubelet"
+              # keep the trailing slash to be compatible with old ACK installations
+              mountPath: "/var/lib/kubelet/"
               mountPropagation: "Bidirectional"
             - name: disk-plugin-dir
               mountPath: /csi/diskplugin.csi.alibabacloud.com
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
