### PR TITLE
Support mountpoint autoswitch

### DIFF
--- a/pkg/bmcpfs/internal/vsc.go
+++ b/pkg/bmcpfs/internal/vsc.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -283,12 +284,52 @@ const (
 	CPFSVscStatusDetaching = "Detaching"
 	CPFSVscStatusDetached  = "Detached"
 	CPFSVscStatusFailed    = "Failed"
+
+	VscAttachNotSupported = "AttachVscTarget.VscAttachNotSupported"
 )
 
 const (
 	defaultPollInterval  = time.Second * 2
 	defaultADWaitTimeout = time.Second * 10
 )
+
+func newAttachNotSupportedError(err error, volumeId, nodeId string) *AttachNotSupportedError {
+	return &AttachNotSupportedError{
+		message:  err.Error(),
+		volumeId: volumeId,
+		vscId:    nodeId,
+	}
+}
+
+// NewAttachNotSupportedError creates a new AttachNotSupportedError
+func NewAttachNotSupportedError(err error, volumeId, nodeId string) *AttachNotSupportedError {
+	return newAttachNotSupportedError(err, volumeId, nodeId)
+}
+
+type AttachNotSupportedError struct {
+	message  string
+	volumeId string
+	vscId    string
+}
+
+func (e *AttachNotSupportedError) Error() string {
+	return "volumeID: " + e.volumeId + "vscId: " + e.vscId + e.message
+}
+
+func IsAttachNotSupportedError(err error) bool {
+	if err == nil {
+		return false
+	}
+	var attachErr *AttachNotSupportedError
+	if errors.As(err, &attachErr) {
+		return true
+	}
+	sdkErr := &tea.SDKError{}
+	if errors.As(err, &sdkErr) && tea.StringValue(sdkErr.Code) == VscAttachNotSupported {
+		return true
+	}
+	return false
+}
 
 type CPFSVscAttachInfo = nasclient.DescribeFilesystemsVscAttachInfoResponseBodyVscAttachInfoVscAttachInfo
 
@@ -331,6 +372,9 @@ func (ad *cpfsAttachDetacher) Attach(ctx context.Context, fsId, vscId string) er
 		}
 	} else {
 		if err := ad.attach(fsId, vscId); err != nil {
+			if strings.Contains(err.Error(), VscAttachNotSupported) {
+				return newAttachNotSupportedError(err, fsId, vscId)
+			}
 			return err
 		}
 	}

--- a/pkg/bmcpfs/internal/vsc_test.go
+++ b/pkg/bmcpfs/internal/vsc_test.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package internal
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/alibabacloud-go/tea/tea"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAttachNotSupportedError_Error(t *testing.T) {
+	err := newAttachNotSupportedError(fmt.Errorf("test error"), "vol-123", "vsc-456")
+	expected := "volumeID: vol-123vscId: vsc-456test error"
+	assert.Equal(t, expected, err.Error())
+}
+
+func TestNewAttachNotSupportedError(t *testing.T) {
+	err := NewAttachNotSupportedError(fmt.Errorf("test error"), "vol-123", "vsc-456")
+	assert.NotNil(t, err)
+	assert.Equal(t, "volumeID: vol-123vscId: vsc-456test error", err.Error())
+}
+
+func TestIsAttachNotSupportedError_NilError(t *testing.T) {
+	assert.False(t, IsAttachNotSupportedError(nil))
+}
+
+func TestIsAttachNotSupportedError_AttachNotSupportedError(t *testing.T) {
+	err := newAttachNotSupportedError(fmt.Errorf("test error"), "vol-123", "vsc-456")
+	assert.True(t, IsAttachNotSupportedError(err))
+}
+
+func TestIsAttachNotSupportedError_SDKErrorWithCorrectCode(t *testing.T) {
+	sdkErr := &tea.SDKError{
+		Code: tea.String(VscAttachNotSupported),
+	}
+	assert.True(t, IsAttachNotSupportedError(sdkErr))
+}
+
+func TestIsAttachNotSupportedError_SDKErrorWithWrongCode(t *testing.T) {
+	sdkErr := &tea.SDKError{
+		Code: tea.String("SomeOtherError"),
+	}
+	assert.False(t, IsAttachNotSupportedError(sdkErr))
+}
+
+func TestIsAttachNotSupportedError_GenericError(t *testing.T) {
+	err := errors.New("generic error")
+	assert.False(t, IsAttachNotSupportedError(err))
+}
+
+func TestIsAttachNotSupportedError_SDKErrorWithAttachNotSupportedInMessage(t *testing.T) {
+	sdkErr := &tea.SDKError{
+		Message: tea.String("Some error with AttachVscTarget.VscAttachNotSupported in message"),
+		Code:    tea.String("DifferentCode"),
+	}
+	// Should be false because the code doesn't match, even if message contains the string
+	assert.False(t, IsAttachNotSupportedError(sdkErr))
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Support mountpoint autoswitch
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
