### PR TITLE
disk: refactor determine ZoneID

### DIFF
--- a/build/csi-agent/Dockerfile
+++ b/build/csi-agent/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM registry-cn-hangzhou.ack.aliyuncs.com/dev/golang:1.22.9 as builder
+FROM --platform=$BUILDPLATFORM registry-cn-hangzhou.ack.aliyuncs.com/dev/golang:1.23.9 as builder
 WORKDIR /src
 ARG TARGETARCH
 ARG TARGETOS

--- a/build/mount-proxy/Dockerfile
+++ b/build/mount-proxy/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM registry-cn-hangzhou.ack.aliyuncs.com/dev/golang:1.22.9 as builder
+FROM --platform=$BUILDPLATFORM registry-cn-hangzhou.ack.aliyuncs.com/dev/golang:1.23.9 as builder
 WORKDIR /src
 ARG TARGETARCH
 ARG TARGETOS

--- a/build/multi/Dockerfile.multi
+++ b/build/multi/Dockerfile.multi
@@ -1,5 +1,5 @@
 # syntax=registry-cn-hangzhou.ack.aliyuncs.com/dev/dockerfile:1.6
-FROM --platform=$BUILDPLATFORM registry-cn-hangzhou.ack.aliyuncs.com/dev/golang:1.22.9 as build
+FROM --platform=$BUILDPLATFORM registry-cn-hangzhou.ack.aliyuncs.com/dev/golang:1.23.9 as build
 WORKDIR /go/src/github.com/kubernetes-sigs/alibaba-cloud-csi-driver
 ARG TARGETARCH
 ARG TARGETOS

--- a/build/multi/Dockerfile.multi.asi
+++ b/build/multi/Dockerfile.multi.asi
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.4
-FROM --platform=$BUILDPLATFORM golang:1.22.9 as build
+FROM --platform=$BUILDPLATFORM golang:1.23.9 as build
 WORKDIR /go/src/github.com/kubernetes-sigs/alibaba-cloud-csi-driver
 COPY . .
 RUN --mount=type=ssh \

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kubernetes-sigs/alibaba-cloud-csi-driver
 
