### PR TITLE
build: fix libblkid install path

### DIFF
--- a/build/multi/Dockerfile.multi
+++ b/build/multi/Dockerfile.multi
@@ -76,11 +76,13 @@ cd /src
 SOURCE_DATE_EPOCH=$(stat -c %Y /src.tar.xz)
 export SOURCE_DATE_EPOCH
 echo "util-linux released at $(date --date "@$SOURCE_DATE_EPOCH" --iso-8601=seconds)"
-./configure --disable-all-programs --enable-blkid --enable-libblkid --prefix=/usr/local \
+./configure --disable-all-programs --enable-blkid --enable-libblkid --libdir=\${prefix}/lib/$HOST \
     --disable-nls --disable-bash-completion --disable-asciidoc --disable-dependency-tracking --disable-static --host=$HOST
 make -j
-make install-strip DESTDIR=/out
-cd /out/usr/local && rm -r include share lib/pkgconfig
+make install-strip DESTDIR=/install
+mkdir -p /out
+cd /install
+cp -dp --parents usr/lib/*/libblkid*.so.* sbin/blkid /out
 EOF
 
 COPY <<"EOT" /out/usr/local/share/sbom/blkid.spdx.json
@@ -146,5 +148,7 @@ FROM csi-base as csi-controller
 USER nonroot
 
 FROM csi-base
-COPY --link --from=build-util-linux /out /
 COPY --link --from=debian /staging-node /
+
+# overwrites libblkid from debian
+COPY --link --from=build-util-linux /out /


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Currently, we install libblkid in /usr/local/lib, this path is configured in
/etc/ld.so.conf.d/libc.conf, in package libc-bin, which is not included in
distroless images. So we are actually still linking to the old version of
libblkid.

Viewing the search path by /lib/aarch64-linux-gnu/ld-linux-aarch64.so.1 --help:

```
Shared library search path:
  (libraries located via /etc/ld.so.cache)
  /lib/aarch64-linux-gnu (system search path)
  /usr/lib/aarch64-linux-gnu (system search path)
  /lib (system search path)
  /usr/lib (system search path)
```

We don't have /etc/ld.so.cache which is created by ldconfig, also in libc-bin.
And /usr is going to be merged for debian. So our only choice is overwriting
the file installed by apt in /usr/lib/aarch64-linux-gnu.

Also refined the install script to exclude more unnecessary files.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fix rare false detection of file system on new encrypted disk.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
