### PR TITLE
Fix kubelet restart grpc calling bugs of runD

### DIFF
--- a/pkg/disk/bdf.go
+++ b/pkg/disk/bdf.go
@@ -594,11 +594,21 @@ func NewDeviceDriver(volumeId, blockDevice, deviceNumber string, _type MachineTy
 			}
 		}
 	} else {
-		output, err := utils.CommandOnNode("xdragon-bdf", "--nvme", "-id=%s", volumeId).CombinedOutput()
-		if err != nil {
-			return nil, fmt.Errorf("Failed to excute bdf command: %s, err: %v", volumeId, err)
+		for _, pciDriver := range []string{"--nvme", "--blk"} {
+			output, err := utils.CommandOnNode("xdragon-bdf", pciDriver, "-id=%s", volumeId).CombinedOutput()
+			if err != nil {
+				klog.ErrorS(err, "Failed to excute xdragon-bdf command", "volumeId", volumeId)
+				continue
+			}
+			bdf := strings.TrimSpace(string(output))
+			if bdf != "" {
+				d.deviceNumber = bdf
+				return d, nil
+			}
 		}
-		d.deviceNumber = string(output)
+	}
+	if d.deviceNumber == "" {
+		return nil, fmt.Errorf("Failed to find device number for %s", volumeId)
 	}
 	return d, nil
 }

