### PR TITLE
ossfs: allow change ossfs pod' dnspolicy to ClusterFirstWithHostNet 

### DIFF
--- a/pkg/mounter/oss/oss_fuse_manager.go
+++ b/pkg/mounter/oss/oss_fuse_manager.go
@@ -3,6 +3,7 @@ package oss
 import (
 	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/cloud/metadata"
 	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/mounter/utils"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
 )
 
@@ -86,4 +87,7 @@ type Options struct {
 	AuthType      string `json:"authType"`
 	FuseType      string `json:"fuseType"`
 	ReadOnly      bool   `json:"readOnly"`
+
+	// pod template
+	DnsPolicy corev1.DNSPolicy `json:"dnsPolicy"`
 }

--- a/pkg/mounter/oss/ossfs.go
+++ b/pkg/mounter/oss/ossfs.go
@@ -228,7 +228,7 @@ func (f *fuseOssfs) buildPodSpec(c *mounterutils.FusePodContext, target string) 
 	spec.Containers = []corev1.Container{container}
 	spec.NodeName = c.NodeName
 	spec.HostNetwork = true
-	spec.DNSPolicy = corev1.DNSClusterFirstWithHostNet
+	spec.DNSPolicy = c.PodTemplateConfig.DnsPolicy
 	spec.PriorityClassName = "system-node-critical"
 	spec.Tolerations = []corev1.Toleration{{Operator: corev1.TolerationOpExists}}
 	return

--- a/pkg/mounter/oss/ossfs2.go
+++ b/pkg/mounter/oss/ossfs2.go
@@ -253,7 +253,7 @@ func (f *fuseOssfs2) buildPodSpec(c *mounterutils.FusePodContext, target string)
 	spec.Containers = []corev1.Container{container}
 	spec.NodeName = c.NodeName
 	spec.HostNetwork = true
-	spec.DNSPolicy = corev1.DNSClusterFirstWithHostNet
+	spec.DNSPolicy = c.PodTemplateConfig.DnsPolicy
 	spec.PriorityClassName = "system-node-critical"
 	spec.Tolerations = []corev1.Toleration{{Operator: corev1.TolerationOpExists}}
 	return

--- a/pkg/mounter/utils/fuse_pod_manager.go
+++ b/pkg/mounter/utils/fuse_pod_manager.go
@@ -59,6 +59,10 @@ type RrsaConfig struct {
 	AssumeRoleArn      string
 }
 
+type PodTemplateConfig struct {
+	DnsPolicy corev1.DNSPolicy
+}
+
 const (
 	DebugLevelFatal = "fatal"
 	DebugLevelError = "error"
@@ -74,11 +78,12 @@ const (
 
 type FusePodContext struct {
 	context.Context
-	Namespace  string
-	NodeName   string
-	VolumeId   string
-	FuseType   string
-	AuthConfig *AuthConfig
+	Namespace         string
+	NodeName          string
+	VolumeId          string
+	FuseType          string
+	AuthConfig        *AuthConfig
+	PodTemplateConfig *PodTemplateConfig
 }
 
 type FuseMounterType interface {

--- a/pkg/oss/controllerserver.go
+++ b/pkg/oss/controllerserver.go
@@ -132,6 +132,8 @@ func (cs *controllerServer) ControllerPublishVolume(ctx context.Context, req *cs
 	if err != nil {
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
+	// make pod template config
+	ptCfg := makePodTemplateConfig(opts)
 	// Skip controller publish for PVs with attribute direct=true.
 	// The actual mounting of these volumes will be handled by rund.
 	if opts.DirectAssigned {
@@ -143,12 +145,13 @@ func (cs *controllerServer) ControllerPublishVolume(ctx context.Context, req *cs
 
 	// launch ossfs pod
 	fusePod, err := cs.fusePodManagers[opts.FuseType].Create(&mounter.FusePodContext{
-		Context:    ctx,
-		Namespace:  fusePodNamespace,
-		NodeName:   nodeName,
-		VolumeId:   req.VolumeId,
-		AuthConfig: authCfg,
-		FuseType:   opts.FuseType,
+		Context:           ctx,
+		Namespace:         fusePodNamespace,
+		NodeName:          nodeName,
+		VolumeId:          req.VolumeId,
+		AuthConfig:        authCfg,
+		PodTemplateConfig: ptCfg,
+		FuseType:          opts.FuseType,
 	}, controllerPublishPath, false)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to create %s pod: %v", opts.FuseType, err)

--- a/pkg/oss/utils_test.go
+++ b/pkg/oss/utils_test.go
@@ -25,8 +25,10 @@ import (
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/cloud/metadata"
 	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/mounter/oss"
+	mounter "github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/mounter/utils"
 	mounterutils "github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/mounter/utils"
 	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
 )
 
 var m = metadata.FakeProvider{
@@ -727,4 +729,14 @@ func TestMakeMountOptions(t *testing.T) {
 	got2, err := makeMountOptions(opt2, ossfs2Fpm, fakeMeta, cap)
 	assert.NoError(t, err)
 	assert.Equal(t, want2, got2)
+}
+
+func TestMakePodTemplateConfig(t *testing.T) {
+	assert.Equal(t, &mounter.PodTemplateConfig{
+		DnsPolicy: corev1.DNSClusterFirstWithHostNet,
+	}, makePodTemplateConfig(&oss.Options{
+		DnsPolicy: corev1.DNSClusterFirstWithHostNet,
+	}))
+
+	assert.Equal(t, &mounter.PodTemplateConfig{}, makePodTemplateConfig(&oss.Options{}))
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug /kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Use ClusterFirstWithHostNet dnsPolicy by default for hostnetwork ossfs pod.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
