### PR TITLE
Fix incorrect nas mounter issue

### DIFF
--- a/pkg/nas/csi_agent.go
+++ b/pkg/nas/csi_agent.go
@@ -16,6 +16,7 @@ type CSIAgent struct {
 
 func NewCSIAgent(socketPath string) *CSIAgent {
 	config := &internal.NodeConfig{
+		AgentMode:        true,
 		EnablePortCheck:  true,
 		MountProxySocket: socketPath,
 		CNFSGetter:       unsupportedCNFSGetter{},

--- a/pkg/nas/internal/config.go
+++ b/pkg/nas/internal/config.go
@@ -86,6 +86,7 @@ type NodeConfig struct {
 
 	// path of mount proxy socket
 	MountProxySocket string
+	AgentMode        bool
 
 	// clients for kubernetes
 	KubeClient kubernetes.Interface

--- a/pkg/nas/mounter.go
+++ b/pkg/nas/mounter.go
@@ -32,12 +32,16 @@ func (m *NasMounter) Mount(source string, target string, fstype string, options 
 	return err
 }
 
-func newNasMounter() mountutils.Interface {
+func newNasMounter(agentMode bool) mountutils.Interface {
 	inner := mountutils.NewWithoutSystemd("")
-	return &NasMounter{
+	m := &NasMounter{
 		Interface:     inner,
 		alinasMounter: inner,
 	}
+	if !agentMode {
+		m.alinasMounter = mounter.NewConnectorMounter(inner, "")
+	}
+	return m
 }
 
 func newNasMounterWithProxy(socketPath string) mountutils.Interface {

--- a/pkg/nas/mounter_test.go
+++ b/pkg/nas/mounter_test.go
@@ -25,7 +25,7 @@ func (m *errorMockMounter) Mount(source string, target string, fstype string, op
 }
 
 func TestNewNasMounter(t *testing.T) {
-	actual := newNasMounter()
+	actual := newNasMounter(true)
 	assert.NotNil(t, actual)
 }
 

--- a/pkg/nas/nodeserver.go
+++ b/pkg/nas/nodeserver.go
@@ -70,7 +70,7 @@ func newNodeServer(config *internal.NodeConfig) *nodeServer {
 		},
 	}
 	if config.MountProxySocket == "" {
-		ns.mounter = newNasMounter()
+		ns.mounter = newNasMounter(ns.config.AgentMode)
 	} else {
 		ns.recorder = utils.NewEventRecorder()
 		ns.mounter = newNasMounterWithProxy(config.MountProxySocket)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Fixes incorrect nas mounter selection: still use NewConnectorMounter when CSI is not running in agent mode.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes incorrect nas mounter selection: still use NewConnectorMounter when CSI is not running in agent mode.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
