### PR TITLE
nas: make 'standard' the default NAS file system type

### DIFF
--- a/pkg/nas/cloud/utils.go
+++ b/pkg/nas/cloud/utils.go
@@ -14,10 +14,9 @@ func GetFilesystemTypeByMountTargetDomain(domain string) string {
 		return FilesystemTypeExtreme
 	case strings.HasSuffix(domain, "cpfs.nas.aliyuncs.com"):
 		return FilesystemTypeCpfs
-	case strings.HasSuffix(domain, "nas.aliyuncs.com"):
-		return FilesystemTypeStandard
 	default:
-		return ""
+		// *.nas.aliyuncs.com
+		return FilesystemTypeStandard
 	}
 }
 

--- a/pkg/nas/cloud/utils_test.go
+++ b/pkg/nas/cloud/utils_test.go
@@ -1,15 +1,10 @@
 package cloud
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
-)
 
-func TestGetFilesystemTypeByMountTargetDomain(t *testing.T) {
-	t.Parallel()
-	actual := GetFilesystemTypeByMountTargetDomain("")
-	assert.Empty(t, actual)
-}
+	"github.com/stretchr/testify/assert"
+)
 
 func TestGetFilesystemTypeByMountTargetDomainExtreme(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

In private cloud environments, NAS service domain names do not follow the `nas.aliyuncs.com` format. This leads to the file system type being incorrectly determined in these private clouds.

To resolve this for private cloud use cases, this patch makes 'standard' the default NAS file system type.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
none
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/cc @AlbeeSo 