### PR TITLE
metric/disk: fix disk size reporting

### DIFF
--- a/pkg/metric/utils.go
+++ b/pkg/metric/utils.go
@@ -302,5 +302,5 @@ func parseCapacityThreshold(s string, defaults float64) (float64, error) {
 
 func getGlobalMountPathByDiskID(diskID string) string {
 	hash := sha256.Sum256([]byte(diskID))
-	return fmt.Sprintf(utils.KubeletRootDir, "/plugins/kubernetes.io/csi/%s/%x/globalmount", diskDriverName, hash)
+	return filepath.Join(utils.KubeletRootDir, fmt.Sprintf("/plugins/kubernetes.io/csi/%s/%x/globalmount", diskDriverName, hash))
 }

--- a/pkg/metric/utils_test.go
+++ b/pkg/metric/utils_test.go
@@ -1,0 +1,13 @@
+package metric
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetGlobalMountPathByDiskID(t *testing.T) {
+	assert.Equal(t,
+		"/var/lib/kubelet/plugins/kubernetes.io/csi/diskplugin.csi.alibabacloud.com/b3f919f99444cdb7b9a4e3906e14c76a1f12111725e2a8044de53a312c61ba2c/globalmount",
+		getGlobalMountPathByDiskID("d-testdiskid"))
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug
/kind regression

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Fixes:
```
E1216 18:26:45.999408  499952 disk_stat_collector.go:462] Get pv /var/lib/kubelet%!(EXTRA string=/plugins/kubernetes.io/csi/%s/%x/globalmount, string=diskplugin.csi.alibabacloud.com, [32]uint8=[209 131 97 74 247 233 227 64 50 28 36 159 14 55 30 150 32 40 33 38 228 79 208 24 110 25 70 70 17 3 96 219]) metrics from kubelet is failed, err: no such file or directory
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1044 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fix that disk size metrics are missing
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
