### PR TITLE
disk: wait for device to appear on attach

### DIFF
--- a/pkg/disk/cloud.go
+++ b/pkg/disk/cloud.go
@@ -42,6 +42,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	v1 "k8s.io/api/core/v1"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog/v2"
@@ -244,15 +245,15 @@ func (ad *DiskAttachDetach) attachDisk(ctx context.Context, diskID, nodeID strin
 
 		// BDF Disk Logical
 		if IsVFNode() && len(devicePaths) == 0 {
-			var bdf string
-			if bdf, err = bindBdfDisk(disk.DiskId); err != nil {
+			bdf, err := bindBdfDisk(disk.DiskId)
+			if err != nil {
 				if err := unbindBdfDisk(disk.DiskId); err != nil {
 					return "", status.Errorf(codes.Aborted, "NodeStageVolume: failed to detach bdf: %v", err)
 				}
 				return "", status.Errorf(codes.Aborted, "NodeStageVolume: failed to attach bdf: %v", err)
 			}
 
-			_, err := DefaultDeviceManager.GetRootBlockByVolumeID(diskID)
+			_, err = DefaultDeviceManager.GetRootBlockByVolumeID(diskID)
 			deviceName := ""
 			if err != nil && bdf != "" {
 				deviceName, err = GetDeviceByBdf(bdf, true)
@@ -291,7 +292,10 @@ func (ad *DiskAttachDetach) attachDisk(ctx context.Context, diskID, nodeID strin
 			return devicePaths[0], nil
 		}
 		// device count is not expected, should retry (later by detaching and attaching again)
-		return "", status.Error(codes.Aborted, "AttachDisk: after attaching to disk, but fail to get mounted device, will retry later")
+		err = utilerrors.NewAggregate([]error{
+			err, fmt.Errorf("unexpected new devices: %v", devicePaths),
+		})
+		return "", status.Errorf(codes.Aborted, "AttachDisk: disk attached, but failed to find device: %v", err)
 	}
 
 	klog.Infof("AttachDisk: Successful attach disk %s to node %s", diskID, nodeID)

--- a/pkg/disk/cloud.go
+++ b/pkg/disk/cloud.go
@@ -234,7 +234,7 @@ func (ad *DiskAttachDetach) attachDisk(ctx context.Context, diskID, nodeID strin
 
 	// step 5: diff device with previous files under /dev
 	if fromNode {
-		device, err := DefaultDeviceManager.GetDeviceByVolumeID(diskID)
+		device, err := DefaultDeviceManager.WaitDevice(ctx, diskID)
 		if err == nil {
 			klog.Infof("AttachDisk: Successful attach disk %s to node %s device %s by DiskID/Device", diskID, nodeID, device)
 			return device, nil

--- a/pkg/disk/nodeserver.go
+++ b/pkg/disk/nodeserver.go
@@ -548,7 +548,7 @@ func (ns *nodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVol
 	// Step 4 Attach volume
 	defaultErrCode := codes.Internal
 	if GlobalConfigVar.ADControllerEnable || isMultiAttach {
-		device, err = DefaultDeviceManager.GetDeviceByVolumeID(req.GetVolumeId())
+		device, err = DefaultDeviceManager.WaitDevice(ctx, req.GetVolumeId())
 		if err != nil {
 			if IsVFNode() {
 				bdf, err := bindBdfDisk(req.GetVolumeId())


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup
/kind flake

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Even after OpenAPI returns Attached status, the device may not be available in OS immediately. We wait for 10s to reduce noisy error events.


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
Reduce flakes in csi-sanity, which will not retry.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
