### PR TITLE
disk: avoid concurrent operation on the same disk

### DIFF
--- a/pkg/disk/attachdetach_slot.go
+++ b/pkg/disk/attachdetach_slot.go
@@ -64,6 +64,9 @@ type serialAD_DetachSlot struct{ *serialADSlot }
 type serialAD_AttachSlot struct{ *serialADSlot }
 
 func (s serialAD_DetachSlot) Aquire(ctx context.Context) error {
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
 	select {
 	case s.highPriorityChannel <- struct{}{}:
 		return nil
@@ -75,6 +78,9 @@ func (s serialAD_DetachSlot) Aquire(ctx context.Context) error {
 }
 
 func (s serialAD_AttachSlot) Aquire(ctx context.Context) error {
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
 	select {
 	case s.slot <- struct{}{}:
 		return nil
@@ -105,7 +111,7 @@ func (parallelSlot) Attach() slot { return noOpSlot{} }
 
 type noOpSlot struct{}
 
-func (noOpSlot) Aquire(ctx context.Context) error { return nil }
+func (noOpSlot) Aquire(ctx context.Context) error { return ctx.Err() }
 func (noOpSlot) Release()                         {}
 
 type serialOneDirSlot struct {
@@ -126,6 +132,9 @@ type serialSlot struct {
 }
 
 func (s serialSlot) Aquire(ctx context.Context) error {
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
 	select {
 	case s.slot <- struct{}{}:
 		return nil

--- a/pkg/disk/attachdetach_slot_test.go
+++ b/pkg/disk/attachdetach_slot_test.go
@@ -81,6 +81,27 @@ func TestCancel(t *testing.T) {
 	}
 }
 
+func TestCancelNoOccupy(t *testing.T) {
+	testSlot := func(t *testing.T, slots AttachDetachSlots) {
+		s := slots.GetSlotFor("node1")
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		if err := s.Detach().Aquire(ctx); err != context.Canceled {
+			t.Fatalf("Expected context.Canceled, got %v", err)
+		}
+		if err := s.Attach().Aquire(ctx); err != context.Canceled {
+			t.Fatalf("Expected context.Canceled, got %v", err)
+		}
+	}
+	t.Run("serial", func(t *testing.T) {
+		testSlot(t, NewSlots(true, true))
+	})
+	t.Run("parallel", func(t *testing.T) {
+		testSlot(t, NewSlots(false, false))
+	})
+}
+
 func TestSerialDetach(t *testing.T) {
 	slots := NewSlots(true, false)
 	s := slots.GetSlotFor("node1")

--- a/pkg/utils/volume_locks.go
+++ b/pkg/utils/volume_locks.go
@@ -23,13 +23,13 @@ import (
 )
 
 type VolumeLocks struct {
-	locks sets.String
+	locks sets.Set[string]
 	mutex sync.Mutex
 }
 
 func NewVolumeLocks() *VolumeLocks {
 	return &VolumeLocks{
-		locks: sets.NewString(),
+		locks: sets.New[string](),
 	}
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug


<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

If the umount takes extremely long time and the NodeUnstageVolume RPC times out, kubelet may invoke NodeStageVolume when it retries and we may mistake an unmounting disk as a good one. This lock only protects us in one process. But fortunately, when restarting CSI, Kubernetes will wait for the previous process to exit before starting the new one, even if it stucks in uninterruptible syscall (D state). So, we will not have multiple processes on the same node and the lock should be safe enough.

Note that there is still small chance that the previous attach/detach OpenAPI is invoked by the terminated CSI process, but the state returned by DescribeDisks is not updated yet. We should fix this by switch attach/detach to controller.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fix unintended disk detach when the unmounting is extremely slow
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
