### PR TITLE
disk: replace conf file with xattr

### DIFF
--- a/deploy/charts/alibaba-cloud-csi-driver/templates/plugin.yaml
+++ b/deploy/charts/alibaba-cloud-csi-driver/templates/plugin.yaml
@@ -75,6 +75,9 @@ spec:
           volumeMounts:
             - name: etc
               mountPath: /host/etc
+            - name: host-dev
+              mountPath: /dev
+              mountPropagation: "HostToContainer"
             - name: csi-plugin-cm
               mountPath: /etc/csi-plugin/config
             - name: host-log

--- a/pkg/disk/csi_agent.go
+++ b/pkg/disk/csi_agent.go
@@ -32,6 +32,10 @@ func NewCSIAgent() *CSIAgent {
 			k8smounter: k8smount.NewWithoutSystemd(""),
 			podCGroup:  podCgroup,
 			locks:      utils.NewVolumeLocks(),
+			ad: DiskAttachDetach{
+				dev:    DefaultDeviceManager,
+				devMap: &devMap{}, // Nobody will add to this map.
+			},
 		},
 	}
 }
@@ -45,7 +49,7 @@ func (a *CSIAgent) NodeGetVolumeStats(ctx context.Context, req *csi.NodeGetVolum
 }
 
 func (a *CSIAgent) NodeExpandVolume(ctx context.Context, req *csi.NodeExpandVolumeRequest) (*csi.NodeExpandVolumeResponse, error) {
-	return localExpandVolume(ctx, req)
+	return a.ns.localExpandVolume(ctx, req)
 }
 
 func (a *CSIAgent) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRequest) (*csi.NodeStageVolumeResponse, error) {

--- a/pkg/disk/nodeserver.go
+++ b/pkg/disk/nodeserver.go
@@ -86,12 +86,8 @@ const (
 	DiskAttachedKey = "k8s.aliyun.com"
 	// DiskAttachedValue attached value
 	DiskAttachedValue = "true"
-	// VolumeDir volume dir
-	VolumeDir = "/host/etc/kubernetes/volumes/disk/"
 	// RundSocketDir dir
 	RundSocketDir = "/host/etc/kubernetes/volumes/rund/"
-	// VolumeDirRemove volume dir remove
-	VolumeDirRemove = "/host/etc/kubernetes/volumes/disk/remove"
 	// InputOutputErr tag
 	InputOutputErr = "input/output error"
 	// CreateDiskARN ARN parameter of the CreateDisk interface
@@ -164,17 +160,9 @@ func parseVolumeCountEnv() (int, error) {
 // NewNodeServer creates node server
 func NewNodeServer(m metadata.MetadataProvider) csi.NodeServer {
 	// Create Directory
-	err := os.MkdirAll(VolumeDir, os.FileMode(0755))
+	err := os.MkdirAll(RundSocketDir, os.FileMode(0755))
 	if err != nil {
-		klog.Errorf("Create Directory %s failed: %v", VolumeDir, err)
-	}
-	err = os.MkdirAll(VolumeDirRemove, os.FileMode(0755))
-	if err != nil {
-		klog.Errorf("Create Directory %s failed: %v", VolumeDir, err)
-	}
-	err = os.MkdirAll(RundSocketDir, os.FileMode(0755))
-	if err != nil {
-		klog.Errorf("Create Directory %s failed: %v", VolumeDir, err)
+		klog.Errorf("Create Directory %s failed: %v", RundSocketDir, err)
 	}
 
 	if IsVFNode() {
@@ -206,6 +194,11 @@ func NewNodeServer(m metadata.MetadataProvider) csi.NodeServer {
 		klog.Fatalf("Failed to initialize pod cgroup: %v", err)
 	}
 
+	devMap, err := NewDevMap(utilsio.RealDevTmpFS{})
+	if err != nil {
+		klog.Fatalf("failed to list devices: %v", err)
+	}
+
 	waiter, batcher := newBatcher(true)
 	return &nodeServer{
 		metadata:     m,
@@ -223,7 +216,8 @@ func NewNodeServer(m metadata.MetadataProvider) csi.NodeServer {
 			attachThrottler: defaultThrottler(),
 			detachThrottler: defaultThrottler(),
 
-			dev: DefaultDeviceManager,
+			dev:    DefaultDeviceManager,
+			devMap: devMap,
 		},
 		locks: utils.NewVolumeLocks(),
 		GenericNodeServer: common.GenericNodeServer{
@@ -269,6 +263,7 @@ func (ns *nodeServer) NodeGetCapabilities(ctx context.Context, req *csi.NodeGetC
 
 // csi disk driver: bind directory from global to pod.
 func (ns *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublishVolumeRequest) (*csi.NodePublishVolumeResponse, error) {
+	logger := klog.FromContext(ctx)
 	if !ns.locks.TryAcquire(req.VolumeId) {
 		return nil, status.Errorf(codes.Aborted, "There is already an operation for %s", req.VolumeId)
 	}
@@ -379,7 +374,7 @@ func (ns *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 	}
 
 	// check device name available
-	expectName, err := GetVolumeDeviceName(req.VolumeId)
+	expectName, err := ns.ad.GetVolumeDeviceName(logger, req.VolumeId)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "NodePublishVolume: VolumeId: %s, get device name error: %s", req.VolumeId, err.Error())
 	}
@@ -587,10 +582,6 @@ func (ns *nodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVol
 		klog.Errorf("NodeStageVolume: check device %s for volume %s with error: %s", device, req.VolumeId, err.Error())
 		return nil, status.Error(defaultErrCode, err.Error())
 	}
-	if err := saveVolumeConfig(req.VolumeId, device); err != nil {
-		klog.Errorf("NodeStageVolume: saveVolumeConfig %s for volume %s with error: %s", device, req.VolumeId, err.Error())
-		return nil, status.Error(defaultErrCode, "NodeStageVolume: saveVolumeConfig for ("+req.VolumeId+device+") error with: "+err.Error())
-	}
 	klog.Infof("NodeStageVolume: Volume Successful Attached: %s, to Node: %s, Device: %s", req.VolumeId, ns.NodeID, device)
 
 	err = ns.setupDisk(ctx, device, targetPath, req)
@@ -676,22 +667,23 @@ func (ns *nodeServer) setupDisk(ctx context.Context, device, targetPath string, 
 	return nil
 }
 
-func addDiskXattr(diskID string) (err error) {
+func (ns *nodeServer) addDiskXattr(logger klog.Logger, diskID string) (err error) {
 	defer func() {
 		if errors.Is(err, os.ErrNotExist) {
 			klog.Infof("addDiskXattr: disk %s not found, skip", diskID)
 			err = nil
 		}
 	}()
-	device, err := GetVolumeDeviceName(diskID)
+	device, err := ns.ad.GetVolumeDeviceName(logger, diskID)
 	if err != nil {
 		return
 	}
-	return unix.Setxattr(device, DiskXattrName, []byte(diskID), 0)
+	return setDiskXattr(device, diskID)
 }
 
 // target format: /var/lib/kubelet/plugins/kubernetes.io/csi/pv/pv-disk-1e7001e0-c54a-11e9-8f89-00163e0e78a0/globalmount
 func (ns *nodeServer) NodeUnstageVolume(ctx context.Context, req *csi.NodeUnstageVolumeRequest) (*csi.NodeUnstageVolumeResponse, error) {
+	logger := klog.FromContext(ctx)
 	klog.Infof("NodeUnstageVolume:: Starting to Unmount volume, volumeId: %s, target: %v", req.VolumeId, req.StagingTargetPath)
 
 	if !ns.locks.TryAcquire(req.VolumeId) {
@@ -779,7 +771,7 @@ func (ns *nodeServer) NodeUnstageVolume(ctx context.Context, req *csi.NodeUnstag
 		}
 	}
 
-	err := addDiskXattr(req.VolumeId)
+	err := ns.addDiskXattr(logger, req.VolumeId)
 	if err != nil {
 		klog.Errorf("NodeUnstageVolume: addDiskXattr %s failed: %v", req.VolumeId, err)
 	}
@@ -797,8 +789,8 @@ func (ns *nodeServer) NodeUnstageVolume(ctx context.Context, req *csi.NodeUnstag
 			klog.Errorf("NodeUnstageVolume: VolumeId: %s, Detach failed with error %v", req.VolumeId, err.Error())
 			return nil, err
 		}
-		_ = removeVolumeConfig(req.VolumeId)
 	}
+	ns.ad.devMap.Delete(req.VolumeId)
 
 	return &csi.NodeUnstageVolumeResponse{}, nil
 }
@@ -924,22 +916,23 @@ func (ns *nodeServer) NodeExpandVolume(ctx context.Context, req *csi.NodeExpandV
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
 
-	return localExpandVolume(ctx, req)
+	return ns.localExpandVolume(ctx, req)
 }
 
-func localExpandVolume(ctx context.Context, req *csi.NodeExpandVolumeRequest) (*csi.NodeExpandVolumeResponse, error) {
+func (ns *nodeServer) localExpandVolume(ctx context.Context, req *csi.NodeExpandVolumeRequest) (*csi.NodeExpandVolumeResponse, error) {
 	requestBytes := req.GetCapacityRange().GetRequiredBytes()
 	volumePath := req.GetVolumePath()
 	diskID := req.GetVolumeId()
+	logger := klog.FromContext(ctx)
 
-	devicePath, err := GetVolumeDeviceName(diskID)
+	devicePath, err := ns.ad.GetVolumeDeviceName(logger, diskID)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			return nil, status.Errorf(codes.NotFound, "can't get devicePath for: %s", diskID)
 		}
 		return nil, status.Errorf(codes.Internal, "NodeExpandVolume: VolumeId: %s, get device name error: %s", req.VolumeId, err.Error())
 	}
-	logger := klog.FromContext(ctx).WithValues("device", devicePath)
+	logger = logger.WithValues("device", devicePath)
 	ctx = klog.NewContext(ctx, logger)
 
 	rootPath, index, err := DefaultDeviceManager.GetDeviceRootAndPartitionIndex(devicePath)
@@ -1237,14 +1230,9 @@ func (ns *nodeServer) mountRunvVolumes(volumeId, sourcePath, targetPath, fsType,
 		klog.Errorf("NodePublishVolume(runv): unmountStageTarget %s with error: %s", sourcePath, err.Error())
 		return status.Error(codes.InvalidArgument, "NodePublishVolume: unmountStageTarget "+sourcePath+" with error: "+err.Error())
 	}
-	deviceName, err := DefaultDeviceManager.GetDeviceByVolumeID(volumeId)
+	deviceName, err := ns.ad.GetRootBlockDevice(klog.TODO(), volumeId)
 	if err != nil {
-		klog.Errorf("NodePublishVolume(runv): failed to get device by deviceName: %s", err.Error())
-		deviceName = getVolumeConfig(volumeId)
-	}
-	if deviceName == "" {
-		klog.Errorf("NodePublishVolume(runv): cannot get local deviceName for volume:  %s", volumeId)
-		return status.Error(codes.InvalidArgument, "NodePublishVolume: cannot get local deviceName for volume: "+volumeId)
+		return status.Errorf(codes.InvalidArgument, "NodePublishVolume: cannot get local deviceName for volume %s: %v", volumeId, err)
 	}
 
 	// save volume info to local file
@@ -1280,9 +1268,11 @@ func (ns *nodeServer) mountRunvVolumes(volumeId, sourcePath, targetPath, fsType,
 
 func (ns *nodeServer) mountRunDVolumes(volumeId, pvName, sourcePath, targetPath, fsType, mkfsOptions string, isRawBlock, pvmMode bool, mountFlags []string) (bool, error) {
 	klog.Infof("NodePublishVolume:: Disk Volume %s Mounted in RunD csi 3.0/2.0 protocol", volumeId)
-	deviceName, err := DefaultDeviceManager.GetDeviceByVolumeID(volumeId)
+	logger := klog.TODO()
+	deviceName, err := ns.ad.GetRootBlockDevice(logger, volumeId)
 	if err != nil {
-		deviceName = getVolumeConfig(volumeId)
+		logger.V(1).Info("RunD volume device not found", "err", err)
+		// maybe OK, we can find the device by xdragon-bdf below.
 	}
 
 	if features.FunctionalMutableFeatureGate.Enabled(features.RundCSIProtocol3) {
@@ -1467,7 +1457,7 @@ func (ns *nodeServer) checkMountedOfRunvAndRund(volumeId, targetPath string) boo
 		}
 	}
 
-	device, err := GetVolumeDeviceName(volumeId)
+	device, err := ns.ad.GetRootBlockDevice(klog.TODO(), volumeId)
 	if err != nil {
 		// In VFIO mode, an empty device is an expected condition, so the resulting error should be ignored.
 		klog.Warningf("NodeStageVolume: GetVolumeDeviceName failed: %s", err.Error())

--- a/pkg/disk/utils_test.go
+++ b/pkg/disk/utils_test.go
@@ -474,12 +474,10 @@ func TestGetAvailableDiskCountFromOpenAPI(t *testing.T) {
 	}
 }
 
+const longDiskID = "d-some-very-looooooooooooooooog-value-that-cause-getxattr-to-fail"
+
 func TestGetVolumeCountFromOpenAPI(t *testing.T) {
-	orgiDiskXattrName := DiskXattrName
-	DiskXattrName = "user.testing-csi-managed-disk"
-	t.Cleanup(func() {
-		DiskXattrName = orgiDiskXattrName
-	})
+	testDiskXattr(t)
 
 	ctrl := gomock.NewController(t)
 	c := cloud.NewMockECSInterface(ctrl)
@@ -501,7 +499,7 @@ func TestGetVolumeCountFromOpenAPI(t *testing.T) {
 	// manually attached disk has no xattr
 	dev.AddDisk(t, "node-for-2zeh74nnxxrobxz49eug", nil)
 	// an arbitrary error for getxattr, we should ignore it
-	dev.AddDisk(t, "node-for-testinglocaldisk", []byte("d-some-very-looooog-value-that-cause-getxattr-to-fail"))
+	dev.AddDisk(t, "node-for-testinglocaldisk", []byte(longDiskID))
 
 	getNode := func() (*corev1.Node, error) { return testNode(), nil }
 	count, err := getVolumeCountFromOpenAPI(getNode, c, efloc, testMetadata, &dev, "")

--- a/pkg/disk/xattr.go
+++ b/pkg/disk/xattr.go
@@ -1,12 +1,141 @@
 package disk
 
+import (
+	"errors"
+	"fmt"
+	"sync"
+
+	utilsio "github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/utils/io"
+	"golang.org/x/sys/unix"
+	"k8s.io/klog/v2"
+)
+
 var (
 	// DiskXattrName xattr is applied on the block device file to indicate that it is managed by the CSI driver.
 	// Value is the disk ID.
-	// Linux only support trusted namespace xattr in tmpfs before kernel v6.6,
-	// but setting trusted xaattr requires CAP_SYS_ADMIN capability, we may use user namespace instead in unit tests.
+	// Linux support only trusted namespace xattr in tmpfs until kernel v6.6,
+	// but setting trusted xattr requires CAP_SYS_ADMIN capability, we may use user namespace instead in unit tests.
 	DiskXattrName = "trusted.csi-managed-disk"
 
 	// DiskXattrVirtioBlkName xattr is applied on the block device file to indicate that it is managed by the CSI driver in PVM ways.
 	DiskXattrVirtioBlkName = "trusted.virtio-blk"
 )
+
+// Alibaba Cloud diskID length is currently 22, but we allow 64 bytes for future extension.
+const DiskXattrMaxLen = 64
+
+var getXattrTestHook = func() {}
+
+func getDiskXattr(p string) (string, error) {
+	var diskID [DiskXattrMaxLen]byte
+	sz, err := unix.Getxattr(p, DiskXattrName, diskID[:])
+	getXattrTestHook()
+	if err == nil {
+		// this disk has xattr, it is managed by us
+		return string(diskID[:sz]), nil
+	} else {
+		return "", fmt.Errorf("failed to get xattr for %s: %w", p, err)
+	}
+}
+
+func setDiskXattr(p, diskID string) error {
+	if len(diskID) > DiskXattrMaxLen {
+		return fmt.Errorf("diskID %s is too long to fit xattr", diskID)
+	}
+	err := unix.Setxattr(p, DiskXattrName, []byte(diskID), 0)
+	if err != nil {
+		return fmt.Errorf("failed to set xattr for %s: %w", p, err)
+	}
+	return nil
+}
+
+// returns map from diskID to its device path
+func listDiskXattrs(dev utilsio.DiskLister) (map[string]string, error) {
+	diskPaths, err := dev.ListDisks()
+	if err != nil {
+		return nil, fmt.Errorf("failed to list devices: %w", err)
+	}
+	result := map[string]string{}
+	for _, p := range diskPaths {
+		diskID, err := getDiskXattr(p)
+		if err != nil {
+			if !utilsio.IsXattrNotFound(err) {
+				klog.Warningf("failed to get xattr of %s, assuming not managed by us: %s", p, err)
+			}
+		} else if diskID != "" {
+			result[diskID] = p
+		}
+	}
+	return result, nil
+}
+
+// devMap records the device path of disks without serial
+//
+// It adds xattr to the device inode.
+// It never removes the xattr. When the disk is detached, the xattr is gone with the device inode.
+// We also use this property to detect any external detach to the disk.
+type devMap struct {
+	m sync.Map
+}
+
+func NewDevMap(dev utilsio.DiskLister) (*devMap, error) {
+	mm, err := listDiskXattrs(dev)
+	if err != nil {
+		return nil, err
+	}
+	m := devMap{}
+	for k, v := range mm {
+		m.m.Store(k, &v)
+	}
+	return &m, nil
+}
+
+func (m *devMap) Add(diskID, devPath string) error {
+	err := setDiskXattr(devPath, diskID)
+	if err != nil {
+		return err
+	}
+	// Use pointer to distinguish different instances of the same devPath.
+	// See CompareAndDelete below.
+	m.m.Store(diskID, &devPath)
+	return nil
+}
+
+// returns empty string is no matching device found
+func (m *devMap) Get(logger klog.Logger, diskID string) (string, error) {
+	v, ok := m.m.Load(diskID)
+	if !ok {
+		return "", nil
+	}
+	devPath := *v.(*string)
+	xattr, err := getDiskXattr(devPath)
+	if err != nil {
+		if errors.Is(err, unix.ENOENT) {
+			logger.V(1).Info("cached disk device disappeared", "dev", devPath, "diskID", diskID)
+			m.stall(logger, diskID, v)
+			return "", nil
+		} else if utilsio.IsXattrNotFound(err) {
+			logger.V(1).Info("disk has no xattr", "dev", devPath, "diskID", diskID)
+			m.stall(logger, diskID, v)
+			return "", nil
+		} else {
+			return "", err
+		}
+	}
+	if xattr != diskID {
+		logger.V(1).Info("disk xattr mismatch", "dev", devPath, "xattr", xattr, "diskID", diskID)
+		m.stall(logger, diskID, v)
+		return "", nil
+	}
+	return devPath, nil
+}
+
+func (m *devMap) stall(logger klog.Logger, diskID string, v any) {
+	if !m.m.CompareAndDelete(diskID, v) {
+		logger.V(1).Info("disk re-added", "diskID", diskID)
+	}
+}
+
+func (m *devMap) Delete(diskID string) {
+	m.m.Delete(diskID)
+}

--- a/pkg/disk/xattr_test.go
+++ b/pkg/disk/xattr_test.go
@@ -1,0 +1,113 @@
+package disk
+
+import (
+	"os"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/unix"
+	"k8s.io/klog/v2/ktesting"
+)
+
+func testDiskXattr(t *testing.T) {
+	orgiDiskXattrName := DiskXattrName
+	DiskXattrName = "user.testing-csi-managed-disk"
+	t.Cleanup(func() {
+		DiskXattrName = orgiDiskXattrName
+	})
+
+}
+
+func TestDevMap(t *testing.T) {
+	testDiskXattr(t)
+	logger, _ := ktesting.NewTestContext(t)
+
+	d := MockDisks{
+		base: t.TempDir(),
+	}
+	d.AddDisk(t, "/vda", []byte("d-disk1"))
+	d.AddDisk(t, "/vdb", nil) // d-disk2
+	d.AddDisk(t, "/vdc", []byte("d-disk3"))
+	d.AddDisk(t, "/vdd", []byte("d-disk4"))
+	d.AddDisk(t, "/vde", []byte("d-disk5"))
+
+	m, err := NewDevMap(&d)
+	assert.NoError(t, err)
+
+	require.NoError(t, os.Remove(d.base+"/vdc")) // vdc detached
+	// detached then attached another disk at vdd
+	require.NoError(t, unix.Setxattr(d.base+"/vdd", DiskXattrName, []byte("d-whatever"), 0))
+	// detached then attached another unmanaged disk at vde
+	require.NoError(t, unix.Removexattr(d.base+"/vde", DiskXattrName))
+
+	p, err := m.Get(logger, "d-disk1")
+	assert.NoError(t, err)
+	assert.Equal(t, d.base+"/vda", p)
+
+	for _, d := range []string{"d-disk2", "d-disk3", "d-disk4", "d-disk5"} {
+		p, err := m.Get(logger, d)
+		assert.NoError(t, err)
+		assert.Equal(t, "", p)
+	}
+
+	require.NoError(t, os.WriteFile(d.base+"/vdf", nil, 0644))
+	assert.NoError(t, m.Add("d-disk6", d.base+"/vdf"))
+	p, err = m.Get(logger, "d-disk6")
+	assert.NoError(t, err)
+	assert.Equal(t, d.base+"/vdf", p)
+
+	m.Delete("d-disk6")
+	p, err = m.Get(logger, "d-disk6")
+	assert.NoError(t, err)
+	assert.Equal(t, "", p)
+
+}
+
+func TestDevMapAddError(t *testing.T) {
+	testDiskXattr(t)
+	m := devMap{}
+	assert.Error(t, m.Add("d-disk1", "/not-exist"))
+	assert.Error(t, m.Add(longDiskID, "/dev/vda"))
+}
+
+func TestDevMapRace(t *testing.T) {
+	testDiskXattr(t)
+
+	getXattrTestHook = func() {
+		time.Sleep(2 * time.Millisecond)
+	}
+	defer func() {
+		getXattrTestHook = func() {}
+	}()
+
+	logger, _ := ktesting.NewTestContext(t)
+	synctest.Test(t, func(t *testing.T) {
+		m := devMap{}
+		base := t.TempDir()
+		require.NoError(t, os.WriteFile(base+"/vda", nil, 0644))
+		require.NoError(t, m.Add("d-disk1", base+"/vda"))
+
+		require.NoError(t, os.Remove(base+"/vda"))
+		require.NoError(t, os.WriteFile(base+"/vdb", nil, 0644))
+
+		// disk1 detached
+		// t0: read disk1 xattr, file not found
+		// t1: disk1 re-attached as vdb
+		// t2: disk1 remove from m, but value mismatch
+		// t3: get disk2, vbd returned
+		go func() {
+			p, err := m.Get(logger, "d-disk1") // t0
+			require.NoError(t, err)
+			require.Equal(t, "", p) // t2
+		}()
+		time.Sleep(1 * time.Millisecond)
+		require.NoError(t, m.Add("d-disk1", base+"/vdb")) // t1
+		time.Sleep(2 * time.Millisecond)
+		p, err := m.Get(logger, "d-disk1") // t3
+		require.NoError(t, err)
+		require.Equal(t, base+"/vdb", p)
+	})
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

We used to use /etc/kubernetes/volumes/disk/d-*.conf files to record the relationships between disks without serial number and the device path. But it has multiple drawbacks:
- leak: we may fail to remove the files we created
- inaccurate: if the disk is detached, switched driver, the device will gone without our knowledge. In this case, the conf file may points to a non-exist file, or even a wrong file.

Replace the conf files with xattr, which we are already using to calculate number of volumes available on node. The xattrs are attached to the device inode, and will go with the inode. So that we don't need to worry about any cleanup or inaccuracy.

Old conf files are migrated to xattr in one go, in the init container.

As a bonus, the partition support is now more decoupled, and should work on more scenarios. xattrs are always attached to root block device, not partition.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

/hold
for manual verification on disks without serial number

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
