### PR TITLE
utils/cgroup: support for cgroupFS driver

### DIFF
--- a/pkg/utils/cgroup/pod.go
+++ b/pkg/utils/cgroup/pod.go
@@ -13,8 +13,35 @@ import (
 	"k8s.io/klog/v2"
 )
 
+type CgroupDriver int
+
+const (
+	Systemd CgroupDriver = iota
+	CgroupFS
+)
+
+var (
+	probePath = [...]string{
+		Systemd:  "kubepods.slice",
+		CgroupFS: "kubepods",
+	}
+	podTemplate = [...][]string{
+		Systemd: {
+			"%s/kubepods-besteffort.slice/kubepods-besteffort-pod%s.slice",
+			"%s/kubepods-burstable.slice/kubepods-burstable-pod%s.slice",
+			"%s/kubepods-pod%s.slice",
+		},
+		CgroupFS: {
+			"%s/besteffort/pod%s",
+			"%s/burstable/pod%s",
+			"%s/pod%s",
+		},
+	}
+)
+
 type PodCGroupSlice struct {
 	KubepodsSlicePath string
+	CgroupDriver      CgroupDriver
 }
 
 func (cg PodCGroupSlice) FindPodDir(podUID string) (int, error) {
@@ -22,13 +49,12 @@ func (cg PodCGroupSlice) FindPodDir(podUID string) (int, error) {
 		return -1, errors.New("no cgroup detected")
 	}
 
-	// /sys/fs/cgroup/blkio/kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-podaadcc749_6776_4933_990d_d50f260f5d46.slice/blkio.throttle.write_bps_device
-	podUID = strings.ReplaceAll(podUID, "-", "_")
-	for _, p := range []string{
-		"%s/kubepods-besteffort.slice/kubepods-besteffort-pod%s.slice",
-		"%s/kubepods-burstable.slice/kubepods-burstable-pod%s.slice",
-		"%s/kubepods-pod%s.slice",
-	} {
+	//  systemd: /sys/fs/cgroup/blkio/kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-podaadcc749_6776_4933_990d_d50f260f5d46.slice/blkio.throttle.write_bps_device
+	// cgroupfs: /sys/fs/cgroup/blkio/kubepods/burstable/podaa704696-c39c-4f18-bace-53f58a2db1cc/blkio.throttle.write_bps_device
+	if cg.CgroupDriver == Systemd {
+		podUID = strings.ReplaceAll(podUID, "-", "_")
+	}
+	for _, p := range podTemplate[cg.CgroupDriver] {
 		p = fmt.Sprintf(p, cg.KubepodsSlicePath, podUID)
 		fd, err := unix.Open(p, utilsio.O_PATH, 0)
 		if err == nil {
@@ -47,24 +73,26 @@ func (cg PodCGroupSlice) FindPodDir(podUID string) (int, error) {
 // Takes the path to the cgroupfs mount point as an argument. Usually /sys/fs/cgroup.
 // Returns the path to kubepods.slice, the IO implementation for the detected version.
 func DetectCgroupVersion(cgroupfsMountPath string) (PodCGroupSlice, IO, error) {
-	v2Path := filepath.Join(cgroupfsMountPath, "kubepods.slice")
-	_, err := os.Stat(v2Path + "/io.max")
-	if err == nil {
-		klog.Infof("Detected cgroup v2 at %s", v2Path)
-		return PodCGroupSlice{v2Path}, V2{}, nil
-	}
-	if !errors.Is(err, os.ErrNotExist) {
-		return PodCGroupSlice{}, nil, err
-	}
+	for driver, p := range probePath {
+		v2Path := filepath.Join(cgroupfsMountPath, p)
+		_, err := os.Stat(v2Path + "/io.max")
+		if err == nil {
+			klog.Infof("Detected cgroup v2 at %s", v2Path)
+			return PodCGroupSlice{v2Path, CgroupDriver(driver)}, V2{}, nil
+		}
+		if !errors.Is(err, os.ErrNotExist) {
+			return PodCGroupSlice{}, nil, err
+		}
 
-	v1Path := filepath.Join(cgroupfsMountPath, "blkio/kubepods.slice")
-	_, err = os.Stat(v1Path + "/blkio.throttle.read_bps_device")
-	if err == nil {
-		klog.Infof("Detected cgroup v1 at %s", v1Path)
-		return PodCGroupSlice{v1Path}, V1{}, nil
-	}
-	if !errors.Is(err, os.ErrNotExist) {
-		return PodCGroupSlice{}, nil, err
+		v1Path := filepath.Join(cgroupfsMountPath, "blkio", p)
+		_, err = os.Stat(v1Path + "/blkio.throttle.read_bps_device")
+		if err == nil {
+			klog.Infof("Detected cgroup v1 at %s", v1Path)
+			return PodCGroupSlice{v1Path, CgroupDriver(driver)}, V1{}, nil
+		}
+		if !errors.Is(err, os.ErrNotExist) {
+			return PodCGroupSlice{}, nil, err
+		}
 	}
 
 	klog.Warningf("No cgroup detected at %s. IO limit will not work", cgroupfsMountPath)

--- a/pkg/utils/cgroup/pod_test.go
+++ b/pkg/utils/cgroup/pod_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"golang.org/x/sys/unix"
 )
 
@@ -13,6 +14,19 @@ func TestFind(t *testing.T) {
 		KubepodsSlicePath: t.TempDir(),
 	}
 	err := os.MkdirAll(slice.KubepodsSlicePath+"/kubepods-podtest_pod_uid.slice", 0755)
+	assert.NoError(t, err)
+
+	fd, err := slice.FindPodDir("test-pod-uid")
+	assert.NoError(t, err)
+	defer unix.Close(fd)
+}
+
+func TestFindCgroupFS(t *testing.T) {
+	slice := PodCGroupSlice{
+		KubepodsSlicePath: t.TempDir(),
+		CgroupDriver:      CgroupFS,
+	}
+	err := os.MkdirAll(slice.KubepodsSlicePath+"/podtest-pod-uid", 0755)
 	assert.NoError(t, err)
 
 	fd, err := slice.FindPodDir("test-pod-uid")
@@ -43,24 +57,36 @@ func TestDetectNone(t *testing.T) {
 
 func TestDetectV1(t *testing.T) {
 	path := t.TempDir()
-	err := os.MkdirAll(path+"/blkio/kubepods.slice", 0755)
-	assert.NoError(t, err)
+	require.NoError(t, os.MkdirAll(path+"/blkio/kubepods.slice", 0755))
 	mkV1Files(t, path+"/blkio/kubepods.slice")
 
 	slice, io, err := DetectCgroupVersion(path)
 	assert.NoError(t, err)
 	assert.Equal(t, path+"/blkio/kubepods.slice", slice.KubepodsSlicePath)
+	assert.Equal(t, Systemd, slice.CgroupDriver)
+	assert.IsType(t, V1{}, io)
+}
+
+func TestDetectV1CgroupFS(t *testing.T) {
+	path := t.TempDir()
+	require.NoError(t, os.MkdirAll(path+"/blkio/kubepods", 0755))
+	mkV1Files(t, path+"/blkio/kubepods")
+
+	slice, io, err := DetectCgroupVersion(path)
+	assert.NoError(t, err)
+	assert.Equal(t, path+"/blkio/kubepods", slice.KubepodsSlicePath)
+	assert.Equal(t, CgroupFS, slice.CgroupDriver)
 	assert.IsType(t, V1{}, io)
 }
 
 func TestDetectV2(t *testing.T) {
 	path := t.TempDir()
-	err := os.MkdirAll(path+"/kubepods.slice", 0755)
-	assert.NoError(t, err)
+	require.NoError(t, os.MkdirAll(path+"/kubepods.slice", 0755))
 	mkFile(t, path+"/kubepods.slice/io.max")
 
 	slice, io, err := DetectCgroupVersion(path)
 	assert.NoError(t, err)
 	assert.Equal(t, path+"/kubepods.slice", slice.KubepodsSlicePath)
+	assert.Equal(t, Systemd, slice.CgroupDriver)
 	assert.IsType(t, V2{}, io)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
support for kubelet --cgroup-driver=cgroupfs
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
