### PR TITLE
Cleanup all non-constant printf format string

### DIFF
--- a/pkg/disk/bdfcheck.go
+++ b/pkg/disk/bdfcheck.go
@@ -95,7 +95,6 @@ func BdfHealthCheck() {
 // record events if bdf hang;
 func notifyBdfHang(recorder record.EventRecorder) {
 	errMsg := fmt.Sprintf("Find BDF Hang in Node %s", GlobalConfigVar.NodeID)
-	klog.Errorf(errMsg)
 	utils.CreateEvent(recorder, ObjReference, v1.EventTypeWarning, BdfVolumeHang, errMsg)
 	DingTalk(errMsg)
 }
@@ -106,12 +105,10 @@ func checkDiskUnused(recorder record.EventRecorder) {
 	deviceList, err := getDiskUnUsedAndAddTag()
 	if err != nil && len(deviceList) == 0 {
 		errMsg := fmt.Sprintf("Get UnUsed BDF Device in Node %s, with error: %v", GlobalConfigVar.NodeID, err)
-		klog.Warningf(errMsg)
 		utils.CreateEvent(recorder, ObjReference, v1.EventTypeWarning, BdfVolumeUnUsed, errMsg)
 		DingTalk(errMsg)
 	} else if err != nil && len(deviceList) != 0 {
 		errMsg := fmt.Sprintf("Get UnUsed BDF Device in Node %s, DeviceList: %v, with message: %v", GlobalConfigVar.NodeID, deviceList, err)
-		klog.Warningf(errMsg)
 		utils.CreateEvent(recorder, ObjReference, v1.EventTypeWarning, BdfVolumeUnUsed, errMsg)
 		DingTalk(errMsg)
 	}

--- a/pkg/disk/nodeserver.go
+++ b/pkg/disk/nodeserver.go
@@ -777,7 +777,7 @@ func (ns *nodeServer) NodeUnstageVolume(ctx context.Context, req *csi.NodeUnstag
 	if msgLog == "" {
 		klog.Infof("NodeUnstageVolume: Unmount TargetPath successful, target %v, volumeId: %s", targetPath, req.VolumeId)
 	} else {
-		klog.Infof(msgLog)
+		klog.Info(msgLog)
 	}
 
 	if IsVFNode() {
@@ -1017,7 +1017,7 @@ func (ns *nodeServer) unmountStageTarget(targetPath string) error {
 		msgLog = fmt.Sprintf("unmountStageTarget: Path %s doesn't exist", targetPath)
 	}
 
-	klog.Infof(msgLog)
+	klog.Info(msgLog)
 	return nil
 }
 

--- a/pkg/disk/utils.go
+++ b/pkg/disk/utils.go
@@ -562,7 +562,7 @@ func getDiskVolumeOptions(req *csi.CreateVolumeRequest) (*diskVolumeArgs, error)
 	// disk Type
 	diskType, err := validateDiskType(volOptions)
 	if err != nil {
-		return nil, fmt.Errorf("Illegal required parameter type: " + volOptions["type"])
+		return nil, fmt.Errorf("illegal required parameter type: %s", volOptions["type"])
 	}
 	diskVolArgs.Type = diskType
 	pls, err := validateDiskPerformanceLevel(volOptions)
@@ -709,11 +709,11 @@ func validateDiskType(opts map[string]string) (diskType []Category, err error) {
 		if _, ok := AllCategories[c]; ok {
 			diskType = append(diskType, c)
 		} else {
-			return nil, fmt.Errorf("Illegal required parameter type: " + cusType)
+			return nil, fmt.Errorf("illegal required parameter type: %s", cusType)
 		}
 	}
 	if len(diskType) == 0 {
-		return diskType, fmt.Errorf("Illegal required parameter type: " + opts["type"])
+		return diskType, fmt.Errorf("illegal required parameter type: %s", opts["type"])
 	}
 	return
 }

--- a/pkg/ens/nodeserver.go
+++ b/pkg/ens/nodeserver.go
@@ -258,9 +258,7 @@ func (ns *nodeServer) NodeUnpublishVolume(ctx context.Context, req *csi.NodeUnpu
 		// Block device
 		if !utils.IsDir(targetPath) && strings.HasPrefix(targetPath, BLOCK_VOLUME_PREFIX) {
 			if removeErr := os.Remove(targetPath); removeErr != nil {
-				err := fmt.Errorf("NodeUnpublishVolume: VolumeId: %s, Could not remove mount block target %s with error %v", req.VolumeId, targetPath, removeErr)
-				klog.Error(err.Error())
-				return nil, status.Errorf(codes.Internal, err.Error())
+				return nil, status.Errorf(codes.Internal, "NodeUnpublishVolume: VolumeId: %s, Could not remove mount block target %s with error %v", req.VolumeId, targetPath, removeErr)
 			}
 			klog.Infof("NodeUnpublishVolume: %s is block volume and is removed successful", targetPath)
 			return &csi.NodeUnpublishVolumeResponse{}, nil
@@ -514,7 +512,7 @@ func (ns *nodeServer) NodeUnstageVolume(ctx context.Context, req *csi.NodeUnstag
 	if msgLog == "" {
 		klog.Infof("NodeUnstageVolume: Unmount TargetPath successful, target %v, volumeId: %s", targetPath, req.VolumeId)
 	} else {
-		klog.Infof(msgLog)
+		klog.Info(msgLog)
 	}
 
 	// Do detach if ADController disable

--- a/pkg/ens/utils.go
+++ b/pkg/ens/utils.go
@@ -82,7 +82,7 @@ func ValidateCreateVolumeParams(params map[string]string) (*DiskParams, error) {
 				if _, ok := ENSDiskTypeMap[cusType]; ok {
 					orderedList = append(orderedList, cusType)
 				} else {
-					return &DiskParams{}, fmt.Errorf("ValidateCreateVolumeParams: Illegal required parameter type: " + cusType)
+					return &DiskParams{}, fmt.Errorf("ValidateCreateVolumeParams: Illegal required parameter type: %s", cusType)
 				}
 			}
 			diskType = strings.Join(orderedList, ",")
@@ -94,7 +94,7 @@ func ValidateCreateVolumeParams(params map[string]string) (*DiskParams, error) {
 		}
 	}
 	if diskType == "" {
-		return &DiskParams{}, fmt.Errorf("ValidateCreateVolumeParams: Illegal required parameter type: " + params["type"])
+		return &DiskParams{}, fmt.Errorf("ValidateCreateVolumeParams: Illegal required parameter type: %s", params["type"])
 	}
 	dp := &DiskParams{
 		RegionID:        regionID,
@@ -330,9 +330,7 @@ func detachDisk(diskID, nodeID string) error {
 					break
 				}
 				if i == 24 {
-					errMsg := fmt.Sprintf("DetachDisk: Detaching Disk %s with timeout", diskID)
-					klog.Errorf(errMsg)
-					return fmt.Errorf(errMsg)
+					return fmt.Errorf("DetachDisk: Detaching Disk %s with timeout", diskID)
 				}
 				time.Sleep(2000 * time.Millisecond)
 			}

--- a/pkg/nas/nodeserver.go
+++ b/pkg/nas/nodeserver.go
@@ -130,7 +130,7 @@ const (
 func validateNodePublishVolumeRequest(req *csi.NodePublishVolumeRequest) error {
 	valid, err := utils.ValidatePath(req.GetTargetPath())
 	if !valid {
-		return status.Errorf(codes.InvalidArgument, err.Error())
+		return status.Error(codes.InvalidArgument, err.Error())
 	}
 	return nil
 }
@@ -400,7 +400,7 @@ func (ns *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 
 	//mount nas client
 	if err := doMount(ns.mounter, opt, mountPath, req.VolumeId, podUID); err != nil {
-		return nil, status.Errorf(codes.Internal, err.Error())
+		return nil, status.Error(codes.Internal, err.Error())
 	}
 	if opt.MountProtocol == "efc" {
 		if strings.Contains(opt.Server, ".nas.aliyuncs.com") {
@@ -443,8 +443,7 @@ func (ns *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 	// check mount
 	notMounted, err = ns.mounter.IsLikelyNotMountPoint(mountPath)
 	if err != nil {
-		klog.Errorf("check mount point %s: %v", mountPath, err)
-		return &csi.NodePublishVolumeResponse{}, status.Errorf(codes.Internal, err.Error())
+		return &csi.NodePublishVolumeResponse{}, status.Errorf(codes.Internal, "check mount point %s: %v", mountPath, err)
 	}
 	if notMounted {
 		return nil, errors.New("Check mount fail after mount:" + mountPath)
@@ -557,7 +556,7 @@ func (ns *nodeServer) isLosetupUsed(lockFile string, opt *Options, volumeID stri
 func validateNodeUnpublishVolumeRequest(req *csi.NodeUnpublishVolumeRequest) error {
 	valid, err := utils.ValidatePath(req.GetTargetPath())
 	if !valid {
-		return status.Errorf(codes.InvalidArgument, err.Error())
+		return status.Error(codes.InvalidArgument, err.Error())
 	}
 	return nil
 }

--- a/pkg/nas/subpath_controller.go
+++ b/pkg/nas/subpath_controller.go
@@ -223,7 +223,7 @@ func (cs *subpathController) DeleteVolume(ctx context.Context, req *csi.DeleteVo
 	// If StorageClass not found, always archive on delete.
 	sc, err := cs.config.KubeClient.StorageV1().StorageClasses().Get(ctx, pv.Spec.StorageClassName, metav1.GetOptions{})
 	if err != nil && !apierrors.IsNotFound(err) {
-		return nil, status.Errorf(codes.Internal, err.Error())
+		return nil, status.Errorf(codes.Internal, "failed to get storage class %s: %v", pv.Spec.StorageClassName, err)
 	}
 	archive := true
 	if sc != nil {

--- a/pkg/oss/controllerserver.go
+++ b/pkg/oss/controllerserver.go
@@ -148,7 +148,7 @@ func (cs *controllerServer) ControllerPublishVolume(ctx context.Context, req *cs
 	}
 	// options validation
 	if err := checkOssOptions(opts); err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, err.Error())
+		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
 	// Skip controller publish for PVs with attribute direct=true.
 	// The actual mounting of these volumes will be handled by rund.

--- a/pkg/oss/nodeserver.go
+++ b/pkg/oss/nodeserver.go
@@ -85,7 +85,7 @@ func (ns *nodeServer) NodeGetCapabilities(ctx context.Context, req *csi.NodeGetC
 func validateNodePublishVolumeRequest(req *csi.NodePublishVolumeRequest) error {
 	valid, err := utils.ValidatePath(req.GetTargetPath())
 	if !valid {
-		return status.Errorf(codes.InvalidArgument, err.Error())
+		return status.Error(codes.InvalidArgument, err.Error())
 	}
 	return nil
 }
@@ -119,7 +119,7 @@ func (ns *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 	}
 	// options validation
 	if err := checkOssOptions(opts); err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, err.Error())
+		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
 
 	switch opts.AuthType {
@@ -231,14 +231,14 @@ func checkOssOptions(opt *Options) error {
 	}
 
 	if !strings.HasPrefix(opt.Path, "/") {
-		return WrapOssError(PathError, "start with "+opt.Path+", should start with /")
+		return WrapOssError(PathError, "start with %s, should start with /", opt.Path)
 	}
 
 	switch opt.AuthType {
 	case mounter.AuthTypeSTS:
 	case mounter.AuthTypeRRSA:
 		if err := checkRRSAParams(opt); err != nil {
-			return WrapOssError(AuthError, err.Error())
+			return WrapOssError(AuthError, "%v", err)
 		}
 	case mounter.AuthTypeCSS:
 		if opt.SecretProviderClass == "" {
@@ -269,7 +269,7 @@ func checkOssOptions(opt *Options) error {
 func validateNodeUnpublishVolumeRequest(req *csi.NodeUnpublishVolumeRequest) error {
 	valid, err := utils.ValidatePath(req.GetTargetPath())
 	if !valid {
-		return status.Errorf(codes.InvalidArgument, err.Error())
+		return status.Error(codes.InvalidArgument, err.Error())
 	}
 	return nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This should avoid any accidental injection of format specifier.

- log before event is not necessary. EventRecorder will do so.
- log before return GRPC error is not necessary. We have interceptor to do so.

resolves all warnings like:
    non-constant format string in call to k8s.io/klog/v2.Errorf

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
