### PR TITLE
feat:support cloud essd with new disk type as xc0 and xc1

### DIFF
--- a/pkg/disk/category.go
+++ b/pkg/disk/category.go
@@ -8,9 +8,12 @@ const (
 	DiskEfficiency Category = "cloud_efficiency"
 	DiskSSD        Category = "cloud_ssd"
 	DiskESSD       Category = "cloud_essd"
-	DiskESSDAuto   Category = "cloud_auto"
-	DiskESSDEntry  Category = "cloud_essd_entry"
-	DiskRegional   Category = "cloud_regional_disk_auto"
+	//special type as _xc* only used in financial cloud
+	DiskESSDXc0   Category = "cloud_essd_xc0"
+	DiskESSDXc1   Category = "cloud_essd_xc1"
+	DiskESSDAuto  Category = "cloud_auto"
+	DiskESSDEntry Category = "cloud_essd_entry"
+	DiskRegional  Category = "cloud_regional_disk_auto"
 
 	DiskPPerf            Category = "cloud_pperf"
 	DiskSPerf            Category = "cloud_sperf"
@@ -53,6 +56,16 @@ var AllCategories = map[Category]CategoryDesc{
 	},
 	DiskSSD: {
 		Size: SizeRange{Min: 20, Max: 65536},
+	},
+	DiskESSDXc0: {
+		Size:                    SizeRange{Min: 20, Max: 65536},
+		InstantAccessSnapshot:   true,
+		SnapshotConsistentGroup: true,
+	},
+	DiskESSDXc1: {
+		Size:                    SizeRange{Min: 20, Max: 65536},
+		InstantAccessSnapshot:   true,
+		SnapshotConsistentGroup: true,
 	},
 	DiskESSD: {
 		Size: SizeRange{Min: 20, Max: 65536},

--- a/pkg/disk/cloud_test.go
+++ b/pkg/disk/cloud_test.go
@@ -234,11 +234,13 @@ func TestGenerateAttempts(t *testing.T) {
 		{
 			name: "no PL",
 			args: &diskVolumeArgs{
-				Type: []Category{DiskESSD, DiskESSDAuto},
+				Type: []Category{DiskESSD, DiskESSDAuto, DiskESSDXc0, DiskESSDXc1},
 			},
 			attempts: []createAttempt{
 				{Category: DiskESSD},
 				{Category: DiskESSDAuto},
+				{Category: DiskESSDXc0},
+				{Category: DiskESSDXc1},
 			},
 		}, {
 			name: "with PL",


### PR DESCRIPTION
What type of PR is this?
/kind feature

What this PR does / why we need it:
In some financial cloud scenarios, we need support some special disk category as cloud_essd_xc0 and cloud_essd_xc1
Which issue(s) this PR fixes:
Fixes #

Special notes for your reviewer:
Does this PR introduce a user-facing change?

Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
