### PR TITLE
oss: translate OSS bucket domain name to endpoint automatically

### DIFF
--- a/pkg/oss/nodeserver.go
+++ b/pkg/oss/nodeserver.go
@@ -439,6 +439,7 @@ func parseOptions(req publishRequest, region string) *Options {
 	if region != "" {
 		url, _ = setNetworkType(url, region)
 	}
+	url, _ = translateDomainToEndpoint(url, opts.Bucket)
 	url, _ = setTransmissionProtocol(url)
 	if url != opts.URL {
 		klog.Infof("Changed oss URL from %s to %s", opts.URL, url)

--- a/pkg/oss/utils.go
+++ b/pkg/oss/utils.go
@@ -145,3 +145,29 @@ func setTransmissionProtocol(originURL string) (URL string, modified bool) {
 	}
 	return "https://" + URL, true
 }
+
+// translateDomainToEndpoint will trim the prefix with "bucket." to
+//
+//	translate the bucket domain name like: bucket.oss-cn-beijing.aliyuncs.com
+//	to endpoint like: oss-cn-beijing.aliyuncs.com
+func translateDomainToEndpoint(originURL, bucket string) (URL string, modified bool) {
+	URL = originURL
+	if utils.IsPrivateCloud() {
+		return
+	}
+	var protocol string
+	t := URL
+	switch {
+	case strings.HasPrefix(URL, "http://"):
+		t = strings.TrimPrefix(URL, "http://")
+		protocol = "http://"
+	case strings.HasPrefix(URL, "https://"):
+		t = strings.TrimPrefix(URL, "https://")
+		protocol = "https://"
+	}
+	if strings.HasPrefix(t, bucket+".") {
+		URL = protocol + strings.TrimPrefix(t, bucket+".")
+		modified = true
+	}
+	return
+}

--- a/pkg/oss/utils_test.go
+++ b/pkg/oss/utils_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package oss
 
 import (
+	"os"
 	"reflect"
 	"testing"
 
@@ -275,6 +276,87 @@ func Test_setTransmissionProtocol(t *testing.T) {
 			if url != tt.wantURL || done != tt.wantModified {
 				t.Errorf("setTransmissionProtocol(%v) = %v, %v, want %v %v",
 					tt.originURL, url, done, tt.wantURL, tt.wantModified)
+			}
+		})
+	}
+}
+
+func setPrivateCloud(privateCloud bool) {
+	if privateCloud {
+		os.Setenv("PRIVATE_CLOUD_TAG", "true")
+		return
+	}
+	os.Setenv("PRIVATE_CLOUD_TAG", "false")
+}
+
+func Test_translateDomainToEndpoint(t *testing.T) {
+	testCases := []struct {
+		name      string
+		originURL string
+		bucket    string
+		isPrivate bool
+		expected  string
+		modified  bool
+	}{
+		{
+			name:      "origin-url-is-not-domain-with-protocol",
+			originURL: "http://oss-cn-beijing.aliyuncs.com",
+			bucket:    "my-bucket",
+			isPrivate: false,
+			expected:  "http://oss-cn-beijing.aliyuncs.com",
+			modified:  false,
+		},
+		{
+			name:      "origin-url-is-not-domain-without-protocol",
+			originURL: "oss-cn-beijing.aliyuncs.com",
+			bucket:    "my-bucket",
+			isPrivate: false,
+			expected:  "oss-cn-beijing.aliyuncs.com",
+			modified:  false,
+		},
+		{
+			name:      "origin-url-is-domain-with-protocol",
+			originURL: "https://my-bucket.oss-cn-beijing.aliyuncs.com",
+			bucket:    "my-bucket",
+			isPrivate: false,
+			expected:  "https://oss-cn-beijing.aliyuncs.com",
+			modified:  true,
+		},
+		{
+			name:      "origin-url-is-domain-without-protocol",
+			originURL: "my-bucket.oss-cn-beijing.aliyuncs.com",
+			bucket:    "my-bucket",
+			isPrivate: false,
+			expected:  "oss-cn-beijing.aliyuncs.com",
+			modified:  true,
+		},
+		{
+			name:      "origin-url-is-invalid",
+			originURL: "tcp://my-bucket.oss-accelerate.aliyuncs.com",
+			bucket:    "my-bucket",
+			isPrivate: false,
+			expected:  "tcp://my-bucket.oss-accelerate.aliyuncs.com",
+			modified:  false,
+		},
+		{
+			name:      "private-cloud",
+			originURL: "my-bucket.oss-cn-beijing.aliyuncs.com",
+			bucket:    "my-bucket",
+			isPrivate: true,
+			expected:  "my-bucket.oss-cn-beijing.aliyuncs.com",
+			modified:  false,
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			setPrivateCloud(tt.isPrivate)
+			url, modified := translateDomainToEndpoint(tt.originURL, tt.bucket)
+			if url != tt.expected {
+				t.Errorf("Expected URL to be %s, got %s", tt.expected, url)
+			}
+			if modified != tt.modified {
+				t.Errorf("Expected modified to be %v, got %v", tt.modified, modified)
 			}
 		})
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
translate oss domain name like: `bucket.oss-cn-beijing.aliyuncs.com` to endpoint that ossfs need like `oss-cn-beijing.aliyuncs.com` to avoid 400 error response in ossfs.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
