### PR TITLE
disk: fix Detaching disks treated as attached

### DIFF
--- a/pkg/disk/cloud.go
+++ b/pkg/disk/cloud.go
@@ -189,6 +189,51 @@ func (ad *DiskAttachDetach) findDevice(ctx context.Context, diskID, serial strin
 	return device, nil
 }
 
+type attachAction int
+
+const (
+	giveUp attachAction = iota
+	alreadyAttached
+	detachFirst
+	forceAttach
+	attachNormally
+)
+
+func chooseAttachAction(disk *ecs.Disk, instanceID string) (attachAction, error) {
+	if disk.MultiAttach == "Disabled" {
+		switch disk.Status {
+		case DiskStatusInuse:
+			if disk.InstanceId == instanceID {
+				return alreadyAttached, nil
+			}
+			return detachFirst, nil
+		case DiskStatusAttaching:
+			return giveUp, status.Errorf(codes.Aborted, "AttachDisk: Disk %s is attaching to %s", disk.DiskId, disk.InstanceId)
+		case DiskStatusDetaching:
+			if disk.InstanceId == instanceID {
+				return giveUp, status.Errorf(codes.Aborted, "AttachDisk: Disk %s is detaching from %s", disk.DiskId, instanceID)
+			}
+			// disk is detaching from another instance
+			return forceAttach, nil
+		}
+	} else {
+		switch disk.Status {
+		case DiskStatusInuse:
+			if waitstatus.IsInstanceAttached(disk, instanceID) {
+				return alreadyAttached, nil
+			}
+		case DiskStatusDetaching:
+			a := disk.Attachments.Attachment
+			if len(a) == 1 && a[0].InstanceId == instanceID {
+				return giveUp, status.Errorf(codes.Aborted, "AttachDisk: Disk %s is detaching from %s", disk.DiskId, instanceID)
+			}
+		}
+		// Not sure for status == "Attaching", maybe attaching to another node, but detaching from the requested node?
+	}
+	// Most likely status == "Available". But let AttachDisk OpenAPI to decide.
+	return attachNormally, nil
+}
+
 // Attach Alibaba Cloud disk.
 // Returns device path if fromNode, disk serial number otherwise.
 func (ad *DiskAttachDetach) attachDisk(ctx context.Context, diskID, nodeID string, fromNode bool) (string, error) {
@@ -238,30 +283,11 @@ func (ad *DiskAttachDetach) attachDisk(ctx context.Context, diskID, nodeID strin
 		}
 	}
 
