### PR TITLE
Access ECS OpenAPI using the VPC endpoint on ECS

### DIFF
--- a/deploy/chart/templates/controller.yaml
+++ b/deploy/chart/templates/controller.yaml
@@ -307,6 +307,10 @@ spec:
             - --nodeid=$(KUBE_NODE_NAME)
 {{- end }}
           env:
+{{- if .Values.deploy.ecs }}
+            - name: ALIBABA_CLOUD_NETWORK_TYPE
+              value: vpc
+{{- end }}
             - name: "DEFAULT_REGISTRY"
               value: {{ .Values.images.registry | quote }}
 {{- if .Values.deploy.ack }}

--- a/deploy/chart/templates/plugin.yaml
+++ b/deploy/chart/templates/plugin.yaml
@@ -117,6 +117,10 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: spec.nodeName
+{{- if $nodePool.deploy.ecs }}
+            - name: ALIBABA_CLOUD_NETWORK_TYPE
+              value: vpc
+{{- end }}
 {{- if $nodePool.deploy.regionID }}
             - name: REGION_ID
               value: {{ $nodePool.deploy.regionID | quote }}

--- a/pkg/disk/utils.go
+++ b/pkg/disk/utils.go
@@ -112,22 +112,28 @@ func newEcsClient(regionID string, ac utils.AccessControl) (ecsClient *ecs.Clien
 		return nil
 	}
 
-	if os.Getenv("INTERNAL_MODE") == "true" {
-		ep := os.Getenv("ECS_ENDPOINT")
-		if ep != "" {
-			klog.Infof("Use ECS_ENDPOINT: %s", ep)
-		} else {
-			var err error
-			ep, err = cloud.ECSQueryLocalEndpoint(regionID, ecsClient)
-			if err != nil {
-				klog.Fatalf("Internal mode, but resolve ECS endpoint failed: %v", err)
-			}
-			klog.Infof("Resolved ECS localAPI endpoint: %s", ep)
+	ep := os.Getenv("ECS_ENDPOINT")
+	if ep != "" {
+		klog.Infof("Use ECS_ENDPOINT: %s", ep)
+	} else if os.Getenv("INTERNAL_MODE") == "true" {
+		var err error
+		ep, err = cloud.ECSQueryLocalEndpoint(regionID, ecsClient)
+		if err != nil {
+			klog.Fatalf("Internal mode, but resolve ECS endpoint failed: %v", err)
 		}
-		_ = aliyunep.AddEndpointMapping(regionID, "Ecs", ep)
-	} else {
-		// Set Unitized Endpoint for hangzhou region
-		SetEcsEndPoint(regionID)
+		klog.Infof("Resolved ECS localAPI endpoint: %s", ep)
+	}
+	if ep != "" {
+		err := aliyunep.AddEndpointMapping(regionID, "Ecs", ep)
+		if err != nil {
+			klog.Fatalf("Set ECS endpoint failed: %v", err)
+		}
+	}
+
+	network := os.Getenv("ALIBABA_CLOUD_NETWORK_TYPE")
+	if network != "" {
+		klog.Infof("Use ALIBABA_CLOUD_NETWORK_TYPE: %s", network)
+		ecsClient.SetEndpointRules(nil, "regional", network)
 	}
 
 	header := utilshttp.MustParseHeaderEnv("ECS_HEADERS")
@@ -146,31 +152,6 @@ func updateEcsClient(client *ecs.Client) *ecs.Client {
 		client.Client.GetConfig().UserAgent = KubernetesAlicloudIdentity
 	}
 	return client
-}
-
-// SetEcsEndPoint Set Endpoint for Ecs
-func SetEcsEndPoint(regionID string) {
-	// use unitized region endpoint for blew regions.
-	// total 19 regions
-	isEndpointSet := false
-	unitizedRegions := []string{"cn-hangzhou", "cn-zhangjiakou", "cn-huhehaote", "cn-shenzhen", "ap-southeast-1", "ap-southeast-2",
-		"ap-southeast-3", "ap-southeast-5", "eu-central-1", "us-east-1", "cn-hongkong", "ap-northeast-1", "ap-south-1",
-		"us-west-1", "me-east-1", "cn-north-2-gov-1", "eu-west-1", "cn-chengdu"}
-	for _, tmpRegion := range unitizedRegions {
-		if regionID == tmpRegion {
-			_ = aliyunep.AddEndpointMapping(regionID, "Ecs", "ecs."+regionID+".aliyuncs.com")
-			isEndpointSet = true
-			break
-		}
-	}
-	if !isEndpointSet {
-		_ = aliyunep.AddEndpointMapping(regionID, "Ecs", "ecs-vpc."+regionID+".aliyuncs.com")
-	}
-
-	// use environment endpoint setting first;
-	if ep := os.Getenv("ECS_ENDPOINT"); ep != "" {
-		_ = aliyunep.AddEndpointMapping(regionID, "Ecs", ep)
-	}
 }
 
 // IsFileExisting check file exist in volume driver


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#449 seems to want to enable VPC endpoint for the listed 19 regions, but ended up using public endpoint for them and use VPC endpoint for other regions. Now we are sure the listed 19 (actually 18) regions support VPC endpoint, and we have been using VPC endpoint for other regions for years without problem. So this change should be safe.

For the listed regions:
* ap-south-1: already closed
* cn-north-2-gov-1: manually checked `ecs-vpc.cn-north-2-gov-1.aliyuncs.com` is accessable
* All other regions are listed in the official doc: https://help.aliyun.com/zh/ecs/developer-reference/call-api-operations-over-the-internal-network?spm=a2c4g.11186623.0.0.10ce48d1z8j7YM

Now VPC endpoint is available for all regions, we should use them by default so that we don't rely on Internet access.

We enable VPC endpoint with a new envvar ALIBABA_CLOUD_NETWORK_TYPE, to try to not breaking the users who deploy CSI on non-ECS env.

If ALIBABA_CLOUD_NETWORK_TYPE is set to:
* `vpc`: always use `ecs-vpc.<region-id>.aliyuncs.com`
* `public`: always use `ecs.<region-id>.aliyuncs.com`
* unset: use SDK built-in logic: basically, looking up a hard-coded map and fallback to `ecs.<region-id>.aliyuncs.com`

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

For internal mode, we always use localAPI endpoint, like `ecs-openapi-share.cn-beijing.aliyuncs.com`, queried from `location-readonly.aliyuncs.com`

Some regions also can resolve public endpoint to VPC VIP. But this is not documented, not supported in all regions, and can be affected by the custom DNS config. So we should not rely on this.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
We now access ECS OpenAPI using the VPC endpoint on ECS. Please ensure any custom network policy allows such access.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
