### PR TITLE
disk: add a feature gate to disable expand auto snapshot

### DIFF
--- a/pkg/disk/controllerserver.go
+++ b/pkg/disk/controllerserver.go
@@ -32,6 +32,7 @@ import (
 	"github.com/aliyun/alibaba-cloud-sdk-go/services/ecs"
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/common"
+	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/features"
 	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/utils"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -890,6 +891,9 @@ func updateVolumeExpandAutoSnapshotID(pvc *v1.PersistentVolumeClaim, snapshotID,
 // autoSnapshot is used in volume expanding of ESSD,
 // returns if the volume expanding should be continued
 func (cs *controllerServer) autoSnapshot(ctx context.Context, disk *ecs.Disk) (bool, *csi.Snapshot, error) {
+	if features.FunctionalMutableFeatureGate.Enabled(features.DisableExpandAutoSnapshot) {
+		return true, nil, nil
+	}
 	if !AllCategories[Category(disk.Category)].InstantAccessSnapshot {
 		return true, nil, nil
 	}

--- a/pkg/disk/utils.go
+++ b/pkg/disk/utils.go
@@ -44,6 +44,7 @@ import (
 	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/cloud/metadata"
 	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/common"
 	proto "github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/disk/proto"
+	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/features"
 	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/utils"
 	utilshttp "github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/utils/http"
 	utilsio "github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/utils/io"
@@ -737,10 +738,12 @@ func getDiskVolumeOptions(req *csi.CreateVolumeRequest) (*diskVolumeArgs, error)
 	}
 
 	// volumeExpandAutoSnapshot, default closed
-	if value, ok = volOptions[VOLUME_EXPAND_AUTO_SNAPSHOT_OP_KEY]; ok {
-		value = strings.ToLower(value)
-		if value != "forced" && value != "besteffort" && value != "closed" {
-			return nil, fmt.Errorf("illegal optional parameter volumeExpandAutoSnapshot, only support forced, besteffort and closed, the input is: %s", value)
+	if !features.FunctionalMutableFeatureGate.Enabled(features.DisableExpandAutoSnapshot) {
+		if value, ok = volOptions[VOLUME_EXPAND_AUTO_SNAPSHOT_OP_KEY]; ok {
+			value = strings.ToLower(value)
+			if value != "forced" && value != "besteffort" && value != "closed" {
+				return nil, fmt.Errorf("illegal optional parameter volumeExpandAutoSnapshot, only support forced, besteffort and closed, the input is: %s", value)
+			}
 		}
 	}
 	if value, ok = volOptions[VOLUME_DELETE_AUTO_SNAPSHOT_OP_RETENT_DAYS_KEY]; ok {

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -29,6 +29,12 @@ const (
 	// Only effective when DiskADController is also enabled.
 	DiskParallelDetach featuregate.Feature = "DiskParallelDetach"
 
+	// Make volumeExpandAutoSnapshot parameter no-op.
+	//
+	// This feature is broken by new ECS intant available snapshot. And it is hard to fix it robustly.
+	// It is very rare (if any) that a disk is corrupted by expand.
+	DisableExpandAutoSnapshot featuregate.Feature = "DisableExpandAutoSnapshot"
+
 	UpdatedOssfsVersion featuregate.Feature = "UpdatedOssfsVersion"
 
 	RundCSIProtocol3 featuregate.Feature = "RundCSIProtocol3"
@@ -37,10 +43,12 @@ const (
 var (
 	FunctionalMutableFeatureGate = featuregate.NewFeatureGate()
 	defaultDiskFeatureGate       = map[featuregate.Feature]featuregate.FeatureSpec{
-		DiskADController:   {Default: false, PreRelease: featuregate.Alpha},
-		DiskParallelAttach: {Default: false, PreRelease: featuregate.Alpha},
-		DiskParallelDetach: {Default: false, PreRelease: featuregate.Alpha},
+		DiskADController:          {Default: false, PreRelease: featuregate.Alpha},
+		DiskParallelAttach:        {Default: false, PreRelease: featuregate.Alpha},
+		DiskParallelDetach:        {Default: false, PreRelease: featuregate.Alpha},
+		DisableExpandAutoSnapshot: {Default: false, PreRelease: featuregate.Alpha},
 	}
+
 	defaultOSSFeatureGate = map[featuregate.Feature]featuregate.FeatureSpec{
 		UpdatedOssfsVersion: {Default: true, PreRelease: featuregate.Beta},
 	}


### PR DESCRIPTION
This feature is broken, and we should provide a way to escape. Protentially disable this feature by default in the future.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind deprecation
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Use DisableExpandAutoSnapshot feature gate to disable the broken expand auto snapshot feature.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