-go 1.22.9
+go 1.23.9
 
 require (
 	github.com/alibabacloud-go/darabonba-openapi v0.1.16

--- a/pkg/cloud/metadata/ack_cluster_profile_test.go
+++ b/pkg/cloud/metadata/ack_cluster_profile_test.go
@@ -17,6 +17,7 @@ var testProfile = v1.ConfigMap{
 	Data: map[string]string{
 		"clusterid": "c12345678",
 		"uid":       "123456789",
+		"vsw-zone":  "vsw-aaaaaaaaaaa:cn-beijing-i,vsw-bbbbbbbbbbbb:cn-beijing-l",
 	},
 }
 
@@ -28,8 +29,9 @@ func TestGetClusterProfile(t *testing.T) {
 	assert.NoError(t, err)
 
 	expectedValues := map[MetadataKey]string{
-		AccountID: "123456789",
-		ClusterID: "c12345678",
+		AccountID:       "123456789",
+		ClusterID:       "c12345678",
+		DataPlaneZoneID: "cn-beijing-i",
 	}
 	for k, v := range expectedValues {
 		t.Log(k, v)

--- a/pkg/cloud/metadata/metadata_test.go
+++ b/pkg/cloud/metadata/metadata_test.go
@@ -55,6 +55,7 @@ func TestCreateK8s(t *testing.T) {
 		m.EnableKubernetes(client)
 		assert.Equal(t, "cn-beijing", MustGet(m, RegionID))
 		assert.Equal(t, "c12345678", MustGet(m, ClusterID))
+		assert.Equal(t, "cn-beijing-i", MustGet(m, DataPlaneZoneID))
 	})
 }
 

--- a/pkg/disk/controllerserver.go
+++ b/pkg/disk/controllerserver.go
@@ -30,6 +30,7 @@ import (
 	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/requests"
 	"github.com/aliyun/alibaba-cloud-sdk-go/services/ecs"
 	"github.com/container-storage-interface/spec/lib/go/csi"
+	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/cloud/metadata"
 	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/common"
 	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/disk/desc"
 	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/disk/waitstatus"
@@ -51,6 +52,7 @@ import (
 type controllerServer struct {
 	recorder       record.EventRecorder
 	ad             DiskAttachDetach
+	meta           metadata.MetadataProvider
 	snapshotWaiter waitstatus.StatusWaiter[ecs.Snapshot]
 	common.GenericControllerServer
 }
@@ -100,10 +102,11 @@ func newSnapshotStatusWaiter() waitstatus.StatusWaiter[ecs.Snapshot] {
 }
 
 // NewControllerServer is to create controller server
-func NewControllerServer(csiCfg utils.Config) csi.ControllerServer {
+func NewControllerServer(csiCfg utils.Config, m metadata.MetadataProvider) csi.ControllerServer {
 	waiter, batcher := newBatcher(false)
 	c := &controllerServer{
 		recorder: utils.NewEventRecorder(),
+		meta:     m,
 		ad: DiskAttachDetach{
 			waiter:  waiter,
 			batcher: batcher,
@@ -139,9 +142,6 @@ func (cs *controllerServer) ControllerGetCapabilities(ctx context.Context, req *
 	}, nil
 }
 
-// the map of multizone and index
-var storageClassZonePos = map[string]int{}
-
 // provisioner: create/delete disk
 func (cs *controllerServer) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest) (*csi.CreateVolumeResponse, error) {
 	logger := klog.FromContext(ctx)
@@ -163,7 +163,7 @@ func (cs *controllerServer) CreateVolume(ctx context.Context, req *csi.CreateVol
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
 
-	diskVol, err := getDiskVolumeOptions(req)
+	diskVol, err := getDiskVolumeOptions(req, cs.meta)
 	if err != nil {
 		klog.Errorf("CreateVolume: error parameters from input: %v, with error: %v", req.Name, err)
 		return nil, status.Errorf(codes.InvalidArgument, "Invalid parameters from input: %v, with error: %v", req.Name, err)

--- a/pkg/disk/controllerserver.go
+++ b/pkg/disk/controllerserver.go
@@ -163,7 +163,7 @@ func (cs *controllerServer) CreateVolume(ctx context.Context, req *csi.CreateVol
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
 
-	diskVol, err := getDiskVolumeOptions(req, cs.meta)
+	diskVol, err := getDiskVolumeOptions(req, cs.meta, cs.recorder)
 	if err != nil {
 		klog.Errorf("CreateVolume: error parameters from input: %v, with error: %v", req.Name, err)
 		return nil, status.Errorf(codes.InvalidArgument, "Invalid parameters from input: %v, with error: %v", req.Name, err)

--- a/pkg/disk/disk.go
+++ b/pkg/disk/disk.go
@@ -121,7 +121,7 @@ func NewDriver(m metadata.MetadataProvider, endpoint string, serviceType utils.S
 	var servers common.Servers
 	servers.IdentityServer = NewIdentityServer()
 	if serviceType&utils.Controller != 0 {
-		servers.ControllerServer = NewControllerServer(csiCfg)
+		servers.ControllerServer = NewControllerServer(csiCfg, m)
 	}
 	if serviceType&utils.Node != 0 {
 		servers.NodeServer = NewNodeServer(m)

--- a/pkg/disk/utils.go
+++ b/pkg/disk/utils.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"iter"
 	"maps"
 	"net"
 	"net/http"
@@ -406,24 +407,24 @@ func removeVolumeConfig(volumeID string) error {
 	return nil
 }
 
-// pickZone selects 1 zone given topology requirement.
-// if not found, empty string is returned.
-func pickZone(requirement *csi.TopologyRequirement) string {
-	if requirement == nil {
-		return ""
-	}
-	for _, topo := range [][]*csi.Topology{requirement.GetPreferred(), requirement.GetRequisite()} {
-		for _, topology := range topo {
-			segs := topology.GetSegments()
-			for _, key := range []string{TopologyZoneKey, common.TopologyKeyZone} {
-				zone, exists := segs[key]
-				if exists {
-					return zone
+// iterZone iterates zones from given topology requirement.
+func iterZone(requirement *csi.TopologyRequirement) iter.Seq[string] {
+	return func(yield func(string) bool) {
+		if requirement == nil {
+			return
+		}
+		for _, topo := range [][]*csi.Topology{requirement.Preferred, requirement.Requisite} {
+			for _, topology := range topo {
+				segs := topology.GetSegments()
+				for _, key := range []string{TopologyZoneKey, common.TopologyKeyZone} {
+					zone, exists := segs[key]
+					if exists && !yield(zone) {
+						return
+					}
 				}
 			}
 		}
 	}
-	return ""
 }
 
 func parseTags(params map[string]string) (map[string]string, error) {
@@ -458,36 +459,64 @@ func parseTags(params map[string]string) (map[string]string, error) {
 	return seenTags, nil
 }
 
+var ErrUnknownZone = errors.New("unknown zone")
+
+func getZone(req *csi.CreateVolumeRequest) (string, error) {
+	volOptions := req.GetParameters()
+	zoneID, ok := volOptions[ZoneID]
+	if !ok {
+		zoneID, ok = volOptions[strings.ToLower(ZoneID)]
+	}
+	var paramZone sets.Set[string]
+	if ok {
+		paramZone = sets.New(strings.Split(zoneID, ",")...)
+	}
+
+	// We use the first zone in the intersection of AccessibilityRequirements and Parameter.
+	// New user is encouraged to use standard AccessibilityRequirements.
+	// For this to work on Kubernetes, --strict-topology needs to be set on external-provisioner
+	// to ensure only the selected node is passed in AccessibilityRequirements.
+
+	// Use set instead of slice because we have instanceID in topology,
+	// so the same zone may appears multiple times.
+	missedZones := sets.New[string]()
+	for zone := range iterZone(req.AccessibilityRequirements) {
+		if paramZone == nil {
+			return zone, nil
+		} else if paramZone.Has(zone) {
+			return zone, nil
+		}
+		missedZones.Insert(zone)
+	}
+
+	if req.AccessibilityRequirements.GetRequisite() != nil {
+		// CSI Spec:
+		// If the list of requisite topologies is specified and the SP is
+		// unable to to make the provisioned volume available from any of the
+		// requisite topologies it MUST fail the CreateVolume call.
+		if len(missedZones) == 0 {
+			return "", fmt.Errorf("no zone info found in accessibility requirements")
+		} else {
+			return "", fmt.Errorf("conflicting zone, parameters specified: %s, accessibility requires: %v", zoneID, sets.List(missedZones))
+		}
+	}
+
+	// Best effort to pick what we have
+	for zone := range paramZone {
+		// Use a random zone from parameters
+		return zone, nil
+	}
+	return "", ErrUnknownZone
+}
+
 // getDiskVolumeOptions
-func getDiskVolumeOptions(req *csi.CreateVolumeRequest) (*diskVolumeArgs, error) {
+func getDiskVolumeOptions(req *csi.CreateVolumeRequest, m metadata.MetadataProvider) (*diskVolumeArgs, error) {
 	var ok bool
 	diskVolArgs := &diskVolumeArgs{
 		DiskTags: map[string]string{},
 	}
 	volOptions := req.GetParameters()
 
-	if diskVolArgs.ZoneID, ok = volOptions[ZoneID]; !ok {
-		if diskVolArgs.ZoneID, ok = volOptions[strings.ToLower(ZoneID)]; !ok {
-			// topology aware feature to get zoneid
-			diskVolArgs.ZoneID = pickZone(req.GetAccessibilityRequirements())
-			if diskVolArgs.ZoneID == "" {
-				klog.Errorf("CreateVolume: Can't get topology info , please check your setup or set zone ID in storage class. Use zone from Meta service: %s", req.Name)
-				diskVolArgs.ZoneID, _ = utils.GetMetaData(ZoneIDTag)
-			}
-		}
-	}
-	// Support Multi zones if set;
-	zoneIDStr := diskVolArgs.ZoneID
-	zones := strings.Split(zoneIDStr, ",")
-	zoneNum := len(zones)
-	if zoneNum > 1 {
-		if _, ok := storageClassZonePos[zoneIDStr]; !ok {
-			storageClassZonePos[zoneIDStr] = 0
-		}
-		zoneIndex := storageClassZonePos[zoneIDStr] % zoneNum
-		diskVolArgs.ZoneID = zones[zoneIndex]
-		storageClassZonePos[zoneIDStr]++
-	}
 	diskVolArgs.RegionID, ok = volOptions["regionId"]
 	if !ok {
 		diskVolArgs.RegionID = GlobalConfigVar.Region
@@ -516,8 +545,20 @@ func getDiskVolumeOptions(req *csi.CreateVolumeRequest) (*diskVolumeArgs, error)
 	}
 
 	if slices.ContainsFunc(diskType, func(t Category) bool { return !AllCategories[t].Regional }) {
+		diskVolArgs.ZoneID, err = getZone(req)
+		if err != nil {
+			if err == ErrUnknownZone {
+				klog.V(1).InfoS("No zone info. Fallback to metadata", "name", req.Name)
+				diskVolArgs.ZoneID, err = metadata.GetFallbackZoneID(m)
+				if err != nil {
+					return nil, fmt.Errorf("no zone info, and failed to get zone id from metadata: %w", err)
+				}
+			} else {
+				return nil, err
+			}
+		}
 		if diskVolArgs.ZoneID == "" {
-			return nil, fmt.Errorf("CreateVolume: Can't get zone ID from node topology info or storage class topology or metadataserver, req: %v", volOptions)
+			return nil, fmt.Errorf("empty zone ID is invalid")
 		}
 	}
 	diskVolArgs.Type = diskType


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Pick the first from the intersection of parameter and AccessibilityRequirements.

Ensure error is returned when parameter and AccessibilityRequirements conflicts, or when unknown topology is specified.

fix possible race in storageClassZonePos, it is now removed. We will respect the order from AccessibilityRequirements, falling back to random.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Replaces #1375 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
We now returns error when zoneID in parameter and AccessibilityRequirements conflicts, or when unknown topology is specified.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
