### PR TITLE
disk: try force attach if the same disk is already detaching

### DIFF
--- a/pkg/disk/category.go
+++ b/pkg/disk/category.go
@@ -45,6 +45,7 @@ type CategoryDesc struct {
 	SingleInstance          bool // Cannot be attached to another instance once it is attached.
 	Regional                bool
 	SnapshotConsistentGroup bool
+	ForceAttach             bool
 }
 
 var AllCategories = map[Category]CategoryDesc{
@@ -99,6 +100,7 @@ var AllCategories = map[Category]CategoryDesc{
 		Size:                  SizeRange{Min: 10, Max: 65536},
 		InstantAccessSnapshot: true,
 		Regional:              true,
+		ForceAttach:           true,
 	},
 
 	// Only available in private cloud


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

In some cases, we cannot detach a disk from ECS, maybe because of
malfunctioning guest OS, or communication issue between control and data plane.
When this happens, we can use force attach to escape to another instance, in
order to recover workload.  The old instance will see I/O error if detach
failed, and the detach will be retried by ECS.

Force attach is currently only possible for regional ESSD, when old and new
instances are in different zone. These restrictions may be lifted in the
future.

For this to work, we rely on KCM to initiate attaching after the first
detaching failed. i.e. Failed detaching will not block next attaching.


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Use force attach when we cannot detach the disk.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
