### PR TITLE
credentials: auto-enable VPC endpoint when running in VPC network

### DIFF
--- a/main.go
+++ b/main.go
@@ -160,15 +160,23 @@ func main() {
 		}
 	}
 
+	regionID, err := meta.Get(metadata.RegionID)
+	if err != nil {
+		klog.ErrorS(err, "failed to get regionID for metadata, use cn-hangzhou")
+		regionID = "cn-hangzhou"
+	} else {
+		// OIDC recognize this env to enable vpc endpoint
+		if _, ok := os.LookupEnv("ALIBABA_CLOUD_STS_REGION"); !ok {
+			if err := os.Setenv("ALIBABA_CLOUD_STS_REGION", regionID); err != nil {
+				klog.ErrorS(err, "failed to set ALIBABA_CLOUD_STS_REGION")
+			}
+		}
+	}
+
 	provider, err := credentials.NewProvider()
 	if err != nil {
 		klog.ErrorS(err, "failed to get credential for metadata, will not enable OpenAPI")
 	} else {
-		regionID, err := meta.Get(metadata.RegionID)
-		if err != nil {
-			klog.ErrorS(err, "failed to get regionID for metadata, use cn-hangzhou")
-			regionID = "cn-hangzhou"
-		}
 		cred := alicred_old.FromCredentialsProvider(provider.GetProviderName(), provider)
 
 		ecsClient, err := ecs20140526.NewClient(utils.GetEcsConfig(regionID).SetCredential(cred))

--- a/pkg/credentials/credential.go
+++ b/pkg/credentials/credential.go
@@ -7,6 +7,7 @@ import (
 	alicred_v1 "github.com/aliyun/alibaba-cloud-sdk-go/sdk/auth/credentials"
 	alicred_old "github.com/aliyun/credentials-go/credentials"
 	alicred "github.com/aliyun/credentials-go/credentials/providers"
+	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/utils"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/clock"
 )
@@ -38,6 +39,13 @@ func NewProvider() (alicred.CredentialsProvider, error) {
 	}
 
 	MigrateEnv()
+
+	if _, ok := os.LookupEnv("ALIBABA_CLOUD_VPC_ENDPOINT_ENABLED"); !ok && utils.GetNetworkType() == "vpc" {
+		// OIDC recognize this env to enable vpc endpoint
+		if err := os.Setenv("ALIBABA_CLOUD_VPC_ENDPOINT_ENABLED", "true"); err != nil {
+			return nil, err
+		}
+	}
 
 	// try managed token credential
 	provider, err := NewManagedTokenProvider(clock.RealClock{}, GetManagedTokenPath())


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

When the CSI driver is running in a VPC network, the Alibaba Cloud credentials SDK supports using VPC endpoints for authentication (controlled by the `ALIBABA_CLOUD_VPC_ENDPOINT_ENABLED` environment variable). Previously, users had to manually set this environment variable to enable VPC endpoint usage.

This PR automatically sets `ALIBABA_CLOUD_VPC_ENDPOINT_ENABLED=true` when:
1. The current network type is detected as `vpc` (via `utils.GetNetworkType()`)
2. The environment variable has not already been set by the user

This improves out-of-the-box behavior for VPC deployments without breaking existing configurations where the variable is explicitly set.

#### Which issue(s) this PR fixes:

No linked issues

#### Special notes for your reviewer:

The check uses `os.LookupEnv` to preserve any existing user-set value (including `false`) and only auto-sets when the variable is absent.

#### Does this PR introduce a user-facing change?

```release-note
credentials: automatically enable VPC endpoint for Alibaba Cloud credential provider when running in VPC network
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
