### PR TITLE
disk: attach disks with serial number at controller

### DIFF
--- a/docs/ram-policies/disk/node.json
+++ b/docs/ram-policies/disk/node.json
@@ -4,7 +4,6 @@
         {
             "Action": [
                 "ecs:AddTags",
-                "ecs:AttachDisk",
                 "ecs:DeleteSnapshot",
                 "ecs:DescribeDisks",
                 "ecs:DescribeInstanceAttribute",
@@ -13,7 +12,6 @@
                 "ecs:DescribeSnapshots",
                 "ecs:DescribeTags",
                 "ecs:DescribeTaskAttribute",
-                "ecs:DetachDisk",
                 "ecs:ListTagResources",
                 "ecs:RemoveTags",
                 "ecs:TagResources",

--- a/pkg/disk/cloud.go
+++ b/pkg/disk/cloud.go
@@ -174,9 +174,13 @@ func (ad *DiskAttachDetach) attachDisk(ctx context.Context, diskID, nodeID strin
 	}
 
 	if !fromNode && disk.SerialNumber == "" {
-		return "", status.Errorf(codes.InvalidArgument,
-			"Disk %s does not have serial number but AD controller is enabled, we cannot attach this disk. "+
-				"Please open ticket to add serial number to this disk", diskID)
+		if GlobalConfigVar.ADControllerEnable {
+			return "", status.Errorf(codes.InvalidArgument,
+				"Disk %s does not have serial number but AD controller is enabled, we cannot attach this disk. "+
+					"Please open ticket to add serial number to this disk", diskID)
+		} else {
+			return "", nil // should defer attach to node
+		}
 	}
 
 	slot := ad.slots.GetSlotFor(nodeID).Attach()
@@ -424,7 +428,7 @@ func (ad *DiskAttachDetach) detachMultiAttachDisk(ctx context.Context, ecsClient
 	return true, nil
 }
 
-func (ad *DiskAttachDetach) detachDisk(ctx context.Context, ecsClient *ecs.Client, diskID, nodeID string) error {
+func (ad *DiskAttachDetach) detachDisk(ctx context.Context, ecsClient *ecs.Client, diskID, nodeID string, fromNode bool) error {
 	disk, err := ad.findDiskByID(ctx, diskID)
 	if err != nil {
 		klog.Errorf("DetachDisk: Describe volume: %s from node: %s, with error: %s", diskID, nodeID, err.Error())
@@ -432,6 +436,10 @@ func (ad *DiskAttachDetach) detachDisk(ctx context.Context, ecsClient *ecs.Clien
 	}
 	if disk == nil {
 		klog.Infof("DetachDisk: Detach Disk %s from node %s describe and find disk not exist", diskID, nodeID)
+		return nil
+	}
+	if fromNode && disk.SerialNumber != "" {
+		klog.V(2).InfoS("server say disk has serial number, defer detach to controller")
 		return nil
 	}
 

--- a/pkg/disk/controllerserver.go
+++ b/pkg/disk/controllerserver.go
@@ -295,7 +295,7 @@ func (cs *controllerServer) DeleteVolume(ctx context.Context, req *csi.DeleteVol
 				// TODO: ECI does not support multi-attach?
 				return nil, status.Errorf(codes.Internal, "refuse to delete disk on serverless instance %s", disk.InstanceId)
 			}
-			err := cs.ad.detachDisk(ctx, ecsClient, req.VolumeId, disk.InstanceId)
+			err := cs.ad.detachDisk(ctx, ecsClient, req.VolumeId, disk.InstanceId, false)
 			if err != nil {
 				newErrMsg := utils.FindSuggestionByErrorMessage(err.Error(), utils.DiskDelete)
 				return nil, status.Errorf(codes.Internal, "DeleteVolume: detach disk: %s from node: %s with error: %s", req.VolumeId, disk.InstanceId, newErrMsg)
@@ -381,11 +381,6 @@ func (cs *controllerServer) ControllerPublishVolume(ctx context.Context, req *cs
 		return &csi.ControllerPublishVolumeResponse{}, nil
 	}
 
-	if !GlobalConfigVar.ADControllerEnable {
-		klog.Infof("ControllerPublishVolume: ADController Disable to attach disk: %s to node: %s", req.VolumeId, req.NodeId)
-		return &csi.ControllerPublishVolumeResponse{}, nil
-	}
-
 	klog.Infof("ControllerPublishVolume: start attach disk: %s to node: %s", req.VolumeId, req.NodeId)
 	isSharedDisk := false
 	if value, ok := req.VolumeContext[SharedEnable]; ok {
@@ -400,7 +395,11 @@ func (cs *controllerServer) ControllerPublishVolume(ctx context.Context, req *cs
 		klog.Errorf("ControllerPublishVolume: attach disk: %s to node: %s with error: %s", req.VolumeId, req.NodeId, err.Error())
 		return nil, err
 	}
-	klog.Infof("ControllerPublishVolume: successfully attached disk: %s (serial %s) to node: %s", req.VolumeId, serial, req.NodeId)
+	if serial == "" {
+		klog.Infof("ControllerPublishVolume: disk %s has no serial number, defer attach to node", req.VolumeId)
+	} else {
+		klog.Infof("ControllerPublishVolume: successfully attached disk: %s (serial %s) to node: %s", req.VolumeId, serial, req.NodeId)
+	}
 	return &csi.ControllerPublishVolumeResponse{
 		PublishContext: map[string]string{
 			PUBLISH_CONTEXT_SERIAL: serial,
@@ -421,11 +420,6 @@ func (cs *controllerServer) ControllerUnpublishVolume(ctx context.Context, req *
 		return &csi.ControllerUnpublishVolumeResponse{}, nil
 	}
 
-	if !GlobalConfigVar.ADControllerEnable {
-		klog.Infof("ControllerUnpublishVolume: ADController Disable to detach disk: %s from node: %s", req.VolumeId, req.NodeId)
-		return &csi.ControllerUnpublishVolumeResponse{}, nil
-	}
-
 	// if DetachDisabled is set to true, return
 	if GlobalConfigVar.DetachDisabled {
 		klog.Infof("ControllerUnpublishVolume: Detach disabled, kept disk %s on node %s", req.VolumeId, req.NodeId)
@@ -433,7 +427,7 @@ func (cs *controllerServer) ControllerUnpublishVolume(ctx context.Context, req *
 	}
 
 	klog.Infof("ControllerUnpublishVolume: detach disk: %s from node: %s", req.VolumeId, req.NodeId)
-	err = cs.ad.detachDisk(ctx, ecsClient, req.VolumeId, req.NodeId)
+	err = cs.ad.detachDisk(ctx, ecsClient, req.VolumeId, req.NodeId, false)
 	if err != nil {
 		klog.Errorf("ControllerUnpublishVolume: detach disk: %s from node: %s with error: %s", req.VolumeId, req.NodeId, err.Error())
 		return nil, err

--- a/pkg/disk/nodeserver.go
+++ b/pkg/disk/nodeserver.go
@@ -689,17 +689,7 @@ func (ns *nodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVol
 	return &csi.NodeStageVolumeResponse{}, nil
 }
 
-func addDiskXattr(diskID string) (err error) {
-	defer func() {
-		if errors.Is(err, os.ErrNotExist) {
-			klog.Infof("addDiskXattr: disk %s not found, skip", diskID)
-			err = nil
-		}
-	}()
-	device, err := GetVolumeDeviceName(diskID)
-	if err != nil {
-		return
-	}
+func addDiskXattr(device, diskID string) (err error) {
 	return unix.Setxattr(device, DiskXattrName, []byte(diskID), 0)
 }
 
@@ -792,25 +782,53 @@ func (ns *nodeServer) NodeUnstageVolume(ctx context.Context, req *csi.NodeUnstag
 		}
 	}
 
-	err := addDiskXattr(req.VolumeId)
+	// All device related errors are not fatal, just log it
+	device, err := GetVolumeDeviceName(req.VolumeId)
 	if err != nil {
-		klog.Errorf("NodeUnstageVolume: addDiskXattr %s failed: %v", req.VolumeId, err)
+		if errors.Is(err, os.ErrNotExist) {
+			klog.Infof("NodeUnstagedVolume: device for disk %s not found", req.VolumeId)
+		} else {
+			klog.ErrorS(err, "failed to get device for disk", "disk", req.VolumeId)
+		}
+	} else {
+		err := addDiskXattr(device, req.VolumeId)
+		if err != nil {
+			klog.Errorf("NodeUnstageVolume: addDiskXattr %s failed: %v", req.VolumeId, err)
+		}
 	}
 
-	// Do detach if ADController disable
-	if !GlobalConfigVar.ADControllerEnable {
-		// if DetachDisabled is set to true, return
-		if GlobalConfigVar.DetachDisabled {
-			klog.Infof("NodeUnstageVolume: ADController is Disable, Detach Flag Set to false, PV %s", req.VolumeId)
+	defer func() {
+		if err == nil {
+			if err := removeVolumeConfig(req.VolumeId); err != nil {
+				klog.Errorf("NodeUnstageVolume: remove volume config %s failed: %v", req.VolumeId, err)
+			}
+		}
+	}()
+
+	if GlobalConfigVar.ADControllerEnable {
+		return &csi.NodeUnstageVolumeResponse{}, nil
+	}
+	if GlobalConfigVar.DetachDisabled {
+		klog.Infof("NodeUnstageVolume: ADController is Disable, Detach Flag Set to false, PV %s", req.VolumeId)
+		return &csi.NodeUnstageVolumeResponse{}, nil
+	}
+
+	if device != "" {
+		// best effort to avoid OpenAPI call. detachDisk will check again.
+		// TODO: this check only works for root device, not partition. We should move partition logic to be file-system only.
+		// See https://github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pull/1071
+		serial, _ := ns.ad.dev.GetDeviceSerial(filepath.Base(device))
+		if serial != "" {
+			klog.V(2).InfoS("locally checked disk has serial number, defer detach to controller")
 			return &csi.NodeUnstageVolumeResponse{}, nil
 		}
-		ecsClient := updateEcsClient(GlobalConfigVar.EcsClient)
-		err = ns.ad.detachDisk(ctx, ecsClient, req.VolumeId, ns.NodeID)
-		if err != nil {
-			klog.Errorf("NodeUnstageVolume: VolumeId: %s, Detach failed with error %v", req.VolumeId, err.Error())
-			return nil, err
-		}
-		_ = removeVolumeConfig(req.VolumeId)
+	}
+	// Do detach if ADController is disabled and disk has no serial number
+	ecsClient := updateEcsClient(GlobalConfigVar.EcsClient)
+	err = ns.ad.detachDisk(ctx, ecsClient, req.VolumeId, ns.NodeID, true)
+	if err != nil {
+		klog.Errorf("NodeUnstageVolume: VolumeId: %s, Detach failed with error %v", req.VolumeId, err.Error())
+		return nil, err
 	}
 
 	return &csi.NodeUnstageVolumeResponse{}, nil


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Attach and detach must be migrated at once, because NodeUnstageVolume may be followed immediately by anoterh NodeStageVolume, without controller actions.
So if we detach disk at NodeUnstageVolume, NodeStageVolume will not find the disk.

Note: user must upgrade controller before node, to avoid any missing detach.

This is the first step to move all attach/detach back to controller, in order to:
- reduce RAM permission on node
- more effective request batching
- rely less on node, which can be down
- resolve some rare racing issue

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

/hold
merge after #1087 


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Disk attach operation is moved to controller for disks with serial number
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
