### PR TITLE
Update plugin.yaml

### DIFF
--- a/deploy/chart/templates/plugin.yaml
+++ b/deploy/chart/templates/plugin.yaml
@@ -1,5 +1,5 @@
 {{- range $key, $nodePool := .Values.nodePools -}}
-{{- if and $.Values.plugin.enabled (ne $nodePool nil) }}
+{{- if and $.Values.plugin.enabled (not (empty $nodePool)) }}
 ---
 {{- $values := deepCopy $.Values }}
 {{- $nodePool := mergeOverwrite $values $nodePool }}


### PR DESCRIPTION


### Problem Description

Currently, when using the Helm chart with `nodePools` enabled, Helm template evaluation may fail in some environments. Specifically, when running:

```bash
helm install ... --values values.yaml
```

with this configuration present:

```yaml
nodePools:
  default:
    pluginname: csi-plugin
    nodeSelectorTerms:
      - matchExpressions:
          - key: kubernetes.io/os
            operator: In
            values:
              - linux
```

we encountered this error:

```
Error: template: alibaba-cloud-csi-driver/templates/plugin.yaml:2:36: executing "alibaba-cloud-csi-driver/templates/plugin.yaml" at <ne $nodePool nil>: error calling ne: uncomparable type map[string]interface {}: map[...]
```

This happens because Helm (Go templating engine) cannot safely compare maps to `nil`. Once `nodePools` is defined, Helm cannot process `ne $nodePool nil` safely.

---

### What we did

We modified the template logic in:

```bash
alibaba-cloud-csi-driver/deploy/chart/templates/plugin.yaml
```

**Before:**

```gotemplate
{{- if ne $nodePool nil }}
```

**After:**

```gotemplate
{{- if and $.Values.plugin.enabled (not (empty $nodePool)) }}
```

* The function `empty` safely evaluates both `nil` and empty maps.
* This change prevents Helm from failing even when `nodePools` is defined and non-empty.
* The behavior remains identical for valid nodePools configurations.

---

### Why we still use `nodePools`

* In our environment, we are using the chart with `nodePools` configuration because it provides us more flexibility to target nodes using `nodeSelectorTerms` instead of only `plugin.nodeSelector`.
* We did not remove `nodePools`. We simply fixed the template evaluation logic so it works safely in all environments, including private cloud and bare metal clusters.

---

### Result

* ✅ Helm chart now installs properly with `nodePools` enabled.
* ✅ DaemonSet is created correctly.
* ✅ CSI Plugin is running and storage provisioning works fine.
* ✅ The fix is backwards compatible and minimal.

---

### Summary

This small change makes Helm chart more robust and compatible with current Helm templating best practices while preserving existing nodePools logic for users who rely on it.

---

✅ **Tested environment:**

* Bare metal Kubernetes cluster
* Private cloud (non-ECS)
* Helm v3.13.0+

---

