### PR TITLE
oss: do not modify vpc100 endpoint

### DIFF
--- a/pkg/oss/nodeserver.go
+++ b/pkg/oss/nodeserver.go
@@ -227,10 +227,10 @@ func (ns *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 		if regionID == "" {
 			log.Warnf("Failed to get region id from both env and metadata, use original URL: %s", opt.URL)
 		}
-		if regionID != "" && strings.Contains(opt.URL, regionID) &&
-			!strings.Contains(opt.URL, "internal") && !utils.IsPrivateCloud() {
-			originUrl := opt.URL
-			opt.URL = strings.ReplaceAll(originUrl, regionID, regionID+"-internal")
+		url, modified := setNetworkType(opt.URL, regionID)
+		if modified {
+			log.Infof("Changed oss URL from %s to %s", opt.URL, url)
+			opt.URL = url
 		}
 
 		mntCmd = fmt.Sprintf("systemd-run --scope -- /usr/local/bin/ossfs %s:%s %s -ourl=%s %s %s", opt.Bucket, opt.Path, mountPath, opt.URL, opt.OtherOpts, credentialProvider)
@@ -245,6 +245,32 @@ func (ns *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 
 	log.Infof("NodePublishVolume:: Mount oss is successfully, volume %s, targetPath: %s, with Command: %s", req.VolumeId, mountPath, mntCmd)
 	return &csi.NodePublishVolumeResponse{}, nil
+}
+
+func setNetworkType(originURL, regionID string) (URL string, modified bool) {
+	URL = originURL
+	if utils.IsPrivateCloud() || !strings.HasSuffix(strings.TrimRight(URL, "/"), ".aliyuncs.com") {
+		return
+	}
+	// compatible with the old OSS accelerator endpoint, remove after it is deprecated
+	var protocol string
+	if strings.HasPrefix(URL, "https://") {
+		protocol = "https://"
+	} else if strings.HasPrefix(URL, "http://") {
+		protocol = "http://"
+	}
+	endpoint := strings.TrimPrefix(URL, protocol)
+	if strings.HasPrefix(endpoint, "oss-cache-") {
+		return
+	}
+	if strings.HasPrefix(endpoint, "vpc100-") {
+		return
+	}
+	if strings.Contains(URL, regionID) && !strings.Contains(URL, "internal") {
+		URL = strings.ReplaceAll(URL, regionID, regionID+"-internal")
+		modified = true
+	}
+	return
 }
 
 // save ak file: bucket:ak_id:ak_secret

--- a/pkg/oss/nodeserver.go
+++ b/pkg/oss/nodeserver.go
@@ -249,27 +249,27 @@ func (ns *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 
 func setNetworkType(originURL, regionID string) (URL string, modified bool) {
 	URL = originURL
-	if utils.IsPrivateCloud() || !strings.HasSuffix(strings.TrimRight(URL, "/"), ".aliyuncs.com") {
+	if utils.IsPrivateCloud() {
 		return
 	}
-	// compatible with the old OSS accelerator endpoint, remove after it is deprecated
 	var protocol string
-	if strings.HasPrefix(URL, "https://") {
+	if strings.HasPrefix(originURL, "https://") {
 		protocol = "https://"
-	} else if strings.HasPrefix(URL, "http://") {
+	} else if strings.HasPrefix(originURL, "http://") {
 		protocol = "http://"
 	}
-	endpoint := strings.TrimPrefix(URL, protocol)
-	if strings.HasPrefix(endpoint, "oss-cache-") {
+	endpoint := strings.TrimPrefix(originURL, protocol)
+
+	switch endpoint {
+	case fmt.Sprintf("oss-%s.aliyuncs.com", regionID):
+		endpoint = fmt.Sprintf("oss-%s-internal.aliyuncs.com", regionID)
+	case fmt.Sprintf("%s.oss-data-acc.aliyuncs.com", regionID):
+		endpoint = fmt.Sprintf("%s-internal.oss-data-acc.aliyuncs.com", regionID)
+	default:
 		return
 	}
-	if strings.HasPrefix(endpoint, "vpc100-") {
-		return
-	}
-	if strings.Contains(URL, regionID) && !strings.Contains(URL, "internal") {
-		URL = strings.ReplaceAll(URL, regionID, regionID+"-internal")
-		modified = true
-	}
+	URL = protocol + endpoint
+	modified = true
 	return
 }
 

--- a/pkg/oss/nodeserver_test.go
+++ b/pkg/oss/nodeserver_test.go
@@ -49,3 +49,79 @@ func TestGetDiskVolumeOptions(t *testing.T) {
 	assert.Equal(t, "Oss path error: start with "+options.Path+", should start with / ", err.Error())
 
 }
+
+func Test_setNetworkType(t *testing.T) {
+	tests := []struct {
+		name         string
+		originURL    string
+		regionID     string
+		wantURL      string
+		wantModified bool
+	}{
+		{
+			"internal-modified",
+			"http://oss-cn-beijing.aliyuncs.com",
+			"cn-beijing",
+			"http://oss-cn-beijing-internal.aliyuncs.com",
+			true,
+		},
+		{
+			"public-unmodified",
+			"https://oss-cn-beijing.aliyuncs.com",
+			"cn-hangzhou",
+			"https://oss-cn-beijing.aliyuncs.com",
+			false,
+		},
+		{
+			"internal-unmodified",
+			"oss-cn-beijing-internal.aliyuncs.com",
+			"cn-beijing",
+			"oss-cn-beijing-internal.aliyuncs.com",
+			false,
+		},
+		{
+			"private",
+			"oss-cn-wulanchabu-xxx-xxxx.ops.xxx.com",
+			"cn-wulanchabu",
+			"oss-cn-wulanchabu-xxx-xxxx.ops.xxx.com",
+			false,
+		},
+		{
+			"old-oss-accelerator",
+			"oss-cache-cn-beijing-h.aliyuncs.com",
+			"cn-beijing",
+			"oss-cache-cn-beijing-h.aliyuncs.com",
+			false,
+		},
+		{
+			"new-oss-accelerator",
+			"cn-hangzhou.oss-data-acc.aliyuncs.com",
+			"cn-hangzhou",
+			"cn-hangzhou-internal.oss-data-acc.aliyuncs.com",
+			true,
+		},
+		{
+			"vpc100",
+			"vpc100-oss-cn-beijing.aliyuncs.com",
+			"cn-beijing",
+			"vpc100-oss-cn-beijing.aliyuncs.com",
+			false,
+		},
+		{
+			"vpc100-with-protocol",
+			"http://vpc100-oss-cn-beijing.aliyuncs.com",
+			"cn-beijing",
+			"http://vpc100-oss-cn-beijing.aliyuncs.com",
+			false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			url, done := setNetworkType(tt.originURL, tt.regionID)
+			if url != tt.wantURL || done != tt.wantModified {
+				t.Errorf("setNetworkType(%v, %v) = %v, %v, want %v %v",
+					tt.originURL, tt.regionID, url, done, tt.wantURL, tt.wantModified)
+			}
+		})
+	}
+}

--- a/pkg/oss/nodeserver_test.go
+++ b/pkg/oss/nodeserver_test.go
@@ -118,10 +118,8 @@ func Test_setNetworkType(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			url, done := setNetworkType(tt.originURL, tt.regionID)
-			if url != tt.wantURL || done != tt.wantModified {
-				t.Errorf("setNetworkType(%v, %v) = %v, %v, want %v %v",
-					tt.originURL, tt.regionID, url, done, tt.wantURL, tt.wantModified)
-			}
+			assert.Equal(t, tt.wantURL, url)
+			assert.Equal(t, tt.wantModified, done)
 		})
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
`vpc100-oss-cn-beijing.aliyuncs.com` is the deprecated internal endpoint. automatically patch `-internal` will make it invalid, this PR will skip all endpoints with `vpc100` prefix. 
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
