### PR TITLE
mounter/proxy: avoid deprecated func and cleanups

### DIFF
--- a/pkg/mounter/proxy/server/ossfs/driver.go
+++ b/pkg/mounter/proxy/server/ossfs/driver.go
@@ -14,7 +14,6 @@ import (
 	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/mounter/proxy"
 	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/mounter/proxy/server"
 	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/mounter/utils"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog/v2"
 	"k8s.io/mount-utils"
 )
@@ -24,14 +23,14 @@ func init() {
 }
 
 type Driver struct {
-	pids *sync.Map
+	pids sync.Map
 	wg   sync.WaitGroup
 	raw  mount.Interface
 }
 
 func NewDriver() *Driver {
 	return &Driver{
-		pids: new(sync.Map),
+		pids: sync.Map{},
 		raw:  mount.NewWithoutSystemd(""),
 	}
 }
@@ -100,48 +99,41 @@ func (h *Driver) Mount(ctx context.Context, req *proxy.MountRequest) error {
 		close(ossfsExited)
 	}()
 
-	err = wait.PollUntilContextCancel(ctx, time.Second, true, func(ctx context.Context) (done bool, err error) {
+	for {
 		select {
 		case err := <-ossfsExited:
 			// TODO: collect ossfs outputs to return in error message
 			if err != nil {
-				return false, fmt.Errorf("ossfs exited: %w", err)
+				return fmt.Errorf("ossfs exited: %w", err)
 			}
-			return false, fmt.Errorf("ossfs exited")
-		default:
+			return fmt.Errorf("ossfs exited")
+		case <-ctx.Done():
+			// terminate ossfs process when timeout
+			terr := cmd.Process.Signal(syscall.SIGTERM)
+			if terr != nil {
+				klog.ErrorS(err, "Failed to terminate ossfs", "pid", pid)
+			}
+			select {
+			case <-ossfsExited:
+			case <-time.After(time.Second * 2):
+				kerr := cmd.Process.Kill()
+				if kerr != nil && !errors.Is(kerr, os.ErrProcessDone) {
+					klog.ErrorS(err, "Failed to kill ossfs", "pid", pid)
+				}
+			}
+			return ctx.Err()
+		case <-time.After(time.Second):
 			notMnt, err := h.raw.IsLikelyNotMountPoint(target)
 			if err != nil {
 				klog.ErrorS(err, "check mountpoint", "mountpoint", target)
-				return false, nil
+				continue
 			}
 			if !notMnt {
 				klog.InfoS("Successfully mounted", "mountpoint", target)
-				return true, nil
-			}
-			return false, nil
-		}
-	})
-
-	if err == nil {
-		return nil
-	}
-
-	if wait.Interrupted(err) {
-		// terminate ossfs process when timeout
-		terr := cmd.Process.Signal(syscall.SIGTERM)
-		if terr != nil {
-			klog.ErrorS(err, "Failed to terminate ossfs", "pid", pid)
-		}
-		select {
-		case <-ossfsExited:
-		case <-time.After(time.Second * 2):
-			kerr := cmd.Process.Kill()
-			if kerr != nil && errors.Is(kerr, os.ErrProcessDone) {
-				klog.ErrorS(err, "Failed to kill ossfs", "pid", pid)
+				return nil
 			}
 		}
 	}
-	return err
 }
 
 func (h *Driver) Init() {}
@@ -153,7 +145,7 @@ func (h *Driver) Terminate() {
 		if err != nil {
 			klog.ErrorS(err, "Failed to terminate ossfs", "pid", key)
 		}
-		klog.V(4).InfoS("Sended sigterm", "pid", key)
+		klog.V(4).InfoS("Sent sigterm", "pid", key)
 		return true
 	})
 	// wait all ossfs processes to exit


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

PollInfiniteWithContext is deprecated, avoid using it, and also the code is simpler, able to capture ossfs exit just before timeout.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
