### PR TITLE
OSS: set default ossfs default log level to err

### DIFF
--- a/pkg/mounter/fuse_pod_manager.go
+++ b/pkg/mounter/fuse_pod_manager.go
@@ -63,6 +63,14 @@ const (
 	AuthTypeCSS  = "csi-secret-store"
 )
 
+const (
+	DebugLevelFatal = "fatal"
+	DebugLevelError = "error"
+	DebugLevelWarn  = "warn"
+	DebugLevelInfo  = "info"
+	DebugLevelDebug = "debug"
+)
+
 type FusePodContext struct {
 	context.Context
 	Namespace  string
@@ -81,6 +89,7 @@ type FuseContainerConfig struct {
 	Resources   corev1.ResourceRequirements
 	Image       string
 	ImageTag    string
+	Dbglevel    string
 	Annotations map[string]string
 	Labels      map[string]string
 	Extra       map[string]string
@@ -103,6 +112,14 @@ func extractFuseContainerConfig(configmap *corev1.ConfigMap, name string) (confi
 		switch key {
 		case "":
 			invalid = true
+		case "dbglevel":
+			switch value {
+			case DebugLevelFatal, DebugLevelError, DebugLevelWarn, DebugLevelInfo, DebugLevelDebug:
+				config.Dbglevel = value
+			default:
+				invalid = true
+				break
+			}
 		case "image":
 			logrus.Warn("'image' config in configmap no longer supported")
 		case "image-tag":

--- a/pkg/mounter/fuse_pod_manager_test.go
+++ b/pkg/mounter/fuse_pod_manager_test.go
@@ -37,9 +37,9 @@ func Test_extractFuseContainerConfig(t *testing.T) {
 				corev1.ResourceMemory: resource.MustParse("500Mi"),
 			},
 		},
-		Image: "",
+		Image:    "",
+		Dbglevel: "info",
 		Extra: map[string]string{
-			"dbglevel":     "info",
 			"mime-support": "false",
 		},
 		Annotations: map[string]string{

--- a/pkg/mounter/ossfs.go
+++ b/pkg/mounter/ossfs.go
@@ -45,6 +45,16 @@ type fuseOssfs struct {
 	config FuseContainerConfig
 }
 
+var ossfsDbglevels = map[string]string{
+	DebugLevelDebug: "debug",
+	DebugLevelInfo:  "info",
+	DebugLevelWarn:  "warn",
+	DebugLevelError: "err",
+	DebugLevelFatal: "crit",
+}
+
+const defaultDbglevel = DebugLevelError
+
 func NewFuseOssfs(configmap *corev1.ConfigMap, m metadata.MetadataProvider) FuseMounterType {
 	config := extractFuseContainerConfig(configmap, "ossfs")
 	// set default image
@@ -192,16 +202,16 @@ func (f *fuseOssfs) AddDefaultMountOptions(options []string) []string {
 			break
 		}
 	}
-	setDbgLevel := "err"
-	switch dbglevel := f.config.Extra["dbglevel"]; dbglevel {
-	case "":
-	case "debug", "info", "warn", "err", "crit":
-		setDbgLevel = dbglevel
-	default:
-		log.Warnf("invalid ossfs dbglevel: %q", dbglevel)
-	}
 	if !alreadySet {
-		options = append(options, fmt.Sprintf("dbglevel=%s", setDbgLevel))
+		level, ok := ossfsDbglevels[f.config.Dbglevel]
+		if ok {
+			options = append(options, fmt.Sprintf("dbglevel=%s", level))
+		} else {
+			if f.config.Dbglevel != "" {
+				log.Warnf("invalid dbglevel for ossfs: %q, use default dbglevel %s", f.config.Dbglevel, defaultDbglevel)
+			}
+			options = append(options, fmt.Sprintf("dbglevel=%s", ossfsDbglevels[defaultDbglevel]))
+		}
 	}
 
 	if !utils.IsFileExisting(filepath.Join(hostPrefix, OssfsDefMimeTypesFilePath)) && strings.ToLower(f.config.Extra["mime-support"]) == "true" {

--- a/pkg/mounter/ossfs_test.go
+++ b/pkg/mounter/ossfs_test.go
@@ -2,7 +2,7 @@ package mounter
 
 import (
 	"context"
-	"strings"
+	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -110,8 +110,8 @@ func Test_AddDefaultMountOptions(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			f := &fuseOssfs{
 				config: FuseContainerConfig{
+					Dbglevel: tt.dbglevel,
 					Extra: map[string]string{
-						"dbglevel":     tt.dbglevel,
 						"mime-support": tt.mime,
 					},
 				},
@@ -121,11 +121,9 @@ func Test_AddDefaultMountOptions(t *testing.T) {
 				t.Errorf("AddDefaultMountOptions() got = %v, want %v", got, tt.want)
 				return
 			}
-			for i := range got {
-				if !strings.EqualFold(got[i], tt.want[i]) {
-					t.Errorf("AddDefaultMountOptions() got = %v, want %v", got, tt.want)
-					return
-				}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("AddDefaultMountOptions() got = %v, want %v", got, tt.want)
+				return
 			}
 		})
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Ossfs's default dbglevel is crit, which means users will not get any error message during mounting.
As Ossfs is containerized, I suggest setting dbglevel to err by default by CSI. 
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