--- a/pkg/disk/bdf.go
+++ b/pkg/disk/bdf.go
@@ -595,9 +595,9 @@ func NewDeviceDriver(volumeId, blockDevice, deviceNumber string, _type MachineTy
 		}
 	} else {
 		for _, pciDriver := range []string{"--nvme", "--blk"} {
-			output, err := utils.CommandOnNode("xdragon-bdf", pciDriver, "-id=%s", volumeId).CombinedOutput()
+			output, err := utils.CommandOnNode("xdragon-bdf", pciDriver, fmt.Sprintf("--id=%s", volumeId)).CombinedOutput()
 			if err != nil {
-				klog.ErrorS(err, "Failed to excute xdragon-bdf command", "volumeId", volumeId)
+				klog.ErrorS(err, "Failed to excute xdragon-bdf command", "volumeId", volumeId, "output", output)
 				continue
 			}
 			bdf := strings.TrimSpace(string(output))

--- a/pkg/disk/nodeserver.go
+++ b/pkg/disk/nodeserver.go
@@ -505,64 +505,17 @@ func (ns *nodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVol
 	isBlock := req.GetVolumeCapability().GetBlock() != nil
 	if isBlock {
 		targetPath = filepath.Join(targetPath, req.VolumeId)
-		notMounted, err := ns.k8smounter.IsLikelyNotMountPoint(targetPath)
-		if err != nil && !errors.Is(err, fs.ErrNotExist) {
-			return nil, status.Errorf(codes.Internal, "failed to check if %s is not a mount point: %v", targetPath, err)
-		}
-		if !notMounted {
-			klog.Infof("NodeStageVolume: Block Already Mounted: volumeId: %s target %s", req.VolumeId, targetPath)
-			return &csi.NodeStageVolumeResponse{}, nil
-		}
-		if err := ns.mounter.EnsureBlock(targetPath); err != nil {
-			klog.Errorf("NodeStageVolume: create block volume %s path %s error: %v", req.VolumeId, targetPath, err)
-			return nil, status.Error(codes.Internal, err.Error())
-		}
-	} else {
-		if err := ns.mounter.EnsureFolder(targetPath); err != nil {
-			klog.Errorf("NodeStageVolume: create volume %s path %s error: %v", req.VolumeId, targetPath, err)
-			return nil, status.Error(codes.Internal, err.Error())
-		}
 	}
-	// check volume is mounted in kata mode;
-	fileName := filepath.Join(filepath.Dir(targetPath), utils.VolDataFileName)
-	if strings.HasSuffix(targetPath, "/") {
-		fileName = filepath.Join(filepath.Dir(filepath.Dir(targetPath)), utils.VolDataFileName)
-	}
-	volumeData, err := utils.LoadJSONData(fileName)
-	if err == nil {
-		if _, ok := volumeData["csi.alibabacloud.com/disk-mounted"]; ok {
-			klog.Infof("NodeStageVolume:  volumeId: %s, Path: %s is already mounted in kata mode", req.VolumeId, targetPath)
-			return &csi.NodeStageVolumeResponse{}, nil
-		}
-	}
-
-	// Step 2: check target path mounted
-	notmounted, err := ns.k8smounter.IsLikelyNotMountPoint(targetPath)
+	// for runc & rund-csi2.0 kubelet restart
+	mounted, err := ns.ensurePathExistsAndCheckMounted(req.VolumeId, targetPath, isBlock)
 	if err != nil {
-		klog.Errorf("NodeStageVolume: check volume %s path %s error: %v", req.VolumeId, targetPath, err)
-		return nil, status.Error(codes.Internal, err.Error())
+		return nil, err
 	}
-	if !notmounted {
-		// if target path is mounted tmpfs, return
-		isTmpfs, err := utils.IsDirTmpfs(ns.k8smounter, req.StagingTargetPath)
-		if err != nil {
-			return nil, status.Errorf(codes.Internal, "NodeStageVolume: failed to check %s for tmpfs: %v", req.StagingTargetPath, err)
-		}
-		if isTmpfs {
-			klog.Infof("NodeStageVolume: TargetPath(%s) is mounted as tmpfs, not need mount again", req.StagingTargetPath)
-			return &csi.NodeStageVolumeResponse{}, nil
-		}
-
-		// check device available
-		deviceName, _, err := mount.GetDeviceNameFromMount(ns.k8smounter, targetPath)
-		if err != nil {
-			return nil, status.Errorf(codes.Internal, "NodePublishVolume: get device name from mount %s error: %s", targetPath, err.Error())
-		}
-		if err := CheckDeviceAvailable(deviceName, req.VolumeId, targetPath); err != nil {
-			klog.Errorf("NodeStageVolume: mountPath is mounted %s, but check device available error: %s", targetPath, err.Error())
-			return nil, status.Error(codes.Internal, err.Error())
-		}
-		klog.Infof("NodeStageVolume:  volumeId: %s, Path: %s is already mounted, device: %s", req.VolumeId, targetPath, deviceName)
+	if mounted {
+		return &csi.NodeStageVolumeResponse{}, nil
+	}
+	mounted = ns.checkMountedOfRunvAndRund(req.VolumeId, targetPath)
+	if mounted {
 		return &csi.NodeStageVolumeResponse{}, nil
 	}
 
@@ -1465,5 +1418,80 @@ func (ns *nodeServer) mountRunDVolumes(volumeId, pvName, sourcePath, targetPath,
 		klog.Warningf("NodeStageVolume: append volume spec to %s with error: %s", fileName, err.Error())
 	}
 	return false, nil
+
+}
+
+// ensurePathExistsAndCheckMounted check if targetPath is mounted or not
+// targeting for runc and rund-csi 2.0 protocol
+func (ns *nodeServer) ensurePathExistsAndCheckMounted(volumeId, targetPath string, isBlock bool) (bool, error) {
+	notMounted, err := ns.k8smounter.IsLikelyNotMountPoint(targetPath)
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return false, status.Errorf(codes.Internal, "failed to check if %s is not a mount point: %v", targetPath, err)
+	}
+	if !notMounted {
+		// if target path is mounted tmpfs, return
+		isTmpfs, err := utils.IsDirTmpfs(ns.k8smounter, targetPath)
+		if err != nil {
+			return false, status.Errorf(codes.Internal, "NodeStageVolume: failed to check %s for tmpfs: %v", targetPath, err)
+		}
+		if isTmpfs {
+			klog.Infof("NodeStageVolume: TargetPath(%s) is mounted as tmpfs, not need mount again", targetPath)
+			return true, nil
+		}
+
+		// check device available
+		deviceName, _, err := mount.GetDeviceNameFromMount(ns.k8smounter, targetPath)
+		if err != nil {
+			return false, status.Errorf(codes.Internal, "NodePublishVolume: get device name from mount %s error: %s", targetPath, err.Error())
+		}
+		if err := CheckDeviceAvailable(deviceName, volumeId, targetPath); err != nil {
+			klog.Errorf("NodeStageVolume: mountPath is mounted %s, but check device available error: %s", targetPath, err.Error())
+			return false, status.Error(codes.Internal, err.Error())
+		}
+		klog.Infof("NodeStageVolume:  volumeId: %s, Path: %s is already mounted, device: %s", volumeId, targetPath, deviceName)
+		return true, nil
+	}
+	if isBlock {
+		if err := ns.mounter.EnsureBlock(targetPath); err != nil {
+			klog.Errorf("NodeStageVolume: create block volume %s path %s error: %v", volumeId, targetPath, err)
+			return false, status.Error(codes.Internal, err.Error())
+		}
+	} else {
+		if err := ns.mounter.EnsureFolder(targetPath); err != nil {
+			klog.Errorf("NodeStageVolume: create volume %s path %s error: %v", volumeId, targetPath, err)
+			return false, status.Error(codes.Internal, err.Error())
+		}
+	}
+	return false, nil
+}
+
+// checkMountedOfRunvAndRund check if targetVolume is used by runv or rund-csi3.0
+func (ns *nodeServer) checkMountedOfRunvAndRund(volumeId, targetPath string) bool {
+	// check volume is mounted in runv mode for kubelet restart;
+	fileName := filepath.Join(filepath.Dir(targetPath), utils.VolDataFileName)
+	if strings.HasSuffix(targetPath, "/") {
+		fileName = filepath.Join(filepath.Dir(filepath.Dir(targetPath)), utils.VolDataFileName)
+	}
+	volumeData, err := utils.LoadJSONData(fileName)
+	if err == nil {
+		if _, ok := volumeData["csi.alibabacloud.com/disk-mounted"]; ok {
+			klog.Infof("NodeStageVolume:  volumeId: %s, Path: %s is already mounted in kata mode", volumeId, targetPath)
+			return true
+		}
+	}
+	d, err := NewDeviceDriver(volumeId, "", "", ns.kataBMIOType, nil)
+	if err != nil {
+		klog.ErrorS(err, "NodeStageVolume:  Failed to get bdf number", "volumeId", volumeId)
+		return false
+	}
+	cDrvier, err := d.CurentDriver()
+	if err != nil {
+		klog.ErrorS(err, "NodeStageVolume:  Failed to get current driver", "volumeId", volumeId)
+		return false
+	}
+	if vfioDrivers.Has(cDrvier) {
+		return true
+	}
+	return false
 
 }

--- a/pkg/disk/nodeserver_test.go
+++ b/pkg/disk/nodeserver_test.go
@@ -1,0 +1,88 @@
+package disk
+
+import (
+	"errors"
+	"io/fs"
+	"testing"
+
+	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/utils"
+	"github.com/stretchr/testify/assert"
+	k8smount "k8s.io/mount-utils"
+)
+
+func TestEnsurePathExistsAndCheckMounted(t *testing.T) {
+	mountCheckErrors := map[string]error{
+		"/err":       errors.New("specific error"),
+		"/notexists": fs.ErrNotExist,
+	}
+	mounter := &k8smount.FakeMounter{
+		MountCheckErrors: mountCheckErrors,
+	}
+	// Create mock instances
+	ns := &nodeServer{
+		k8smounter: mounter,
+		mounter:    utils.NewFakeMounter(),
+	}
+
+	tests := []struct {
+		name       string
+		volumeId   string
+		targetPath string
+		fsType     string
+		source     string
+		isBlock    bool
+		expectErr  bool
+	}{
+		{
+			name:       "",
+			volumeId:   "aaa",
+			targetPath: "/",
+			fsType:     "",
+			source:     "",
+			isBlock:    true,
+			expectErr:  false,
+		}, {
+			name:       "",
+			volumeId:   "aaa",
+			targetPath: "/tmpfs",
+			source:     "tmpfs",
+			fsType:     "tmpfs",
+			isBlock:    false,
+			expectErr:  false,
+		}, {
+			name:       "",
+			volumeId:   "aaa",
+			targetPath: "/ext4",
+			source:     "/dev/ext4",
+			fsType:     "ext4",
+			isBlock:    false,
+			expectErr:  false,
+		},
+		{
+			name:       "",
+			volumeId:   "aaa",
+			targetPath: "/notexists",
+			isBlock:    false,
+			expectErr:  true,
+		}, {
+			name:       "",
+			volumeId:   "aaa",
+			targetPath: "/err",
+			isBlock:    false,
+			expectErr:  true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.fsType != "" {
+				ns.mounter.Mount(tt.source, tt.targetPath, tt.fsType)
+			}
+			_, err := ns.ensurePathExistsAndCheckMounted(tt.volumeId, tt.targetPath, tt.isBlock)
+			if tt.expectErr {
+				assert.NotNil(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/pkg/utils/fake_mounter.go
+++ b/pkg/utils/fake_mounter.go
@@ -1,0 +1,36 @@
+package utils
+
+type fakeMounter struct {
+}
+
+func NewFakeMounter() Mounter {
+	return &fakeMounter{}
+}
+
+func (m *fakeMounter) EnsureBlock(target string) error {
+	return nil
+}
+
+func (m *fakeMounter) EnsureFolder(target string) error {
+	return nil
+}
+
+func (m *fakeMounter) Format(source, fsType string) error {
+	return nil
+}
+
+func (m *fakeMounter) Mount(source, target, fsType string, options ...string) error {
+	return nil
+}
+
+func (m *fakeMounter) MountBlock(source, target string, options ...string) error {
+	return nil
+}
+
+func (m *fakeMounter) Unmount(target string) error {
+	return nil
+}
+
+func (m *fakeMounter) HasMountRefs(mountPath string, mountRefs []string) bool {
+	return false
+}

--- a/pkg/utils/rund/directvolume/utils.go
+++ b/pkg/utils/rund/directvolume/utils.go
@@ -14,11 +14,28 @@ func AddMountInfo(volumePath string, mountInfo MountInfo) error {
 }
 
 func IsRunD3VolumePath(volumePath string) (*MountInfo, bool) {
+	// targetPath(publishPath) must contains poduid, which is the base path name of the volumeDevice path.
+	// thus, it diffs from volumeMount path
 	mountInfo, err := VolumeMountInfo(volumePath)
-	if err != nil {
-		return nil, false
+	if err == nil {
+		return mountInfo, true
 	}
-	return mountInfo, true
+	mountInfo, err = VolumeMountInfo(filepath.Dir(volumePath))
+	if err == nil {
+		return mountInfo, true
+	}
+	return nil, false
+}
+
+func EnsureVolumeAttributesFileDir(targetPath string, isBlock bool) string {
+	// targetPath(publishPath) must contains poduid, which is the base path name of the volumeDevice path.
+	// thus, it diffs from volumeMount path
+	if !isBlock {
+		return filepath.Dir(targetPath)
+	}
+	// remove volumeDevice file, volumeDevice dir will be created in the Add method
+	os.Remove(targetPath)
+	return targetPath
 }
 
 func IsRunD2VolumePath(volumePath string) bool {
@@ -51,6 +68,7 @@ func IsRunDVolumeAlreadyMount(volumePath string) bool {
 	if _, b := IsRunD3VolumePath(volumePath); b {
 		return true
 	}
+
 	if IsRunD2VolumePath(volumePath) {
 		return true
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Confirm if volume is in use by runD after kubelet restarts

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
