### PR TITLE
refactor: make kube config optional in nas/oss node drivers

### DIFF
--- a/pkg/common/start.go
+++ b/pkg/common/start.go
@@ -33,8 +33,15 @@ func ParseEndpoint(ep string) (string, string, error) {
 }
 
 func RunCSIServer(driverType, endpoint string, servers Servers) {
-	config := options.MustGetRestConfig()
-	clientset := kubernetes.NewForConfigOrDie(config)
+	config, err := options.GetRestConfig()
+	if err != nil {
+		klog.ErrorS(err, "failed to get rest config")
+	}
+
+	var clientset kubernetes.Interface
+	if config != nil {
+		clientset = kubernetes.NewForConfigOrDie(config)
+	}
 
 	proto, addr, err := ParseEndpoint(endpoint)
 	if err != nil {

--- a/pkg/metric/collector.go
+++ b/pkg/metric/collector.go
@@ -46,9 +46,9 @@ type CSICollector struct {
 }
 
 // newCSICollector method returns the CSICollector object
-func newCSICollector(driverNames []string, serviceType utils.ServiceType) error {
+func newCSICollector(driverNames []string, serviceType utils.ServiceType) {
 	if csiCollectorInstance != nil {
-		return nil
+		return
 	}
 	collectors := make(map[string]Collector)
 	if serviceType&utils.Node != 0 {
@@ -67,16 +67,15 @@ func newCSICollector(driverNames []string, serviceType utils.ServiceType) error 
 			if enabled {
 				collector, err := reg.Factory()
 				if err != nil {
-					return err
+					klog.ErrorS(err, "Failed to create collector")
+				} else {
+					collectors[reg.Name] = collector
 				}
-				collectors[reg.Name] = collector
 			}
 		}
 	}
 	collectors[CsiGrpcExecTimeCollectorName] = &CsiGrpcExecTimeCollector
 	csiCollectorInstance = &CSICollector{Collectors: collectors}
-
-	return nil
 }
 
 // Describe implements the prometheus.Collector interface.

--- a/pkg/metric/metric.go
+++ b/pkg/metric/metric.go
@@ -44,10 +44,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 // NewMetricHandler method returns a promHttp object
 func NewMetricHandler(driverNames []string, serviceType utils.ServiceType) *Handler {
 	//csi collector singleton
-	err := newCSICollector(driverNames, serviceType)
-	if err != nil {
-		klog.Errorf("Couldn't create collector: %s", err)
-	}
+	newCSICollector(driverNames, serviceType)
 	return newHandler()
 }
 

--- a/pkg/mounter/fuse_pod_manager/fuse_pod_manager.go
+++ b/pkg/mounter/fuse_pod_manager/fuse_pod_manager.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	mounterutils "github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/mounter/utils"
+	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/utils"
 	corev1 "k8s.io/api/core/v1"
 	apiserrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -101,14 +102,11 @@ type FuseContainerConfig struct {
 	Extra       map[string]string
 }
 
-func ExtractFuseContainerConfig(configmap *corev1.ConfigMap, name string) (config FuseContainerConfig) {
+func ExtractFuseContainerConfig(csiCfg utils.Config, name string) (config FuseContainerConfig) {
 	config.Resources.Requests = make(corev1.ResourceList)
 	config.Resources.Limits = make(corev1.ResourceList)
 
-	if configmap == nil {
-		return
-	}
-	content := configmap.Data["fuse-"+name]
+	content := csiCfg.Get("fuse-"+name, "OSS_FUSE_"+strings.ToUpper(name), "")
 	for _, line := range strings.Split(content, "\n") {
 		line = strings.TrimSpace(line)
 		if line == "" {

--- a/pkg/mounter/fuse_pod_manager/fuse_pod_manager_test.go
+++ b/pkg/mounter/fuse_pod_manager/fuse_pod_manager_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/utils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
@@ -17,8 +18,8 @@ import (
 )
 
 func Test_ExtractFuseContainerConfig(t *testing.T) {
-	configmap := &corev1.ConfigMap{
-		Data: map[string]string{
+	csiCfg := utils.Config{
+		ConfigMap: map[string]string{
 			"fuse-ossfs": `
 				image=ossfs:latest
 				cpu-request=100m
@@ -32,7 +33,7 @@ func Test_ExtractFuseContainerConfig(t *testing.T) {
 			`,
 		},
 	}
-	config := ExtractFuseContainerConfig(configmap, "ossfs")
+	config := ExtractFuseContainerConfig(csiCfg, "ossfs")
 	expected := FuseContainerConfig{
 		Resources: corev1.ResourceRequirements{
 			Limits: corev1.ResourceList{

--- a/pkg/mounter/fuse_pod_manager/oss/ossfs/manager.go
+++ b/pkg/mounter/fuse_pod_manager/oss/ossfs/manager.go
@@ -53,8 +53,8 @@ var ossfsDbglevels = map[string]string{
 	fpm.DebugLevelFatal: "crit",
 }
 
-func NewFuseOssfs(configmap *corev1.ConfigMap, m metadata.MetadataProvider) ossfpm.OSSFuseMounterType {
-	config := fpm.ExtractFuseContainerConfig(configmap, mounterutils.OssFsType)
+func NewFuseOssfs(csiCfg utils.Config, m metadata.MetadataProvider) ossfpm.OSSFuseMounterType {
+	config := fpm.ExtractFuseContainerConfig(csiCfg, mounterutils.OssFsType)
 
 	// set default image
 	ossfpm.SetDefaultImage(mounterutils.OssFsType, m, &config)

--- a/pkg/mounter/fuse_pod_manager/oss/ossfs/manager_test.go
+++ b/pkg/mounter/fuse_pod_manager/oss/ossfs/manager_test.go
@@ -10,6 +10,7 @@ import (
 	fpm "github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/mounter/fuse_pod_manager"
 	ossfpm "github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/mounter/fuse_pod_manager/oss"
 	mounterutils "github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/mounter/utils"
+	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/utils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
@@ -102,7 +103,7 @@ func Test_buildAuthSpec_ossfs(t *testing.T) {
 
 func TestPrecheckAuthConfig_ossfs(t *testing.T) {
 	fakeMeta := metadata.NewMetadata()
-	fakeOssfs := NewFuseOssfs(nil, fakeMeta)
+	fakeOssfs := NewFuseOssfs(utils.Config{}, fakeMeta)
 	tests := []struct {
 		name    string
 		opts    *ossfpm.Options
@@ -316,7 +317,7 @@ func TestMakeAuthConfig_ossfs(t *testing.T) {
 	t.Setenv("CLUSTER_ID", "cluster-id")
 	t.Setenv("ALIBABA_CLOUD_ACCOUNT_ID", "account-id")
 	fakeMeta := metadata.NewMetadata()
-	fakeOssfs := NewFuseOssfs(nil, fakeMeta)
+	fakeOssfs := NewFuseOssfs(utils.Config{}, fakeMeta)
 	tests := []struct {
 		name           string
 		options        *ossfpm.Options
@@ -597,7 +598,7 @@ func TestMakeMountOptions_ossfs(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Setenv("REGION_ID", tt.region)
 			fakeMeta := metadata.NewMetadata()
-			fakeOssfs := NewFuseOssfs(nil, fakeMeta)
+			fakeOssfs := NewFuseOssfs(utils.Config{}, fakeMeta)
 			mountOptions, err := fakeOssfs.MakeMountOptions(tt.opts, fakeMeta)
 			assert.Equal(t, tt.expectedError, err != nil)
 			assert.ElementsMatch(t, tt.expected, mountOptions)
@@ -710,7 +711,7 @@ func TestGetAuthOpttions_ossfs(t *testing.T) {
 
 func TestAddDefaultMountOptions_ossfs(t *testing.T) {
 	fakeMeta := metadata.NewMetadata()
-	fakeInter := NewFuseOssfs(nil, fakeMeta)
+	fakeInter := NewFuseOssfs(utils.Config{}, fakeMeta)
 	fakeOssfs, ok := fakeInter.(*fuseOssfs)
 	if !ok {
 		t.Fatalf("failed to cast to fuseOssfs")

--- a/pkg/mounter/fuse_pod_manager/oss/ossfs2/manager.go
+++ b/pkg/mounter/fuse_pod_manager/oss/ossfs2/manager.go
@@ -39,8 +39,8 @@ var ossfs2Dbglevels = map[string]string{
 	fpm.DebugLevelInfo:  "info",
 }
 
-func NewFuseOssfs(configmap *corev1.ConfigMap, m metadata.MetadataProvider) ossfpm.OSSFuseMounterType {
-	config := fpm.ExtractFuseContainerConfig(configmap, mounterutils.OssFs2Type)
+func NewFuseOssfs(csiCfg utils.Config, m metadata.MetadataProvider) ossfpm.OSSFuseMounterType {
+	config := fpm.ExtractFuseContainerConfig(csiCfg, mounterutils.OssFs2Type)
 	// set default image
 	ossfpm.SetDefaultImage(mounterutils.OssFs2Type, m, &config)
 	// set default memory request

--- a/pkg/mounter/fuse_pod_manager/oss/ossfs2/manager_test.go
+++ b/pkg/mounter/fuse_pod_manager/oss/ossfs2/manager_test.go
@@ -11,6 +11,7 @@ import (
 	fpm "github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/mounter/fuse_pod_manager"
 	ossfpm "github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/mounter/fuse_pod_manager/oss"
 	mounterutils "github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/mounter/utils"
+	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/utils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
@@ -19,7 +20,7 @@ import (
 
 func TestPrecheckAuthConfig_ossfs2(t *testing.T) {
 	fakeMeta := metadata.NewMetadata()
-	fakeOssfs := NewFuseOssfs(nil, fakeMeta)
+	fakeOssfs := NewFuseOssfs(utils.Config{}, fakeMeta)
 	tests := []struct {
 		name    string
 		opts    *ossfpm.Options
@@ -156,7 +157,7 @@ func TestMakeAuthConfig_ossfs2(t *testing.T) {
 	t.Setenv("CLUSTER_ID", "cluster-id")
 	t.Setenv("ALIBABA_CLOUD_ACCOUNT_ID", "account-id")
 	fakeMeta := metadata.NewMetadata()
-	fakeOssfs := NewFuseOssfs(nil, fakeMeta)
+	fakeOssfs := NewFuseOssfs(utils.Config{}, fakeMeta)
 	tests := []struct {
 		name    string
 		options *ossfpm.Options
@@ -371,7 +372,7 @@ func TestMakeMountOptions_ossfs2(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Setenv("REGION_ID", tt.region)
 			fakeMeta := metadata.NewMetadata()
-			fakeOssfs := NewFuseOssfs(nil, fakeMeta)
+			fakeOssfs := NewFuseOssfs(utils.Config{}, fakeMeta)
 			opts, err := fakeOssfs.MakeMountOptions(tt.opts, fakeMeta)
 			assert.Equal(t, tt.expectedError, err != nil)
 			assert.Equal(t, tt.expected, opts)
@@ -381,7 +382,7 @@ func TestMakeMountOptions_ossfs2(t *testing.T) {
 
 func TestAddDefaultMountOptions_ossfs2(t *testing.T) {
 	fakeMeta := metadata.NewMetadata()
-	fakeInter := NewFuseOssfs(nil, fakeMeta)
+	fakeInter := NewFuseOssfs(utils.Config{}, fakeMeta)
 	fakeOssfs, ok := fakeInter.(*fuseOssfs)
 	if !ok {
 		t.Fatalf("failed to cast to fuseOssfs")

--- a/pkg/mounter/fuse_pod_manager/oss/registry_test.go
+++ b/pkg/mounter/fuse_pod_manager/oss/registry_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/mounter"
 	fpm "github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/mounter/fuse_pod_manager"
 	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/mounter/interceptors"
+	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/utils"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 )
@@ -54,7 +55,7 @@ func TestGetFuseMounterInterceptors(t *testing.T) {
 func TestGetAllRegisteredFuseTypes(t *testing.T) {
 	// Register a test factory
 	testType := "test-fuse-type-3"
-	testFactory := func(*corev1.ConfigMap, metadata.MetadataProvider) OSSFuseMounterType {
+	testFactory := func(utils.Config, metadata.MetadataProvider) OSSFuseMounterType {
 		return nil
 	}
 	RegisterFuseMounter(testType, testFactory)
@@ -75,13 +76,13 @@ func TestGetAllOSSFusePodManagers(t *testing.T) {
 
 	// Register a test factory that returns a valid mounter
 	testType := "test-fuse-type-4"
-	testFactory := func(*corev1.ConfigMap, metadata.MetadataProvider) OSSFuseMounterType {
+	testFactory := func(utils.Config, metadata.MetadataProvider) OSSFuseMounterType {
 		return &testFuseMounter{name: testType}
 	}
 	RegisterFuseMounter(testType, testFactory)
 
 	// Test with nil configmap and nil client (CSI agent mode)
-	managers := GetAllOSSFusePodManagers(nil, fakeMeta, nil)
+	managers := GetAllOSSFusePodManagers(utils.Config{}, fakeMeta, nil)
 
 	// Should have at least the test manager
 	assert.GreaterOrEqual(t, len(managers), 1, "Should have at least 1 fuse pod manager")

--- a/pkg/mounter/utils/utils.go
+++ b/pkg/mounter/utils/utils.go
@@ -197,6 +197,10 @@ func GetCredientialsSecretName(fuseType string) string {
 }
 
 func CleanupCredentialSecret(ctx context.Context, clientset kubernetes.Interface, node, volumeId, fuseType string) error {
+	if clientset == nil {
+		klog.V(2).InfoS("Skip cleaning up credential secret due to nil kube client")
+		return nil
+	}
 	key := fmt.Sprintf("%s.%s", node, volumeId)
 	secretName := GetCredientialsSecretName(fuseType)
 	secretClient := clientset.CoreV1().Secrets(LegacyFusePodNamespace)

--- a/pkg/nas/internal/config_test.go
+++ b/pkg/nas/internal/config_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/jarcoal/httpmock"
 	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/cloud/metadata"
 	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/options"
+	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/utils"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -53,13 +54,6 @@ const (
 }`
 )
 
-func TestMustGetKubeClients(t *testing.T) {
-	prepareFakeK8sContext()
-	client, cnfsGetter := mustGetKubeClients()
-	assert.NotNil(t, client)
-	assert.NotNil(t, cnfsGetter)
-}
-
 func prepareFakeK8sContext() {
 	options.MasterURL = masterUrl
 }
@@ -72,7 +66,7 @@ func TestGetControllerConfigSuccess(t *testing.T) {
 	prepareFakeRegionEnvVar(t)
 
 	metadataProviders := metadata.NewMetadata()
-	config, err := GetControllerConfig(metadataProviders)
+	config, err := GetControllerConfig(metadataProviders, utils.Config{})
 
 	assert.NoError(t, err)
 	assert.NotNil(t, config)
@@ -91,15 +85,6 @@ func registerConfigMapResponder() {
 	httpmock.RegisterResponder("GET", url, responder)
 }
 
-func TestGetControllerConfigError(t *testing.T) {
-	prepareFakeK8sContext()
-	prepareFakeRegionEnvVar(t)
-	metadataProviders := metadata.NewMetadata()
-	config, err := GetControllerConfig(metadataProviders)
-	assert.Error(t, err)
-	assert.Nil(t, config)
-}
-
 func TestGetNodeConfigSuccess(t *testing.T) {
 	httpmock.Activate()
 	defer httpmock.DeactivateAndReset()
@@ -108,7 +93,7 @@ func TestGetNodeConfigSuccess(t *testing.T) {
 	prepareFakeK8sContext()
 	prepareNodeConfigEnvVars(t)
 
-	config, err := GetNodeConfig()
+	config, err := GetNodeConfig(utils.Config{})
 	assert.NoError(t, err)
 	assert.NotNil(t, config)
 }
@@ -129,13 +114,6 @@ func prepareNodeConfigEnvVars(t *testing.T) {
 	t.Setenv("NAS_LOSETUP_ENABLE", "true")
 }
 
-func TestGetNodeConfigConfigMapGetError(t *testing.T) {
-	prepareFakeK8sContext()
-	config, err := GetNodeConfig()
-	assert.Error(t, err)
-	assert.Nil(t, config)
-}
-
 func TestGetNodeConfigNodeGetError(t *testing.T) {
 	httpmock.Activate()
 	defer httpmock.DeactivateAndReset()
@@ -143,7 +121,7 @@ func TestGetNodeConfigNodeGetError(t *testing.T) {
 	prepareFakeK8sContext()
 	t.Setenv("NAS_LOSETUP_ENABLE", "true")
 
-	config, err := GetNodeConfig()
+	config, err := GetNodeConfig(utils.Config{})
 	assert.Error(t, err)
 	assert.Nil(t, config)
 }
@@ -156,7 +134,7 @@ func TestGetNodeConfigLosetupError(t *testing.T) {
 	prepareFakeK8sContext()
 	prepareNodeConfigEnvVars(t)
 
-	config, err := GetNodeConfig()
+	config, err := GetNodeConfig(utils.Config{})
 	assert.Error(t, err)
 	assert.Nil(t, config)
 }

--- a/pkg/nas/nas.go
+++ b/pkg/nas/nas.go
@@ -36,7 +36,7 @@ type NAS struct {
 	servers  common.Servers
 }
 
-func NewDriver(meta *metadata.Metadata, endpoint string, serviceType utils.ServiceType) *NAS {
+func NewDriver(meta *metadata.Metadata, endpoint string, serviceType utils.ServiceType, csiCfg utils.Config) *NAS {
 	klog.Infof("Driver: %v version: %v", driverName, version.VERSION)
 
 	var d NAS
@@ -45,7 +45,7 @@ func NewDriver(meta *metadata.Metadata, endpoint string, serviceType utils.Servi
 	servers.IdentityServer = newIdentityServer()
 
 	if serviceType&utils.Controller != 0 {
-		config, err := internal.GetControllerConfig(meta)
+		config, err := internal.GetControllerConfig(meta, csiCfg)
 		if err != nil {
 			klog.Fatalf("Get nas controller config: %v", err)
 		}
@@ -56,7 +56,7 @@ func NewDriver(meta *metadata.Metadata, endpoint string, serviceType utils.Servi
 		servers.ControllerServer = cs
 	}
 	if serviceType&utils.Node != 0 {
-		config, err := internal.GetNodeConfig()
+		config, err := internal.GetNodeConfig(csiCfg)
 		if err != nil {
 			klog.Fatalf("Get nas node config: %v", err)
 		}

--- a/pkg/nas/nas_test.go
+++ b/pkg/nas/nas_test.go
@@ -55,7 +55,7 @@ func TestNewDriverProvisioner(t *testing.T) {
 	prepareNasTestFakeK8sContext()
 	prepareFakeRegionEnvVar(t)
 
-	driver := NewDriver(metadata.NewMetadata(), "", utils.Controller)
+	driver := NewDriver(metadata.NewMetadata(), "", utils.Controller, utils.Config{})
 	assert.NotNil(t, driver)
 }
 
@@ -84,7 +84,7 @@ func TestNewDriverPlugin(t *testing.T) {
 	prepareNasTestFakeK8sContext()
 	prepareNodeConfigEnvVars(t)
 
-	driver := NewDriver(metadata.NewMetadata(), "", utils.Node)
+	driver := NewDriver(metadata.NewMetadata(), "", utils.Node, utils.Config{})
 	assert.NotNil(t, driver)
 }
 

--- a/pkg/options/genericoptions.go
+++ b/pkg/options/genericoptions.go
@@ -40,14 +40,6 @@ func init() {
 	flag.IntVar(&KubeAPIBurst, KubeAPIBurstFlag, 10, "Burst to use while communicating with the kubernetes apiserver.")
 }
 
-func MustGetRestConfig() *rest.Config {
-	config, err := GetRestConfig()
-	if err != nil {
-		panic(err)
-	}
-	return config
-}
-
 func GetRestConfig() (*rest.Config, error) {
 	cfg, err := clientcmd.BuildConfigFromFlags(MasterURL, Kubeconfig)
 	if err != nil {

--- a/pkg/oss/csi_agent.go
+++ b/pkg/oss/csi_agent.go
@@ -25,7 +25,7 @@ func NewCSIAgent(m metadata.MetadataProvider, socketPath string) *CSIAgent {
 		locks:           utils.NewVolumeLocks(),
 		rawMounter:      mountutils.NewWithoutSystemd(""),
 		skipAttach:      true, // label for csi-agent environment
-		fusePodManagers: ossfpm.GetAllOSSFusePodManagers(nil, m, nil),
+		fusePodManagers: ossfpm.GetAllOSSFusePodManagers(utils.Config{}, m, nil),
 		ossfsPaths:      ossfpm.GetAllFuseMounterPaths(),
 	}
 	return &CSIAgent{

--- a/pkg/oss/nodeserver_test.go
+++ b/pkg/oss/nodeserver_test.go
@@ -27,7 +27,7 @@ func setupTestNodeServer(t *testing.T, mounter mountutils.Interface, skipAttach 
 		},
 	}
 
-	fusePodManagers := ossfpm.GetAllOSSFusePodManagers(nil, fakeMeta, nil)
+	fusePodManagers := ossfpm.GetAllOSSFusePodManagers(utils.Config{}, fakeMeta, nil)
 	ossfsPaths := ossfpm.GetAllFuseMounterPaths()
 
 	return &nodeServer{

--- a/pkg/oss/utils.go
+++ b/pkg/oss/utils.go
@@ -325,7 +325,7 @@ func parseOptions(volOptions, secrets map[string]string, volCaps []*csi.VolumeCa
 }
 
 func setCNFSOptions(ctx context.Context, cnfsGetter cnfsv1beta1.CNFSGetter, opts *ossfpm.Options) error {
-	if opts.CNFSName == "" {
+	if opts.CNFSName == "" || cnfsGetter == nil {
 		return nil
 	}
 	cnfs, err := cnfsGetter.GetCNFS(ctx, opts.CNFSName)

--- a/pkg/oss/utils_test.go
+++ b/pkg/oss/utils_test.go
@@ -29,6 +29,7 @@ import (
 	_ "github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/mounter/fuse_pod_manager/oss/ossfs"
 	_ "github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/mounter/fuse_pod_manager/oss/ossfs2"
 	mounterutils "github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/mounter/utils"
+	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/utils"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 )
@@ -774,8 +775,8 @@ func TestSetFsType(t *testing.T) {
 
 func Test_checkOssOptions(t *testing.T) {
 	fakeMeta := metadata.NewMetadata()
-	ossfs, _ := ossfpm.GetFuseMounter(mounterutils.OssFsType, nil, fakeMeta)
-	ossfs2, _ := ossfpm.GetFuseMounter(mounterutils.OssFs2Type, nil, fakeMeta)
+	ossfs, _ := ossfpm.GetFuseMounter(mounterutils.OssFsType, utils.Config{}, fakeMeta)
+	ossfs2, _ := ossfpm.GetFuseMounter(mounterutils.OssFs2Type, utils.Config{}, fakeMeta)
 	fusePodManagers := map[string]*ossfpm.OSSFusePodManager{
 		mounterutils.OssFsType:  ossfpm.NewOSSFusePodManager(ossfs, nil),
 		mounterutils.OssFs2Type: ossfpm.NewOSSFusePodManager(ossfs2, nil),
@@ -902,7 +903,7 @@ func Test_checkOssOptions(t *testing.T) {
 
 func TestMakeAuthConfig(t *testing.T) {
 	fakeMeta := metadata.NewMetadata()
-	ossfs, _ := ossfpm.GetFuseMounter(mounterutils.OssFsType, nil, fakeMeta)
+	ossfs, _ := ossfpm.GetFuseMounter(mounterutils.OssFsType, utils.Config{}, fakeMeta)
 	ossfsFpm := ossfpm.NewOSSFusePodManager(ossfs, nil)
 	opt := &ossfpm.Options{
 		URL:    "1.1.1.1",
@@ -923,7 +924,7 @@ func TestMakeAuthConfig(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, want, authCfg)
 
-	ossfs2, _ := ossfpm.GetFuseMounter(mounterutils.OssFs2Type, nil, fakeMeta)
+	ossfs2, _ := ossfpm.GetFuseMounter(mounterutils.OssFs2Type, utils.Config{}, fakeMeta)
 	ossfs2Fpm := ossfpm.NewOSSFusePodManager(ossfs2, nil)
 	opt2 := &ossfpm.Options{
 		URL:    "1.1.1.1",
@@ -948,7 +949,7 @@ func TestMakeAuthConfig(t *testing.T) {
 func TestMakeMountOptions(t *testing.T) {
 	t.Setenv("REGION_ID", "cn-beijing")
 	fakeMeta := metadata.NewMetadata()
-	ossfs, _ := ossfpm.GetFuseMounter(mounterutils.OssFsType, nil, fakeMeta)
+	ossfs, _ := ossfpm.GetFuseMounter(mounterutils.OssFsType, utils.Config{}, fakeMeta)
 	ossfsFpm := ossfpm.NewOSSFusePodManager(ossfs, nil)
 	opt := &ossfpm.Options{
 		URL:    "1.1.1.1",
@@ -983,7 +984,7 @@ func TestMakeMountOptions(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, want, got)
 
-	ossfs2, _ := ossfpm.GetFuseMounter(mounterutils.OssFs2Type, nil, fakeMeta)
+	ossfs2, _ := ossfpm.GetFuseMounter(mounterutils.OssFs2Type, utils.Config{}, fakeMeta)
 	ossfs2Fpm := ossfpm.NewOSSFusePodManager(ossfs2, nil)
 	opt2 := &ossfpm.Options{
 		URL:    "1.1.1.1",

--- a/pkg/utils/util.go
+++ b/pkg/utils/util.go
@@ -397,6 +397,9 @@ func getPodFromK8s(ctx context.Context, client kubernetes.Interface, req *csi.No
 	if name == "" || namespace == "" {
 		return nil, fmt.Errorf("empty pod name or namespace: '%s', '%s'", name, namespace)
 	}
+	if client == nil {
+		return nil, fmt.Errorf("kube client is nil")
+	}
 	pod, err := client.CoreV1().Pods(namespace).Get(ctx, name, metav1.GetOptions{})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Make kube config optional on oss and nas node servers, supporting reading relevant configurations from env variables.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
