### PR TITLE
Support fsetid static attach

### DIFF
--- a/pkg/bmcpfs/bmcpfs.go
+++ b/pkg/bmcpfs/bmcpfs.go
@@ -42,6 +42,8 @@ const (
 	// network types of CPFS mount targets
 	networkTypeVPC = "vpc"
 	networkTypeVSC = "vsc"
+
+	volumeHandleDelimiter = "+"
 )
 
 type Driver struct {

--- a/pkg/bmcpfs/controllerserver.go
+++ b/pkg/bmcpfs/controllerserver.go
@@ -43,12 +43,18 @@ type controllerServer struct {
 	vscManager     *internal.PrimaryVscManagerWithCache
 	attachDetacher internal.CPFSAttachDetacher
 	nasClient      *nasclient.Client
+	skipDetach     bool
 }
 
 func newControllerServer(region string) (*controllerServer, error) {
 	efloClient, err := newEfloClient(region)
 	if err != nil {
 		return nil, err
+	}
+
+	skipDetach := false
+	if skipDetach, _ := strconv.ParseBool(os.Getenv("SKIP_BMCPFS_DETACH")); skipDetach {
+		skipDetach = true
 	}
 
 	nasClient, err := cloud.NewNasClientV2(region)
@@ -59,6 +65,7 @@ func newControllerServer(region string) (*controllerServer, error) {
 		vscManager:     internal.NewPrimaryVscManagerWithCache(efloClient),
 		attachDetacher: internal.NewCPFSAttachDetacher(nasClient),
 		nasClient:      nasClient,
+		skipDetach:     skipDetach,
 	}, nil
 }
 
@@ -85,11 +92,12 @@ func (cs *controllerServer) ControllerPublishVolume(ctx context.Context, req *cs
 		}, nil
 	}
 
+	cpfsID, _ := parseVolumeHandle(req.VolumeId)
 	// Get VscMountTarget of filesystem
 	mt := req.VolumeContext[_vscMountTarget]
 	if mt == "" {
 		var err error
-		mt, err = getMountTarget(cs.nasClient, req.VolumeId, networkTypeVSC)
+		mt, err = getMountTarget(cs.nasClient, cpfsID, networkTypeVSC)
 		if err != nil {
 			return nil, status.Errorf(codes.Internal, "failed to get VscMountTarget: %v", err)
 		}
@@ -107,7 +115,7 @@ func (cs *controllerServer) ControllerPublishVolume(ctx context.Context, req *cs
 	klog.Info("Use VSC MountTarget for lingjun node", "nodeId", req.NodeId, "vscId", vscId)
 
 	// Attach CPFS to VSC
-	err = cs.attachDetacher.Attach(ctx, req.VolumeId, vscId)
+	err = cs.attachDetacher.Attach(ctx, cpfsID, vscId)
 	if err != nil {
 		if autoSwitch, _ := strconv.ParseBool(req.VolumeContext[_mpAutoSwitch]); autoSwitch && internal.IsAttachNotSupportedError(err) {
 			if req.VolumeContext[_vpcMountTarget] == "" {
@@ -138,10 +146,9 @@ func (cs *controllerServer) ControllerPublishVolume(ctx context.Context, req *cs
 func (cs *controllerServer) ControllerUnpublishVolume(ctx context.Context, req *csi.ControllerUnpublishVolumeRequest) (
 	*csi.ControllerUnpublishVolumeResponse, error,
 ) {
-	if !strings.HasPrefix(req.NodeId, LingjunNodeIDPrefix) {
+	if !strings.HasPrefix(req.NodeId, LingjunNodeIDPrefix) || cs.skipDetach {
 		return &csi.ControllerUnpublishVolumeResponse{}, nil
 	}
-
 	// Create Primary vsc for Lingjun node
 	lingjunInstanceId := strings.TrimPrefix(req.NodeId, LingjunNodeIDPrefix)
 	if LingjunNodeIDPrefix == "" {
@@ -155,6 +162,7 @@ func (cs *controllerServer) ControllerUnpublishVolume(ctx context.Context, req *
 		klog.InfoS("ControllerUnpublishVolume: skip detaching cpfs from vsc as vsc not found", "node", req.NodeId)
 		return &csi.ControllerUnpublishVolumeResponse{}, nil
 	}
+	// If `req.VolumeId` is a combination of `cpfsID` and `fsetID`, Detach will trigger an error.
 	err = cs.attachDetacher.Detach(ctx, req.VolumeId, vsc.VscID)
 	if err != nil {
 		return nil, status.Error(codes.Internal, err.Error())
@@ -207,6 +215,14 @@ func newEfloClient(region string) (*efloclient.Client, error) {
 	config = config.SetProtocol(scheme)
 	// init client
 	return efloclient.NewClient(config)
+}
+
+func parseVolumeHandle(volumeHandle string) (string, string) {
+	parts := strings.Split(volumeHandle, volumeHandleDelimiter)
+	if len(parts) == 2 {
+		return parts[0], parts[1]
+	}
+	return parts[0], ""
 }
 
 func getMountTarget(client *nasclient.Client, fsId, networkType string) (string, error) {

--- a/pkg/bmcpfs/controllerserver_test.go
+++ b/pkg/bmcpfs/controllerserver_test.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package bmcpfs
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestParseVolumeHandle tests the parseVolumeHandle function with various inputs
+func TestParseVolumeHandle(t *testing.T) {
+	tests := []struct {
+		name           string
+		volumeHandle   string
+		expectedFsId   string
+		expectedFsetId string
+	}{
+		{
+			name:           "single part",
+			volumeHandle:   "fs-12345",
+			expectedFsId:   "fs-12345",
+			expectedFsetId: "",
+		},
+		{
+			name:           "two parts",
+			volumeHandle:   "fs-12345+fset-67890",
+			expectedFsId:   "fs-12345",
+			expectedFsetId: "fset-67890",
+		},
+		{
+			name:           "multiple delimiters",
+			volumeHandle:   "fs-12345+fset-67890+extra",
+			expectedFsId:   "fs-12345",
+			expectedFsetId: "fset-67890+extra",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fsId, fsetId := parseVolumeHandle(tt.volumeHandle)
+			assert.Equal(t, tt.expectedFsId, fsId)
+			assert.Equal(t, tt.expectedFsetId, fsetId)
+		})
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Activates fileset at PVC/PV level with SKIP_BMCPFS_DETACH=true.

volumeattachments fail if SKIP_BMCPFS_DETACH is set to false.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
