### PR TITLE
ossfs 1.0: add default option: listobjectsv2

### DIFF
--- a/pkg/mounter/oss/ossfs.go
+++ b/pkg/mounter/oss/ossfs.go
@@ -343,6 +343,10 @@ func (f *fuseOssfs) AddDefaultMountOptions(options []string) []string {
 	}
 
 	// set listobjectsv2
+	// Note: OSS officially recommends using v2 API as the preferred version,
+	// but ossfs hasn't enabled listobjectv2 by default yet.
+	// This is a temporary workaround added by CSI driver.
+	// TODO: Remove this logic when ossfs enables it by default.
 	if _, ok := tm[KeyListObjectsV2]; !ok {
 		options = append(options, "listobjectsv2")
 	}

--- a/pkg/mounter/oss/ossfs.go
+++ b/pkg/mounter/oss/ossfs.go
@@ -303,10 +303,7 @@ func (f *fuseOssfs) getAuthOptions(o *Options, region string) (mountOptions []st
 func (f *fuseOssfs) AddDefaultMountOptions(options []string) []string {
 	defaultOSSFSOptions := os.Getenv("DEFAULT_OSSFS_OPTIONS")
 	if defaultOSSFSOptions != "" {
-		optList := strings.Split(defaultOSSFSOptions, ",")
-		for _, opt := range optList {
-			options = append(options, strings.TrimSpace(opt))
-		}
+		options = append(options, strings.Split(defaultOSSFSOptions, ",")...)
 	}
 
 	alreadySet := false

--- a/pkg/mounter/oss/ossfs.go
+++ b/pkg/mounter/oss/ossfs.go
@@ -301,6 +301,14 @@ func (f *fuseOssfs) getAuthOptions(o *Options, region string) (mountOptions []st
 }
 
 func (f *fuseOssfs) AddDefaultMountOptions(options []string) []string {
+	defaultOSSFSOptions := os.Getenv("DEFAULT_OSSFS_OPTIONS")
+	if defaultOSSFSOptions != "" {
+		optList := strings.Split(defaultOSSFSOptions, ",")
+		for _, opt := range optList {
+			options = append(options, strings.TrimSpace(opt))
+		}
+	}
+
 	alreadySet := false
 	for _, option := range options {
 		if strings.Contains(option, "dbglevel") {
@@ -325,10 +333,6 @@ func (f *fuseOssfs) AddDefaultMountOptions(options []string) []string {
 		options = append(options, fmt.Sprintf("mime=%s", OssfsCsiMimeTypesFilePath))
 	}
 
-	defaultOSSFSOptions := os.Getenv("DEFAULT_OSSFS_OPTIONS")
-	if defaultOSSFSOptions != "" {
-		options = append(options, strings.Split(defaultOSSFSOptions, ",")...)
-	}
 	return options
 }
 

--- a/pkg/mounter/oss/ossfs2.go
+++ b/pkg/mounter/oss/ossfs2.go
@@ -192,13 +192,9 @@ const (
 )
 
 func (f *fuseOssfs2) AddDefaultMountOptions(options []string) []string {
-
 	defaultOSSFSOptions := os.Getenv("DEFAULT_OSSFS2_OPTIONS")
 	if defaultOSSFSOptions != "" {
-		optList := strings.Split(defaultOSSFSOptions, ",")
-		for _, opt := range optList {
-			options = append(options, strings.TrimSpace(opt))
-		}
+		options = append(options, strings.Split(defaultOSSFSOptions, ",")...)
 	}
 
 	tm := map[string]string{}
@@ -206,11 +202,8 @@ func (f *fuseOssfs2) AddDefaultMountOptions(options []string) []string {
 		if option == "" {
 			continue
 		}
-		parts := strings.SplitN(option, "=", 2)
-		if len(parts) == 1 {
-			parts = append(parts, "")
-		}
-		tm[parts[0]] = parts[1]
+		k, v, _ := strings.Cut(option, "=")
+		tm[k] = v
 	}
 
 	// set default log level
@@ -228,7 +221,7 @@ func (f *fuseOssfs2) AddDefaultMountOptions(options []string) []string {
 
 	// set default log dir
 	if _, ok := tm[KeyLogDir]; !ok {
-		options = append(options, fmt.Sprintf("log_dir=%s", "/dev/stdout"))
+		options = append(options, "log_dir=/dev/stdout")
 	}
 
 	return options

--- a/pkg/mounter/oss/ossfs2_test.go
+++ b/pkg/mounter/oss/ossfs2_test.go
@@ -236,7 +236,7 @@ func TestAddDefaultMountOptions_ossfs2(t *testing.T) {
 			name:        "default options",
 			cfglevel:    "",
 			options:     nil,
-			defaultOpts: "others, log_dir=/tmp/ossfs2",
+			defaultOpts: "others,log_dir=/tmp/ossfs2",
 			want:        []string{"others", "log_dir=/tmp/ossfs2", "log_level=info"},
 		},
 	}

--- a/pkg/mounter/oss/ossfs2_test.go
+++ b/pkg/mounter/oss/ossfs2_test.go
@@ -207,37 +207,37 @@ func TestAddDefaultMountOptions_ossfs2(t *testing.T) {
 		{
 			name:    "empty option, empty config",
 			options: []string{"others"},
-			want:    []string{"others", "log_level=info"},
+			want:    []string{"others", "log_level=info", "log_dir=/dev/stdout"},
 		},
 		{
 			name:    "set option",
-			options: []string{"others", "log_level=debug", "others"},
-			want:    []string{"others", "log_level=debug", "others"},
+			options: []string{"others", "log_level=debug", "log_dir=/tmp/ossfs2", "others"},
+			want:    []string{"others", "log_level=debug", "log_dir=/tmp/ossfs2", "others"},
 		},
 		{
 			name:     "set option, set config",
 			cfglevel: "info",
 			options:  []string{"others", "log_level=debug", "others"},
-			want:     []string{"others", "log_level=debug", "others"},
+			want:     []string{"others", "log_level=debug", "others", "log_dir=/dev/stdout"},
 		},
 		{
 			name:     "empty option, set config",
 			cfglevel: "debug",
 			options:  []string{"others"},
-			want:     []string{"others", "log_level=debug"},
+			want:     []string{"others", "log_level=debug", "log_dir=/dev/stdout"},
 		},
 		{
 			name:     "empty option, invalid config",
 			cfglevel: "invalid",
 			options:  []string{"others"},
-			want:     []string{"others", "log_level=info"},
+			want:     []string{"others", "log_level=info", "log_dir=/dev/stdout"},
 		},
 		{
 			name:        "default options",
 			cfglevel:    "",
 			options:     nil,
-			defaultOpts: "others",
-			want:        []string{"log_level=info", "others"},
+			defaultOpts: "others, log_dir=/tmp/ossfs2",
+			want:        []string{"others", "log_dir=/tmp/ossfs2", "log_level=info"},
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/mounter/oss/ossfs_test.go
+++ b/pkg/mounter/oss/ossfs_test.go
@@ -3,7 +3,6 @@ package oss
 import (
 	"context"
 	"fmt"
-	"reflect"
 	"testing"
 
 	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/cloud/metadata"
@@ -59,93 +58,6 @@ func Test_buildAuthSpec_ossfs(t *testing.T) {
 	volumeMount := container.VolumeMounts[len(container.VolumeMounts)-1]
 	assert.Contains(t, "/var/run/secrets/ack.alibabacloud.com/rrsa-tokens", volumeMount.MountPath)
 	assert.Contains(t, "rrsa-oidc-token", volumeMount.Name)
-}
-
-func Test_AddDefaultMountOptions(t *testing.T) {
-	tests := []struct {
-		name        string
-		options     []string
-		dbglevel    string
-		mime        string
-		defaultOpts string
-		want        []string
-	}{
-		{
-			name:     "Debug level not set",
-			options:  []string{},
-			dbglevel: "",
-			mime:     "false",
-			want:     []string{"dbglevel=err"},
-		},
-		{
-			name:     "Debug level set by config",
-			options:  []string{},
-			dbglevel: "warn",
-			mime:     "false",
-			want:     []string{"dbglevel=warn"},
-		},
-		{
-			name:     "Debug level set by mount options",
-			options:  []string{"dbglevel=info"},
-			dbglevel: "warn",
-			mime:     "false",
-			want:     []string{"dbglevel=info"},
-		},
-		{
-			name:     "Invalid debug level",
-			options:  []string{},
-			dbglevel: "unknown",
-			mime:     "false",
-			want:     []string{"dbglevel=err"},
-		},
-		{
-			name:     "Mime support enabled without existing mime.types",
-			options:  []string{},
-			dbglevel: "",
-			mime:     "true",
-			want:     []string{"dbglevel=err", "mime=" + OssfsCsiMimeTypesFilePath},
-		},
-		{
-			name:     "Mime support disabled with existing mime.types",
-			options:  []string{},
-			dbglevel: "",
-			mime:     "false",
-			want:     []string{"dbglevel=err"},
-		},
-		{
-			name:        "Default options",
-			options:     []string{},
-			dbglevel:    "",
-			mime:        "false",
-			defaultOpts: "allow_other,umask=000",
-			want:        []string{"dbglevel=err", "allow_other", "umask=000"},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			f := &fuseOssfs{
-				config: mounterutils.FuseContainerConfig{
-					Dbglevel: tt.dbglevel,
-					Extra: map[string]string{
-						"mime-support": tt.mime,
-					},
-				},
-			}
-			if tt.defaultOpts != "" {
-				t.Setenv("DEFAULT_OSSFS_OPTIONS", tt.defaultOpts)
-			}
-			got := f.AddDefaultMountOptions(tt.options)
-			if len(got) != len(tt.want) {
-				t.Errorf("AddDefaultMountOptions() got = %v, want %v", got, tt.want)
-				return
-			}
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("AddDefaultMountOptions() got = %v, want %v", got, tt.want)
-				return
-			}
-		})
-	}
 }
 
 func TestPrecheckAuthConfig_ossfs(t *testing.T) {

--- a/pkg/mounter/oss/ossfs_test.go
+++ b/pkg/mounter/oss/ossfs_test.go
@@ -561,36 +561,41 @@ func TestAddDefaultMountOptions_ossfs(t *testing.T) {
 		{
 			name:    "empty option, empty config",
 			options: []string{"others"},
-			want:    []string{"others", "dbglevel=err"},
+			want:    []string{"others", "dbglevel=err", "listobjectsv2"},
 		},
 		{
 			name:    "set option",
 			options: []string{"others", "dbglevel=debug", "others"},
-			want:    []string{"others", "dbglevel=debug", "others"},
+			want:    []string{"others", "dbglevel=debug", "others", "listobjectsv2"},
 		},
 		{
 			name:     "set option, set config",
 			cfglevel: "info",
 			options:  []string{"others", "dbglevel=debug", "others"},
-			want:     []string{"others", "dbglevel=debug", "others"},
+			want:     []string{"others", "dbglevel=debug", "others", "listobjectsv2"},
 		},
 		{
 			name:     "empty option, set config",
 			cfglevel: "debug",
 			options:  []string{"others"},
-			want:     []string{"others", "dbglevel=debug"},
+			want:     []string{"others", "dbglevel=debug", "listobjectsv2"},
 		},
 		{
 			name:     "empty option, invalid config",
 			cfglevel: "invalid",
 			options:  []string{"others"},
-			want:     []string{"others", "dbglevel=err"},
+			want:     []string{"others", "dbglevel=err", "listobjectsv2"},
 		},
 		{
 			name:        "mime-support=true",
 			enabledMime: true,
 			options:     []string{"others"},
-			want:        []string{"others", "dbglevel=err", "mime=" + OssfsCsiMimeTypesFilePath},
+			want:        []string{"others", "dbglevel=err", "mime=" + OssfsCsiMimeTypesFilePath, "listobjectsv2"},
+		},
+		{
+			name:    "listobjectsv2 has set",
+			options: []string{"others", "listobjectsv2"},
+			want:    []string{"others", "listobjectsv2", "dbglevel=err"},
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
https://help.aliyun.com/zh/oss/developer-reference/listobjects#section-t6d-ovx-jse
As the document of OSS, it's recommended to use listObjectsV2 by default.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
