### PR TITLE
oss: use stat to detect mountpoint

### DIFF
--- a/pkg/mounter/proxy_mounter.go
+++ b/pkg/mounter/proxy_mounter.go
@@ -37,7 +37,7 @@ func (m *ProxyMounter) MountWithSecrets(source, target, fstype string, options [
 	if err != nil {
 		return fmt.Errorf("failed to mount: %w", err)
 	}
-	notMnt, err := mountutils.IsNotMountPoint(m.Interface, target)
+	notMnt, err := m.IsLikelyNotMountPoint(target)
 	if err != nil {
 		return err
 	}

--- a/pkg/oss/nodeserver.go
+++ b/pkg/oss/nodeserver.go
@@ -102,7 +102,7 @@ func (ns *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 		return nil, err
 	}
 	// check if already mounted
-	notMnt, err := isNotMountPoint(ns.rawMounter, targetPath, true)
+	notMnt, err := isNotMountPoint(ns.rawMounter, targetPath)
 	if err != nil {
 		return nil, err
 	}
@@ -192,7 +192,7 @@ func (ns *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 	// When work as csi nodeserver, mount on the attach path under /run/fuse.ossfs and then perform the bind mount.
 	// check whether the attach path is mounted
 	attachPath := mounter.GetOssfsAttachPath(req.VolumeId)
-	notMnt, err = isNotMountPoint(ns.rawMounter, attachPath, false)
+	notMnt, err = isNotMountPoint(ns.rawMounter, attachPath)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/oss/utils.go
+++ b/pkg/oss/utils.go
@@ -322,12 +322,8 @@ func parseOtherOpts(otherOpts string) (mountOptions []string, err error) {
 	return mountOptions, nil
 }
 
-func isNotMountPoint(mounter mountutils.Interface, target string, expensive bool) (notMnt bool, err error) {
-	if expensive {
-		notMnt, err = mountutils.IsNotMountPoint(mounter, target)
-	} else {
-		notMnt, err = mounter.IsLikelyNotMountPoint(target)
-	}
+func isNotMountPoint(mounter mountutils.Interface, target string) (notMnt bool, err error) {
+	notMnt, err = mounter.IsLikelyNotMountPoint(target)
 	if err != nil {
 		if os.IsNotExist(err) {
 			if err := os.MkdirAll(target, os.ModePerm); err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

mountutils.IsNotMountPoint is deprecated.

IsLikelyNotMountPoint only fails if it is bind mount within the same device. We don't have such case.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
