### PR TITLE
fixed to expand nas loopdevice file system issue

### DIFF
--- a/pkg/losetup/losetup.go
+++ b/pkg/losetup/losetup.go
@@ -9,14 +9,14 @@ import (
 )
 
 type LoopDevice struct {
-	Name      string `json:"name"`
-	Sizelimit string `json:"sizelimit"`
-	Offset    string `json:"offset"`
-	Autoclear string `json:"autoclear"`
-	RO        string `json:"ro"`
-	BackFile  string `json:"back-file"`
-	Dio       string `json:"dio"`
-	LogSec    string `json:"log-sec"`
+	Name      string      `json:"name"`
+	Sizelimit json.Number `json:"sizelimit"`
+	Offset    json.Number `json:"offset"`
+	Autoclear bool        `json:"autoclear"`
+	RO        bool        `json:"ro"`
+	BackFile  string      `json:"back-file"`
+	Dio       bool        `json:"dio"`
+	LogSec    json.Number `json:"log-sec"`
 }
 
 type option []string

--- a/pkg/nas/nodeserver.go
+++ b/pkg/nas/nodeserver.go
@@ -632,10 +632,11 @@ func (ns *nodeServer) LosetupExpandVolume(req *csi.NodeExpandVolumeRequest) erro
 	// /mnt/nasplugin.alibabacloud.com/6c690876-74aa-46f6-a301-da7f4353665d/pv-losetup/
 	nfsPath := filepath.Join(NasMntPoint, podID, pvName)
 	imgFile := filepath.Join(nfsPath, LoopImgFile)
+	volSizeBytes := req.GetCapacityRange().GetRequiredBytes()
+	klog.Infof("NodeExpandVolume: expected expand %q to %vB", imgFile, volSizeBytes)
+
 	if utils.IsFileExisting(imgFile) {
-		volSizeBytes := req.GetCapacityRange().GetRequiredBytes()
-		err := losetup.TruncateFile(imgFile, volSizeBytes)
-		if err != nil {
+		if err := os.Truncate(imgFile, volSizeBytes); err != nil {
 			klog.Errorf("NodeExpandVolume: nas resize img file error %v", err)
 			return fmt.Errorf("NodeExpandVolume: nas resize img file error, %v", err)
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Fixed losetup command output, Unmarshal failure issue

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
