### PR TITLE
oss: cnfs-oss support use subpath 

### DIFF
--- a/pkg/common/constants.go
+++ b/pkg/common/constants.go
@@ -1,6 +1,7 @@
 package common
 
 const (
+	CsiAlibabaCloudPrefix    = "csi.alibabacloud.com"
 	ECSInstanceIDTopologyKey = "alibabacloud.com/ecs-instance-id"
 	TopologyKeyZone          = "topology.kubernetes.io/zone"
 	TopologyKeyRegion        = "topology.kubernetes.io/region"

--- a/pkg/nas/filesystem_controller.go
+++ b/pkg/nas/filesystem_controller.go
@@ -72,8 +72,6 @@ const (
 	LosetupType = "losetup"
 	// SkipMountType tag
 	SkipMountType = "skipmount"
-
-	csiAlibabaCloudName = "csi.alibabacloud.com"
 )
 
 // Alibaba Cloud nas volume parameters

--- a/pkg/nas/sharepath_controller.go
+++ b/pkg/nas/sharepath_controller.go
@@ -21,6 +21,7 @@ import (
 	"path/filepath"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
+	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/common"
 	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/nas/internal"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -40,7 +41,7 @@ func (cs *sharepathController) VolumeAs() string {
 
 func (cs *sharepathController) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest) (*csi.CreateVolumeResponse, error) {
 	parameters := req.Parameters
-	reclaimPolicy, ok := parameters[csiAlibabaCloudName+"/"+"reclaimPolicy"]
+	reclaimPolicy, ok := parameters[common.CsiAlibabaCloudPrefix+"/"+"reclaimPolicy"]
 	if ok && reclaimPolicy != string(corev1.PersistentVolumeReclaimRetain) {
 		return nil, status.Errorf(codes.InvalidArgument, "Use sharepath mode, reclaimPolicy must be Retain. The current reclaimPolicy is %q", reclaimPolicy)
 	}

--- a/pkg/oss/controllerserver.go
+++ b/pkg/oss/controllerserver.go
@@ -73,7 +73,7 @@ func (cs *controllerServer) CreateVolume(ctx context.Context, req *csi.CreateVol
 		return nil, err
 	}
 	region, _ := cs.metadata.Get(metadata.RegionID)
-	ossVol := parseOptions(req.GetParameters(), req.GetSecrets(), req.GetVolumeCapabilities(), false, region)
+	ossVol := parseOptions(req.GetParameters(), req.GetSecrets(), req.GetVolumeCapabilities(), false, region, req.GetName())
 	csiTargetVolume := &csi.Volume{}
 	volumeContext := req.GetParameters()
 	if volumeContext == nil {
@@ -133,7 +133,7 @@ func (cs *controllerServer) ControllerPublishVolume(ctx context.Context, req *cs
 	// parse options
 	nodeName := req.NodeId
 	region, _ := cs.metadata.Get(metadata.RegionID)
-	opts := parseOptions(req.GetVolumeContext(), req.GetSecrets(), []*csi.VolumeCapability{req.GetVolumeCapability()}, req.GetReadonly(), region)
+	opts := parseOptions(req.GetVolumeContext(), req.GetSecrets(), []*csi.VolumeCapability{req.GetVolumeCapability()}, req.GetReadonly(), region, "")
 	if err := setCNFSOptions(ctx, cs.cnfsGetter, opts); err != nil {
 		return nil, err
 	}

--- a/pkg/oss/controllerserver.go
+++ b/pkg/oss/controllerserver.go
@@ -28,6 +28,7 @@ import (
 	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/utils"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2"
@@ -62,6 +63,14 @@ func validateCreateVolumeRequest(req *csi.CreateVolumeRequest) error {
 	valid, err := utils.CheckRequestArgs(req.GetParameters())
 	if !valid {
 		return status.Errorf(codes.InvalidArgument, err.Error())
+	}
+	params := req.GetParameters()
+	if params == nil {
+		return nil
+	}
+	reclaimPolicy, ok := params[common.CsiAlibabaCloudPrefix+"/"+"reclaimPolicy"]
+	if ok && reclaimPolicy != string(corev1.PersistentVolumeReclaimRetain) {
+		return status.Errorf(codes.InvalidArgument, "ReclaimPolicy must be Retain. The current reclaimPolicy is %q", reclaimPolicy)
 	}
 
 	return nil

--- a/pkg/oss/nodeserver.go
+++ b/pkg/oss/nodeserver.go
@@ -113,7 +113,7 @@ func (ns *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 
 	// parse options
 	region, _ := ns.metadata.Get(metadata.RegionID)
-	opts := parseOptions(req.GetVolumeContext(), req.GetSecrets(), []*csi.VolumeCapability{req.GetVolumeCapability()}, req.GetReadonly(), region)
+	opts := parseOptions(req.GetVolumeContext(), req.GetSecrets(), []*csi.VolumeCapability{req.GetVolumeCapability()}, req.GetReadonly(), region, "")
 	if err := setCNFSOptions(ctx, ns.cnfsGetter, opts); err != nil {
 		return nil, err
 	}

--- a/pkg/oss/utils_test.go
+++ b/pkg/oss/utils_test.go
@@ -33,8 +33,9 @@ func Test_parseOptions(t *testing.T) {
 	// CreateVolume
 	testCVReq := csi.CreateVolumeRequest{
 		Parameters: map[string]string{
-			"bucket": "test-bucket",
-			"url":    "oss-cn-beijing.aliyuncs.com",
+			"bucket":   "test-bucket",
+			"url":      "oss-cn-beijing.aliyuncs.com",
+			"volumeAs": "subpath",
 		},
 		Secrets: map[string]string{
 			AkID:     "test-akid",
@@ -54,12 +55,12 @@ func Test_parseOptions(t *testing.T) {
 		AkID:          "test-akid",
 		AkSecret:      "test-aksecret",
 		FuseType:      "ossfs",
-		Path:          "/",
+		Path:          "/volume-id",
 		UseSharedPath: true,
 		MetricsTop:    defaultMetricsTop,
 	}
 	gotOptions = parseOptions(testCVReq.GetParameters(),
-		testCVReq.GetSecrets(), testCVReq.GetVolumeCapabilities(), false, "")
+		testCVReq.GetSecrets(), testCVReq.GetVolumeCapabilities(), false, "", "volume-id")
 	assert.Equal(t, expectedOptions, gotOptions)
 
 	// ControllerPublishVolume
@@ -96,7 +97,7 @@ func Test_parseOptions(t *testing.T) {
 	}
 	gotOptions = parseOptions(testCPVReq.GetVolumeContext(),
 		testCPVReq.GetSecrets(), []*csi.VolumeCapability{testCPVReq.GetVolumeCapability()},
-		testCPVReq.Readonly, "cn-beijing")
+		testCPVReq.Readonly, "cn-beijing", "")
 	assert.Equal(t, expectedOptions, gotOptions)
 
 	// NodePublishVolume
@@ -128,7 +129,7 @@ func Test_parseOptions(t *testing.T) {
 	}
 	gotOptions = parseOptions(testNPReq.GetVolumeContext(),
 		testNPReq.GetSecrets(), []*csi.VolumeCapability{testNPReq.GetVolumeCapability()},
-		testNPReq.Readonly, "cn-beijing")
+		testNPReq.Readonly, "cn-beijing", "")
 	assert.Equal(t, expectedOptions, gotOptions)
 }
 

--- a/pkg/oss/utils_test.go
+++ b/pkg/oss/utils_test.go
@@ -42,7 +42,7 @@ func Test_parseOptions(t *testing.T) {
 			AkSecret: "test-aksecret",
 		},
 		VolumeCapabilities: []*csi.VolumeCapability{
-			&csi.VolumeCapability{
+			{
 				AccessMode: &csi.VolumeCapability_AccessMode{
 					Mode: csi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER,
 				},

--- a/pkg/oss/utils_test.go
+++ b/pkg/oss/utils_test.go
@@ -41,7 +41,7 @@ func Test_parseOptions(t *testing.T) {
 			AkSecret: "test-aksecret",
 		},
 		VolumeCapabilities: []*csi.VolumeCapability{
-			{
+			&csi.VolumeCapability{
 				AccessMode: &csi.VolumeCapability_AccessMode{
 					Mode: csi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER,
 				},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
From 1.91+ version, ossfs support to mount a non-existed path (object) in OSS server, making it possible to support `subpath` mode as NAS for cnfs-oss.
 
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
