### PR TITLE
csi-agent: cmd mounter support ossfs 2.0 & add volume stats capability to disk driver

### DIFF
--- a/pkg/disk/csi_agent.go
+++ b/pkg/disk/csi_agent.go
@@ -24,6 +24,7 @@ func NewCSIAgent() *CSIAgent {
 	if err != nil {
 		klog.Fatalf("Failed to initialize pod cgroup: %v", err)
 	}
+	GlobalConfigVar.MetricEnable = true
 
 	return &CSIAgent{
 		ns: &nodeServer{
@@ -39,8 +40,20 @@ func (a *CSIAgent) NodeGetCapabilities(ctx context.Context, req *csi.NodeGetCapa
 	return a.ns.NodeGetCapabilities(ctx, req)
 }
 
+func (a *CSIAgent) NodeGetVolumeStats(ctx context.Context, req *csi.NodeGetVolumeStatsRequest) (*csi.NodeGetVolumeStatsResponse, error) {
+	return a.ns.NodeGetVolumeStats(ctx, req)
+}
+
 func (a *CSIAgent) NodeExpandVolume(ctx context.Context, req *csi.NodeExpandVolumeRequest) (*csi.NodeExpandVolumeResponse, error) {
 	return localExpandVolume(ctx, req)
+}
+
+func (a *CSIAgent) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRequest) (*csi.NodeStageVolumeResponse, error) {
+	return &csi.NodeStageVolumeResponse{}, nil
+}
+
+func (a *CSIAgent) NodeUnstageVolume(ctx context.Context, req *csi.NodeUnstageVolumeRequest) (*csi.NodeUnstageVolumeResponse, error) {
+	return &csi.NodeUnstageVolumeResponse{}, nil
 }
 
 func (a *CSIAgent) NodePublishVolume(ctx context.Context, req *csi.NodePublishVolumeRequest) (*csi.NodePublishVolumeResponse, error) {

--- a/pkg/mounter/proxy/server/ossfs/driver.go
+++ b/pkg/mounter/proxy/server/ossfs/driver.go
@@ -47,7 +47,7 @@ func (h *Driver) Mount(ctx context.Context, req *proxy.MountRequest) error {
 	options := req.Options
 
 	// prepare passwd file
-	passwdFile, err := utils.SaveOssSecretsToFile(req.Secrets)
+	passwdFile, err := utils.SaveOssSecretsToFile(req.Secrets, req.Fstype)
 	if err != nil {
 		return err
 	}

--- a/pkg/mounter/utils/utils.go
+++ b/pkg/mounter/utils/utils.go
@@ -30,13 +30,13 @@ func WaitFdReadable(fd int, timeout time.Duration) error {
 	return nil
 }
 
-func SaveOssSecretsToFile(secrets map[string]string, fsType string) (filePath string, err error) {
-	passwd := secrets[GetPasswdFileName(fsType)]
+func SaveOssSecretsToFile(secrets map[string]string, fuseType string) (filePath string, err error) {
+	passwd := secrets[GetPasswdFileName(fuseType)]
 	if passwd == "" {
 		return
 	}
 
-	tmpDir, err := os.MkdirTemp("", fsType+"-")
+	tmpDir, err := os.MkdirTemp("", fuseType+"-")
 	if err != nil {
 		return "", err
 	}
@@ -44,6 +44,6 @@ func SaveOssSecretsToFile(secrets map[string]string, fsType string) (filePath st
 	if err = os.WriteFile(filePath, []byte(passwd), 0o600); err != nil {
 		return "", err
 	}
-	klog.V(4).InfoS(fmt.Sprintf("created %s passwd file", fsType), "path", filePath)
+	klog.V(4).InfoS(fmt.Sprintf("created %s passwd file", fuseType), "path", filePath)
 	return
 }

--- a/pkg/mounter/utils/utils.go
+++ b/pkg/mounter/utils/utils.go
@@ -30,13 +30,13 @@ func WaitFdReadable(fd int, timeout time.Duration) error {
 	return nil
 }
 
-func SaveOssSecretsToFile(secrets map[string]string) (filePath string, err error) {
-	passwd := secrets["passwd-ossfs"]
+func SaveOssSecretsToFile(secrets map[string]string, fsType string) (filePath string, err error) {
+	passwd := secrets[GetPasswdFileName(fsType)]
 	if passwd == "" {
 		return
 	}
 
-	tmpDir, err := os.MkdirTemp("", "ossfs-")
+	tmpDir, err := os.MkdirTemp("", fsType+"-")
 	if err != nil {
 		return "", err
 	}
@@ -44,6 +44,6 @@ func SaveOssSecretsToFile(secrets map[string]string) (filePath string, err error
 	if err = os.WriteFile(filePath, []byte(passwd), 0o600); err != nil {
 		return "", err
 	}
-	klog.V(4).InfoS("created ossfs passwd file", "path", filePath)
+	klog.V(4).InfoS(fmt.Sprintf("created %s passwd file", fsType), "path", filePath)
 	return
 }

--- a/pkg/nas/mounter.go
+++ b/pkg/nas/mounter.go
@@ -36,7 +36,7 @@ func newNasMounter() mountutils.Interface {
 	inner := mountutils.NewWithoutSystemd("")
 	return &NasMounter{
 		Interface:     inner,
-		alinasMounter: mounter.NewConnectorMounter(inner, ""),
+		alinasMounter: inner,
 	}
 }
 

--- a/pkg/nas/nodeserver.go
+++ b/pkg/nas/nodeserver.go
@@ -138,6 +138,7 @@ const (
 	cnfsAlwaysFallbackEventTmpl                 = "CNFS automatically switched from %s to %s."
 	cnfsIfConnectFailedFallbackEventTmpl        = "Due to network issues, CNFS automatically switched from %s to %s."
 	cnfsIfMountTargetUnhealthyFallbackEventTmpl = "Due to mount target inactive, CNFS automatically switched from %s to %s."
+	cpfsServerSuffix                            = "cpfs.aliyuncs.com"
 )
 
 func validateNodePublishVolumeRequest(req *csi.NodePublishVolumeRequest) error {
@@ -206,6 +207,16 @@ func (ns *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 	var cnfsName string
 	for key, value := range req.VolumeContext {
 		switch strings.ToLower(key) {
+		case "useclient": // only VK will fetch this parameter from CNFS and add it to VolumeContext
+			opt.ClientType = strings.ToLower(value)
+			if opt.ClientType == EFCClient {
+				opt.MountProtocol = MountProtocolEFC
+			}
+			if strings.HasSuffix(req.VolumeContext["server"], cpfsServerSuffix) {
+				opt.FSType = "cpfs"
+			} else {
+				opt.FSType = "standard"
+			}
 		case "server":
 			opt.Server = value
 		case "accesspoint":

--- a/pkg/oss/csi_agent.go
+++ b/pkg/oss/csi_agent.go
@@ -10,6 +10,11 @@ import (
 	mountutils "k8s.io/mount-utils"
 )
 
+const (
+	ossfsExecPath  = "/usr/local/bin/ossfs"
+	ossfs2ExecPath = "/usr/local/bin/ossfs2"
+)
+
 type CSIAgent struct {
 	csi.UnimplementedNodeServer
 	// mount-proxy socket path
@@ -31,6 +36,10 @@ func NewCSIAgent(m metadata.MetadataProvider, socketPath string) *CSIAgent {
 		rawMounter:      mountutils.NewWithoutSystemd(""),
 		skipAttach:      true,
 		fusePodManagers: fusePodManagers,
+		ossfsPaths: map[string]string{
+			OssFsType:  ossfsExecPath,
+			OssFs2Type: ossfs2ExecPath,
+		},
 	}
 	return &CSIAgent{
 		ns:         ns,

--- a/pkg/oss/nodeserver.go
+++ b/pkg/oss/nodeserver.go
@@ -44,6 +44,7 @@ type nodeServer struct {
 	cnfsGetter      cnfsv1beta1.CNFSGetter
 	rawMounter      mountutils.Interface
 	fusePodManagers map[string]*oss.OSSFusePodManager
+	ossfsPaths      map[string]string
 	common.GenericNodeServer
 	skipAttach bool
 }
@@ -59,7 +60,8 @@ const (
 	OssFs2Type = "ossfs2"
 	// metricsPathPrefix
 	metricsPathPrefix = "/host/var/run/ossfs/"
-	ossfsExecPath     = "/usr/local/bin/ossfs"
+	// defaultMetricsTop
+	defaultMetricsTop = "10"
 )
 
 // for cases where fuseType does not affect like UnPublishVolume,
@@ -161,7 +163,7 @@ func (ns *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 		if err != nil {
 			return nil, status.Error(codes.Internal, err.Error())
 		}
-		ossfsMounter = mounter.NewOssCmdMounter(ossfsExecPath, req.VolumeId, ns.rawMounter)
+		ossfsMounter = mounter.NewOssCmdMounter(ns.ossfsPaths[opts.FuseType], req.VolumeId, ns.rawMounter)
 	} else {
 		ossfsMounter = mounter.NewProxyMounter(socketPath, ns.rawMounter)
 	}

--- a/pkg/oss/nodeserver.go
+++ b/pkg/oss/nodeserver.go
@@ -60,8 +60,6 @@ const (
 	OssFs2Type = "ossfs2"
 	// metricsPathPrefix
 	metricsPathPrefix = "/host/var/run/ossfs/"
-	// defaultMetricsTop
-	defaultMetricsTop = "10"
 )
 
 // for cases where fuseType does not affect like UnPublishVolume,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
1. Enable disk volume stats by default.
2. Support ossfs 2.0 in OssCmdMounter.
3. Support mount NAS using EFCClient with `useClient` field.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