-	tryForceAttach := false
-
-	// disk is attached, means disk_ad_controller env is true, disk must be created after 2020.06
-	switch disk.Status {
-	case DiskStatusInuse:
-		if disk.InstanceId == nodeID {
-			if !fromNode {
-				klog.Infof("AttachDisk: Disk %s is already attached to Instance %s, skipping", diskID, disk.InstanceId)
-				return disk.SerialNumber, nil
-			}
-			if disk.SerialNumber != "" {
-				return ad.dev.WaitRootBlock(ctx, disk.SerialNumber)
-			} else {
-				device, err := ad.devMap.Get(logger, diskID)
-				if err != nil {
-					return "", err
-				}
-				if device != "" {
-					return device, nil
-				}
-				klog.Warningf("AttachDisk: Disk (no serial) %s is already attached to instance %s, but device unknown, will be detached and try again", diskID, disk.InstanceId)
-			}
-		}
-
+	action, err := chooseAttachAction(disk, nodeID)
+	if err != nil {
+		return "", err
+	}
+	if action == detachFirst || action == forceAttach {
 		if GlobalConfigVar.DiskBdfEnable {
 			if allowed, err := forceDetachAllowed(GlobalConfigVar.EcsClient, disk); err != nil {
 				return "", status.Errorf(codes.Aborted, "forceDetachAllowed failed: %v", err)
@@ -273,31 +299,48 @@ func (ad *DiskAttachDetach) attachDisk(ctx context.Context, diskID, nodeID strin
 		if !GlobalConfigVar.DetachBeforeAttach {
 			return "", status.Errorf(codes.Aborted, "AttachDisk: Disk %s is already attached to instance %s, env DISK_FORCE_DETACHED is false reject force detach", diskID, disk.InstanceId)
 		}
-		if canForceAttach {
-			tryForceAttach = true
-		} else {
-			klog.Infof("AttachDisk: Disk %s is already attached to instance %s, will be detached", diskID, disk.InstanceId)
-			detachRequest := ecs.CreateDetachDiskRequest()
-			detachRequest.InstanceId = disk.InstanceId
-			detachRequest.DiskId = disk.DiskId
-			for key, value := range GlobalConfigVar.RequestBaseInfo {
-				detachRequest.AppendUserAgent(key, value)
-			}
-			_, err = ad.ecs.DetachDisk(detachRequest)
-			if err != nil {
-				klog.Errorf("AttachDisk: Can't Detach disk %s from instance %s: with error: %v", diskID, disk.InstanceId, err)
-				return "", status.Errorf(codes.Aborted, "AttachDisk: Can't Detach disk %s from instance %s: with error: %v", diskID, disk.InstanceId, err)
-			}
-			klog.Infof("AttachDisk: Wait for disk %s to be detached", diskID)
-			if err := ad.waitForDiskDetached(ctx, diskID, nodeID); err != nil {
-				return "", err
-			}
+	}
+	if canForceAttach && action == detachFirst {
+		action = forceAttach
+	}
+	if action == forceAttach && !canForceAttach {
+		action = attachNormally // should fail, but try it anyway
+	}
+
+	switch action {
+	case alreadyAttached:
+		if !fromNode {
+			klog.Infof("AttachDisk: Disk %s is already attached to Instance %s, skipping", diskID, disk.InstanceId)
+			return disk.SerialNumber, nil
 		}
-	case DiskStatusAttaching:
-		return "", status.Errorf(codes.Aborted, "AttachDisk: Disk %s is attaching %v", diskID, disk)
-	case DiskStatusDetaching:
-		if canForceAttach {
-			tryForceAttach = true
+		if disk.SerialNumber != "" {
+			return ad.dev.WaitRootBlock(ctx, disk.SerialNumber)
+		}
+		device, err := ad.devMap.Get(logger, diskID)
+		if err != nil {
+			return "", err
+		}
+		if device != "" {
+			return device, nil
+		}
+		klog.Warningf("AttachDisk: Disk (no serial) %s is already attached to instance %s, but device unknown, will be detached and try again", diskID, disk.InstanceId)
+		fallthrough
+	case detachFirst:
+		klog.Infof("AttachDisk: Disk %s is already attached to instance %s, will be detached", diskID, disk.InstanceId)
+		detachRequest := ecs.CreateDetachDiskRequest()
+		detachRequest.InstanceId = disk.InstanceId
+		detachRequest.DiskId = disk.DiskId
+		for key, value := range GlobalConfigVar.RequestBaseInfo {
+			detachRequest.AppendUserAgent(key, value)
+		}
+		_, err = ad.ecs.DetachDisk(detachRequest)
+		if err != nil {
+			klog.Errorf("AttachDisk: Can't Detach disk %s from instance %s: with error: %v", diskID, disk.InstanceId, err)
+			return "", status.Errorf(codes.Aborted, "AttachDisk: Can't Detach disk %s from instance %s: with error: %v", diskID, disk.InstanceId, err)
+		}
+		klog.Infof("AttachDisk: Wait for disk %s to be detached", diskID)
+		if err := ad.waitForDiskDetached(ctx, diskID, nodeID); err != nil {
+			return "", err
 		}
 	}
 
@@ -313,7 +356,7 @@ func (ad *DiskAttachDetach) attachDisk(ctx context.Context, diskID, nodeID strin
 	attachRequest := ecs.CreateAttachDiskRequest()
 	attachRequest.InstanceId = nodeID
 	attachRequest.DiskId = diskID
-	if tryForceAttach {
+	if action == forceAttach {
 		attachRequest.Force = requests.NewBoolean(true)
 		logger.V(1).Info("try force attach", "from", disk.InstanceId, "to", nodeID)
 	}

--- a/pkg/disk/cloud.go
+++ b/pkg/disk/cloud.go
@@ -243,8 +243,7 @@ func (ad *DiskAttachDetach) attachDisk(ctx context.Context, diskID, nodeID strin
 	// Step 1: check disk status
 	disk, err := ad.findDiskByID(ctx, diskID)
 	if err != nil {
-		klog.Errorf("AttachDisk: find disk: %s with error: %s", diskID, err.Error())
-		return "", status.Errorf(codes.Internal, "AttachDisk: find disk: %s with error: %s", diskID, err.Error())
+		return "", status.Errorf(codes.Internal, "AttachDisk: find disk: %s with error: %v", diskID, err)
 	}
 	if disk == nil {
 		return "", status.Errorf(codes.NotFound, "AttachDisk: csi can't find disk: %s in region: %s, Please check if the cloud disk exists, if the region is correct, or if the csi permissions are correct", diskID, GlobalConfigVar.Region)
@@ -310,7 +309,7 @@ func (ad *DiskAttachDetach) attachDisk(ctx context.Context, diskID, nodeID strin
 	switch action {
 	case alreadyAttached:
 		if !fromNode {
-			klog.Infof("AttachDisk: Disk %s is already attached to Instance %s, skipping", diskID, disk.InstanceId)
+			logger.V(2).Info("already attached, skipping")
 			return disk.SerialNumber, nil
 		}
 		if disk.SerialNumber != "" {
@@ -323,10 +322,10 @@ func (ad *DiskAttachDetach) attachDisk(ctx context.Context, diskID, nodeID strin
 		if device != "" {
 			return device, nil
 		}
-		klog.Warningf("AttachDisk: Disk (no serial) %s is already attached to instance %s, but device unknown, will be detached and try again", diskID, disk.InstanceId)
+		logger.V(1).Info("disk has no serial, but device unknown, will be detached and try again")
 		fallthrough
 	case detachFirst:
-		klog.Infof("AttachDisk: Disk %s is already attached to instance %s, will be detached", diskID, disk.InstanceId)
+		logger.V(1).Info("already attached to another instance, will be detached", "from", disk.InstanceId)
 		detachRequest := ecs.CreateDetachDiskRequest()
 		detachRequest.InstanceId = disk.InstanceId
 		detachRequest.DiskId = disk.DiskId
@@ -335,10 +334,9 @@ func (ad *DiskAttachDetach) attachDisk(ctx context.Context, diskID, nodeID strin
 		}
 		_, err = ad.ecs.DetachDisk(detachRequest)
 		if err != nil {
-			klog.Errorf("AttachDisk: Can't Detach disk %s from instance %s: with error: %v", diskID, disk.InstanceId, err)
 			return "", status.Errorf(codes.Aborted, "AttachDisk: Can't Detach disk %s from instance %s: with error: %v", diskID, disk.InstanceId, err)
 		}
-		klog.Infof("AttachDisk: Wait for disk %s to be detached", diskID)
+		logger.V(2).Info("Waiting for disk to be detached")
 		if err := ad.waitForDiskDetached(ctx, diskID, nodeID); err != nil {
 			return "", err
 		}
@@ -358,7 +356,7 @@ func (ad *DiskAttachDetach) attachDisk(ctx context.Context, diskID, nodeID strin
 	attachRequest.DiskId = diskID
 	if action == forceAttach {
 		attachRequest.Force = requests.NewBoolean(true)
-		logger.V(1).Info("try force attach", "from", disk.InstanceId, "to", nodeID)
+		logger.V(1).Info("try force attach", "from", disk.InstanceId)
 	}
 	if cate.SingleInstance {
 		attachRequest.DeleteWithInstance = requests.NewBoolean(true)
@@ -385,7 +383,7 @@ func (ad *DiskAttachDetach) attachDisk(ctx context.Context, diskID, nodeID strin
 	}
 
 	// Step 4: wait for disk attached
-	klog.Infof("AttachDisk: Waiting for Disk %s is Attached to instance %s with RequestId: %s", diskID, nodeID, response.RequestId)
+	logger.V(2).Info("waiting for disk to attach", "requestID", response.RequestId)
 	if err := ad.waitForDiskAttached(ctx, diskID, nodeID); err != nil {
 		return "", err
 	}
@@ -399,7 +397,7 @@ func (ad *DiskAttachDetach) attachDisk(ctx context.Context, diskID, nodeID strin
 		return device, nil
 	}
 
-	klog.Infof("AttachDisk: Successful attach disk %s to node %s", diskID, nodeID)
+	logger.V(2).Info("Successfully attached disk")
 	return disk.SerialNumber, nil
 }
 

--- a/pkg/disk/cloud_test.go
+++ b/pkg/disk/cloud_test.go
@@ -686,9 +686,10 @@ func TestAttachDisk(t *testing.T) {
 			expectErr: true,
 		},
 		{
-			name:   "detaching from self",
-			before: disk("Detaching", "i-testinstanceid"),
-			after:  disk("In_use", "i-testinstanceid"), // FIXME
+			name:      "detaching from self",
+			before:    disk("Detaching", "i-testinstanceid"),
+			noAttach:  true,
+			expectErr: true,
 		},
 		{
 			// This not supported by ECS, but desired by us to speed up failover. Hopes they will support it someday.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

We should reject to attach disk detaching from the requested node.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

It is strange that ECS does not return error on attaching a detaching disk. But we fix it at our side first.

/hold
based on #1460, wait for that one to be merged first

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
