### PR TITLE
fix(build): mount.nfs failed

### DIFF
--- a/build/gather-node-deps.sh
+++ b/build/gather-node-deps.sh
@@ -5,6 +5,7 @@ set -e
 mkdir -p /staging-node/var/lib/dpkg/status.d
 
 DEPS=(
+    /etc/netconfig
     /etc/mke2fs.conf /sbin/{fsck,mkfs,mount,umount}.{ext{2,3,4},xfs,nfs}
     /usr/bin/{mount,umount,lspci,lsof,chmod,grep,tail,nsenter}
     /usr/sbin/{fsck,mkfs,sfdisk,losetup,blockdev}

--- a/hack/base-image-deps.txt
+++ b/hack/base-image-deps.txt
@@ -29,6 +29,7 @@ libselinux1         3.4-1+b6          deb
 libsmartcols1       2.38.1-5+deb12u2  deb     
 libssl3             3.0.15-1~deb12u1  deb     
 libtinfo6           6.4-4             deb     
+libtirpc-common     1.3.3+ds-1        deb     
 libtirpc3           1.3.3+ds-1        deb     
 libudev1            252.31-1~deb12u1  deb     
 liburcu8            0.13.2-1          deb     


### PR DESCRIPTION
Missing /etc/netconfig causes 'mount.nfs: Protocol not supported' error.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

#### What this PR does / why we need it:

Missing /etc/netconfig causes 'mount.nfs: Protocol not supported' error.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
