### PR TITLE
disk: refactor node RPC methods to use structured logging

### DIFF
--- a/pkg/common/nodeserver.go
+++ b/pkg/common/nodeserver.go
@@ -120,6 +120,12 @@ func (s NodeServerWithLog) NodeExpandVolume(ctx context.Context, req *csi.NodeEx
 	return logGRPC(s.NodeServerWithValidator.NodeExpandVolume, ctx, req)
 }
 
+func (s NodeServerWithLog) NodeGetInfo(ctx context.Context, req *csi.NodeGetInfoRequest) (*csi.NodeGetInfoResponse, error) {
+	logger := klog.FromContext(ctx)
+	ctx = klog.NewContext(ctx, logger.WithValues("method", "NodeGetInfo"))
+	return logGRPC(s.NodeServerWithValidator.NodeGetInfo, ctx, req)
+}
+
 type NodeServerWithValidator struct {
 	csi.NodeServer
 }

--- a/pkg/disk/nodeserver.go
+++ b/pkg/disk/nodeserver.go
@@ -285,11 +285,10 @@ func (ns *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 	// if target path mounted already, return
 	notMounted, err := ns.k8smounter.IsLikelyNotMountPoint(targetPath)
 	if err != nil && !errors.Is(err, fs.ErrNotExist) {
-		klog.Errorf("NodePublishVolume: failed to check if %s is a mount point err: %v", targetPath, err)
 		return nil, status.Errorf(codes.Internal, "failed to check if %s is a mount point: %v", targetPath, err)
 	}
 	if !notMounted {
-		klog.Infof("NodePublishVolume: TargetPath(%s) is mounted, not need mount again", targetPath)
+		logger.V(2).Info("TargetPath is mounted, not need mount again", "target", targetPath)
 		return &csi.NodePublishVolumeResponse{}, nil
 	}
 
@@ -298,22 +297,21 @@ func (ns *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 		sourcePath = filepath.Join(req.StagingTargetPath, req.VolumeId)
 	} else {
 		if err := os.MkdirAll(targetPath, 0755); err != nil {
-			klog.Errorf("NodePublishVolume: create volume %s path %s error: %v", req.VolumeId, targetPath, err)
-			return nil, status.Error(codes.Internal, err.Error())
+			return nil, status.Errorf(codes.Internal, "create target path %s: %v", targetPath, err)
 		}
 	}
 
 	options, fsType := prepareMountInfos(req)
 
-	klog.Infof("NodePublishVolume: Starting Mount Volume %s, source %s > target %s", req.VolumeId, sourcePath, targetPath)
+	logger.V(2).Info("Starting mount", "source", sourcePath, "target", targetPath)
 
 	mkfsOptions := req.VolumeContext[MkfsOptions]
 	// Logics will be merged into runD when vfio of pvm is ready
 	if req.PublishContext["csi.alibabacloud.com/runtimeClassName"] == utils.PVMRunTimeTag {
-		klog.Infof("NodePublishVolume: start mount in pvm mode %s", req.TargetPath)
+		logger.V(2).Info("start mount in pvm mode", "target", req.TargetPath)
 		mountFlags := req.GetVolumeCapability().GetMount().GetMountFlags()
 		pvName := utils.GetPvNameFormPodMnt(targetPath)
-		returned, err := ns.mountRunDVolumes(req.VolumeId, pvName, sourcePath, req.TargetPath, fsType, mkfsOptions, isBlock, true, mountFlags)
+		returned, err := ns.mountRunDVolumes(logger, req.VolumeId, pvName, sourcePath, req.TargetPath, fsType, mkfsOptions, isBlock, true, mountFlags)
 		if err != nil {
 			return nil, err
 		}
@@ -325,16 +323,16 @@ func (ns *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 	// check pod runtime
 	switch runtime {
 	case utils.RunvRunTimeTag:
-		err := ns.mountRunvVolumes(req.VolumeId, sourcePath, req.TargetPath, fsType, mkfsOptions, isBlock, options)
+		err := ns.mountRunvVolumes(logger, req.VolumeId, sourcePath, req.TargetPath)
 		if err != nil {
 			return nil, err
 		}
 		return &csi.NodePublishVolumeResponse{}, nil
 	case utils.RundRunTimeTag:
-		klog.Infof("NodePublishVolume: TargetPath: %s is unmounted, start mount in kata mode", req.TargetPath)
+		logger.V(2).Info("start mount in kata mode", "target", req.TargetPath)
 		mountFlags := req.GetVolumeCapability().GetMount().GetMountFlags()
 		pvName := utils.GetPvNameFormPodMnt(targetPath)
-		returned, err := ns.mountRunDVolumes(req.VolumeId, pvName, sourcePath, req.TargetPath, fsType, mkfsOptions, isBlock, false, mountFlags)
+		returned, err := ns.mountRunDVolumes(logger, req.VolumeId, pvName, sourcePath, req.TargetPath, fsType, mkfsOptions, isBlock, false, mountFlags)
 		if err != nil {
 			return nil, err
 		}
@@ -359,7 +357,7 @@ func (ns *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 				return nil, err
 			}
 		}
-		klog.Infof("NodePublishVolume: Mount Successful Block Volume: %s, from source %s to target %v", req.VolumeId, sourcePath, targetPath)
+		logger.V(2).Info("Mount successful (block volume)", "source", sourcePath, "target", targetPath)
 		return &csi.NodePublishVolumeResponse{}, nil
 	}
 
@@ -370,34 +368,33 @@ func (ns *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 	if sourceNotMounted {
 		device, err := DefaultDeviceManager.GetDeviceByVolumeID(req.GetVolumeId())
 		if err == nil {
-			if err := ns.mountDeviceToGlobal(req.VolumeCapability, req.VolumeContext, device, sourcePath); err != nil {
-				return nil, status.Errorf(codes.Internal, "NodePublishVolume: VolumeId: %s, remount disk to sourcePath %s failed: %s", req.VolumeId, sourcePath, err.Error())
+			if err := ns.mountDeviceToGlobal(logger, req.VolumeCapability, req.VolumeContext, device, sourcePath); err != nil {
+				return nil, status.Errorf(codes.Internal, "remount disk to sourcePath %s: %v", sourcePath, err)
 			}
-			klog.Infof("NodePublishVolume: SourcePath %s not mounted, and mounted again with device %s", sourcePath, device)
+			logger.V(2).Info("SourcePath not mounted, remounted with device", "source", sourcePath, "device", device)
 		} else {
-			return nil, status.Errorf(codes.Internal, "NodePublishVolume: VolumeId: %s, sourcePath %s is not mounted, and device not found: %s", req.VolumeId, sourcePath, err.Error())
+			return nil, status.Errorf(codes.Internal, "sourcePath %s is not mounted, and device not found: %v", sourcePath, err)
 		}
 	}
 
 	// check device name available
 	expectName, err := ns.ad.GetVolumeDeviceName(logger, req.VolumeId)
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "NodePublishVolume: VolumeId: %s, get device name error: %s", req.VolumeId, err.Error())
+		return nil, status.Errorf(codes.Internal, "get device name: %v", err)
 	}
 
 	realDevice, _, err := k8smount.GetDeviceNameFromMount(ns.k8smounter, sourcePath)
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "NodePublishVolume: get device name from mount %s error: %s", sourcePath, err.Error())
+		return nil, status.Errorf(codes.Internal, "get device name from mount %s: %v", sourcePath, err)
 	}
 	if realDevice == "" {
 		opts := append(options, "shared")
 		if err := ns.k8smounter.Mount(expectName, sourcePath, fsType, opts); err != nil {
-			klog.Errorf("NodePublishVolume: mount source error: %s, %s, %s", expectName, sourcePath, err.Error())
-			return nil, status.Error(codes.Internal, "NodePublishVolume: mount source error: "+expectName+", "+sourcePath+", "+err.Error())
+			return nil, status.Errorf(codes.Internal, "mount source %s to %s: %v", expectName, sourcePath, err)
 		}
 		realDevice, _, err = k8smount.GetDeviceNameFromMount(ns.k8smounter, sourcePath)
 		if err != nil {
-			return nil, status.Errorf(codes.Internal, "NodePublishVolume: get device name from mount %s error: %s", sourcePath, err.Error())
+			return nil, status.Errorf(codes.Internal, "get device name from mount %s: %v", sourcePath, err)
 		}
 	}
 	if realDevice != "tmpfs" {
@@ -405,40 +402,40 @@ func (ns *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 		if realDevice != "" {
 			realMajor, realMinor, err := DefaultDeviceManager.DevTmpFS.DevFor(realDevice)
 			if err != nil {
-				return nil, status.Errorf(codes.Internal, "NodePublishVolume: VolumeId: %s, stat real %q failed: %s", req.VolumeId, realDevice, err.Error())
+				return nil, status.Errorf(codes.Internal, "stat real device %q: %v", realDevice, err)
 			}
 			expectMajor, expectMinor, err := DefaultDeviceManager.DevTmpFS.DevFor(expectName)
 			if err != nil {
-				return nil, status.Errorf(codes.Internal, "NodePublishVolume: VolumeId: %s, stat expect %q failed: %s", req.VolumeId, expectName, err.Error())
+				return nil, status.Errorf(codes.Internal, "stat expected device %q: %v", expectName, err)
 			}
 			if realMajor == expectMajor && realMinor == expectMinor {
 				matched = true
 			}
 		}
 		if !matched {
-			return nil, status.Errorf(codes.Internal, "NodePublishVolume: VolumeId: %s, real Device: %s not same with expected: %s", req.VolumeId, realDevice, expectName)
+			return nil, status.Errorf(codes.Internal, "real device %s not same with expected %s", realDevice, expectName)
 		}
 	}
 
 	// Set volume IO Limit
 	err = ns.podCGroup.ApplyConfig(realDevice, req)
 	if err != nil {
-		klog.Errorf("NodePublishVolume: Set Disk Volume(%s) IO Limit with Error: %s", req.VolumeId, err.Error())
-		return nil, status.Error(codes.Internal, err.Error())
+		return nil, status.Errorf(codes.Internal, "set IO limit: %v", err)
 	}
 
-	klog.Infof("NodePublishVolume: Starting mount volume %s with flags %v and fsType %s", req.VolumeId, options, fsType)
+	logger.V(2).Info("Starting mount", "options", options, "fsType", fsType)
 	if err = ns.k8smounter.Mount(sourcePath, targetPath, fsType, options); err != nil {
-		return nil, status.Error(codes.Internal, err.Error())
+		return nil, status.Errorf(codes.Internal, "mount %s to %s: %v", sourcePath, targetPath, err)
 	}
 
-	klog.Infof("NodePublishVolume: Mount Successful Volume: %s, from source %s to target %v", req.VolumeId, sourcePath, targetPath)
+	logger.V(2).Info("Mount successful", "source", sourcePath, "target", targetPath)
 	return &csi.NodePublishVolumeResponse{}, nil
 }
 
 func (ns *nodeServer) NodeUnpublishVolume(ctx context.Context, req *csi.NodeUnpublishVolumeRequest) (*csi.NodeUnpublishVolumeResponse, error) {
+	logger := klog.FromContext(ctx)
 	targetPath := req.GetTargetPath()
-	klog.Infof("NodeUnpublishVolume: Starting to Unmount Volume %s, Target %v", req.VolumeId, targetPath)
+	logger.V(2).Info("Starting to unmount", "target", targetPath)
 
 	if !ns.locks.TryAcquire(req.VolumeId) {
 		return nil, status.Errorf(codes.Aborted, "There is already an operation for %s", req.VolumeId)
@@ -447,10 +444,10 @@ func (ns *nodeServer) NodeUnpublishVolume(ctx context.Context, req *csi.NodeUnpu
 
 	// Step 1: check folder exists
 	if !IsFileExisting(targetPath) {
-		if err := ns.unmountDuplicateMountPoint(targetPath, req.VolumeId); err != nil {
+		if err := ns.unmountDuplicateMountPoint(logger, targetPath, req.VolumeId); err != nil {
 			return nil, status.Error(codes.Internal, err.Error())
 		}
-		klog.Infof("NodeUnpublishVolume: Volume %s Folder %s doesn't exist", req.VolumeId, targetPath)
+		logger.V(2).Info("Folder doesn't exist", "target", targetPath)
 		return &csi.NodeUnpublishVolumeResponse{}, nil
 	}
 
@@ -461,58 +458,55 @@ func (ns *nodeServer) NodeUnpublishVolume(ctx context.Context, req *csi.NodeUnpu
 	}
 	if notmounted {
 		// check runtime mode
-		isRunDType, err := ns.umountRunDVolumes(targetPath)
+		isRunDType, err := ns.umountRunDVolumes(logger, targetPath)
 		if err != nil {
-			return nil, status.Errorf(codes.Internal, "NodeUnpublishVolume: umountRunDVolumes with error: %s", err.Error())
+			return nil, status.Errorf(codes.Internal, "umountRunDVolumes: %v", err)
 		}
 		if isRunDType {
-			klog.Infof("NodeUnpublishVolume: %s is runD volume and is removed successful", targetPath)
+			logger.V(2).Info("runD volume removed successfully", "target", targetPath)
 			return &csi.NodeUnpublishVolumeResponse{}, nil
 		}
 
 		if empty, _ := IsDirEmpty(targetPath); empty {
-			if err := ns.unmountDuplicateMountPoint(targetPath, req.VolumeId); err != nil {
+			if err := ns.unmountDuplicateMountPoint(logger, targetPath, req.VolumeId); err != nil {
 				return nil, status.Error(codes.Internal, err.Error())
 			}
-			klog.Infof("NodeUnpublishVolume: %s is unmounted and empty", targetPath)
+			logger.V(2).Info("target is unmounted and empty", "target", targetPath)
 			return &csi.NodeUnpublishVolumeResponse{}, nil
 		}
 		// Block device
 		if !utils.IsDir(targetPath) && strings.HasPrefix(targetPath, BLOCKVOLUMEPREFIX) {
 			if removeErr := os.Remove(targetPath); removeErr != nil {
-				klog.Errorf("NodeUnpublishVolume: VolumeId: %s, Could not remove mount block target %s with error %v", req.VolumeId, targetPath, removeErr)
-				return nil, status.Errorf(codes.Internal, "Could not remove mount block target %s: %v", targetPath, removeErr)
+				return nil, status.Errorf(codes.Internal, "remove mount block target %s: %v", targetPath, removeErr)
 			}
-			klog.Infof("NodeUnpublishVolume: %s is block volume and is removed successful", targetPath)
+			logger.V(2).Info("block volume removed successfully", "target", targetPath)
 			return &csi.NodeUnpublishVolumeResponse{}, nil
 		}
-		klog.Errorf("NodeUnpublishVolume: VolumeId: %s, Path %s is unmounted, but not empty dir", req.VolumeId, targetPath)
-		return nil, status.Errorf(codes.Internal, "NodeUnpublishVolume: VolumeId: %s, Path %s is unmounted, but not empty dir", req.VolumeId, targetPath)
+		return nil, status.Errorf(codes.Internal, "path %s is unmounted, but not empty dir", targetPath)
 	}
 
 	// Step 3: umount target path
 	err = ns.k8smounter.Unmount(targetPath)
 	if err != nil {
-		klog.Errorf("NodeUnpublishVolume: volumeId: %s, umount path: %s with error: %s", req.VolumeId, targetPath, err.Error())
-		return nil, status.Error(codes.Internal, err.Error())
+		return nil, status.Errorf(codes.Internal, "umount %s: %v", targetPath, err)
 	}
 	err = os.Remove(targetPath)
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "NodeUnpublishVolume: Cannot remove targetPath %s: %v", targetPath, err)
+		return nil, status.Errorf(codes.Internal, "remove targetPath %s: %v", targetPath, err)
 	}
 
 	// below directory can not be unmounted by kubelet in ack
-	if err := ns.unmountDuplicateMountPoint(targetPath, req.VolumeId); err != nil {
-		klog.Errorf("NodeUnpublishVolume: umount duplicate mountpoint %s with error: %v", targetPath, err)
-		return nil, status.Error(codes.Internal, err.Error())
+	if err := ns.unmountDuplicateMountPoint(logger, targetPath, req.VolumeId); err != nil {
+		return nil, status.Errorf(codes.Internal, "umount duplicate mountpoint %s: %v", targetPath, err)
 	}
 
-	klog.Infof("NodeUnpublishVolume: Umount Successful for volume %s, target %v", req.VolumeId, targetPath)
+	logger.V(2).Info("Umount successful", "target", targetPath)
 	return &csi.NodeUnpublishVolumeResponse{}, nil
 }
 
 func (ns *nodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRequest) (*csi.NodeStageVolumeResponse, error) {
-	klog.Infof("NodeStageVolume: Stage VolumeId: %s, Target Path: %s, VolumeContext: %v", req.GetVolumeId(), req.StagingTargetPath, req.VolumeContext)
+	logger := klog.FromContext(ctx)
+	logger.V(2).Info("Stage", "target", req.StagingTargetPath, "volumeContext", req.VolumeContext)
 
 	if !ns.locks.TryAcquire(req.VolumeId) {
 		return nil, status.Errorf(codes.Aborted, "There is already an operation for %s", req.VolumeId)
@@ -523,8 +517,7 @@ func (ns *nodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVol
 	// targetPath format: /var/lib/kubelet/plugins/kubernetes.io/csi/pv/pv-disk-1e7001e0-c54a-11e9-8f89-00163e0e78a0/globalmount
 
 	if err := os.MkdirAll(targetPath, 0755); err != nil {
-		klog.Errorf("NodeStageVolume: create volume %s path %s error: %v", req.VolumeId, targetPath, err)
-		return nil, status.Error(codes.Internal, err.Error())
+		return nil, status.Errorf(codes.Internal, "create target path %s: %v", targetPath, err)
 	}
 
 	isBlock := req.GetVolumeCapability().GetBlock() != nil
@@ -532,14 +525,14 @@ func (ns *nodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVol
 		targetPath = filepath.Join(targetPath, req.VolumeId)
 	}
 	// for runc & rund-csi2.0 kubelet restart
-	mounted, err := ns.checkTargetPathMounted(req.VolumeId, targetPath)
+	mounted, err := ns.checkTargetPathMounted(logger, req.VolumeId, targetPath)
 	if err != nil {
-		return nil, err
+		return nil, status.Errorf(codes.Internal, "checkTargetPathMounted: %v", err)
 	}
 	if mounted {
 		return &csi.NodeStageVolumeResponse{}, nil
 	}
-	mounted = ns.checkMountedOfRunvAndRund(req.VolumeId, targetPath)
+	mounted = ns.checkMountedOfRunvAndRund(logger, req.VolumeId, targetPath)
 	if mounted {
 		return &csi.NodeStageVolumeResponse{}, nil
 	}
@@ -564,7 +557,7 @@ func (ns *nodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVol
 		device, err = ns.ad.findDevice(ctx, req.VolumeId, serial, nil)
 		if err != nil {
 			if GlobalConfigVar.ADControllerEnable || isMultiAttach {
-				return nil, status.Errorf(defaultErrCode, "NodeStageVolume: ADController Enabled, but disk %s can't be found: %v", req.VolumeId, err)
+				return nil, status.Errorf(defaultErrCode, "ADController Enabled, but disk can't be found: %v", err)
 			}
 			// This disk should have been attached by controller, but old NodeUnstageVolume detaches it.
 			// So lets try attach it back.
@@ -574,8 +567,8 @@ func (ns *nodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVol
 		device, err = ns.ad.attachDisk(ctx, req.GetVolumeId(), ns.NodeID, true)
 		if err != nil {
 			fullErrorMessage := utils.FindSuggestionByErrorMessage(err.Error(), utils.DiskAttachDetach)
-			klog.Errorf("NodeStageVolume: Attach volume: %s with error: %s", req.VolumeId, fullErrorMessage)
-			return nil, status.Errorf(codes.Aborted, "NodeStageVolume: Attach volume: %s with error: %+v", req.VolumeId, err)
+			logger.Error(err, "Attach volume failed", "suggestion", fullErrorMessage)
+			return nil, status.Errorf(codes.Aborted, "attach volume: %v", err)
 		}
 		// Now we have attached the disk, if we fail later, NodeStageVolume is in-progress.
 		// Return Aborted so that the CO will call NodeUnstageVolume later to detach.
@@ -585,15 +578,14 @@ func (ns *nodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVol
 	if req.VolumeCapability.GetMount() != nil {
 		device, err = DefaultDeviceManager.adaptDevicePartition(device)
 		if err != nil {
-			return nil, status.Errorf(codes.Aborted, "NodeStageVolume: failed to adapt partition %s: %v", device, err)
+			return nil, status.Errorf(codes.Aborted, "failed to adapt partition %s: %v", device, err)
 		}
 	}
 
 	if err := CheckDeviceAvailable(device, req.VolumeId, targetPath); err != nil {
-		klog.Errorf("NodeStageVolume: check device %s for volume %s with error: %s", device, req.VolumeId, err.Error())
-		return nil, status.Error(defaultErrCode, err.Error())
+		return nil, status.Errorf(defaultErrCode, "check device %s: %v", device, err)
 	}
-	klog.Infof("NodeStageVolume: Volume Successful Attached: %s, to Node: %s, Device: %s", req.VolumeId, ns.NodeID, device)
+	logger.V(2).Info("Volume attached successfully", "node", ns.NodeID, "device", device)
 
 	sysConfigs, err := utilsio.ParseSysConfigs(req.VolumeContext[SysConfigTag], allowSysConfigKey)
 	if err != nil {
@@ -727,7 +719,7 @@ func (ns *nodeServer) unmountTargetPath(logger klog.Logger, targetPath, volumeID
 
 func (ns *nodeServer) NodeUnstageVolume(ctx context.Context, req *csi.NodeUnstageVolumeRequest) (*csi.NodeUnstageVolumeResponse, error) {
 	logger := klog.FromContext(ctx)
-	logger.Info("Starting to Unmount volume", "target", req.StagingTargetPath)
+	logger.V(2).Info("Starting to unmount volume", "target", req.StagingTargetPath)
 
 	if !ns.locks.TryAcquire(req.VolumeId) {
 		return nil, status.Errorf(codes.Aborted, "There is already an operation for %s", req.VolumeId)
@@ -741,7 +733,7 @@ func (ns *nodeServer) NodeUnstageVolume(ctx context.Context, req *csi.NodeUnstag
 
 	if IsVFNode() {
 		if err := unbindBdfDisk(req.VolumeId); err != nil {
-			klog.Errorf("NodeUnstageVolume: unbind bdf disk %s with error: %v", req.VolumeId, err)
+			logger.Error(err, "unbind bdf disk failed")
 			return nil, err
 		}
 	}
@@ -751,7 +743,7 @@ func (ns *nodeServer) NodeUnstageVolume(ctx context.Context, req *csi.NodeUnstag
 			return nil, err
 		}
 		if err := clearBdfInfo(req.VolumeId, bdf); err != nil {
-			klog.Errorf("NodeUnstagedVolume: clear disk bdf info %s with err: %s", req.VolumeId, err)
+			logger.Error(err, "clear disk bdf info failed")
 			return nil, err
 		}
 	}
@@ -768,7 +760,7 @@ func (ns *nodeServer) NodeUnstageVolume(ctx context.Context, req *csi.NodeUnstag
 	} else {
 		err := setDiskXattr(device, req.VolumeId)
 		if err != nil {
-			klog.Errorf("NodeUnstageVolume: addDiskXattr %s failed: %v", req.VolumeId, err)
+			logger.Error(err, "setDiskXattr failed")
 		}
 	}
 
@@ -776,20 +768,20 @@ func (ns *nodeServer) NodeUnstageVolume(ctx context.Context, req *csi.NodeUnstag
 		return &csi.NodeUnstageVolumeResponse{}, nil
 	}
 	if GlobalConfigVar.DetachDisabled {
-		klog.Infof("NodeUnstageVolume: ADController is Disable, Detach Flag Set to false, PV %s", req.VolumeId)
+		logger.V(2).Info("ADController is disabled, detach flag set to false")
 		return &csi.NodeUnstageVolumeResponse{}, nil
 	}
 
 	if device != "" {
 		// best effort to avoid OpenAPI call. detachDisk will check again.
-		klog.V(2).InfoS("locally checked disk has serial number, defer detach to controller")
+		logger.V(2).Info("locally checked disk has serial number, defer detach to controller")
 		return &csi.NodeUnstageVolumeResponse{}, nil
 	}
 	// Do detach if ADController is disabled and disk has no serial number
 	ecsClient := GlobalConfigVar.EcsClient
 	err = ns.ad.detachDisk(ctx, ecsClient, req.VolumeId, ns.NodeID, true)
 	if err != nil {
-		klog.Errorf("NodeUnstageVolume: VolumeId: %s, Detach failed with error %v", req.VolumeId, err.Error())
+		logger.Error(err, "Detach failed")
 		return nil, err
 	}
 	ns.ad.devMap.Delete(req.VolumeId)
@@ -798,6 +790,8 @@ func (ns *nodeServer) NodeUnstageVolume(ctx context.Context, req *csi.NodeUnstag
 }
 
 func (ns *nodeServer) NodeGetInfo(ctx context.Context, req *csi.NodeGetInfoRequest) (*csi.NodeGetInfoResponse, error) {
+	logger := klog.FromContext(ctx)
+
 	maxVolumesNum, err := parseVolumeCountEnv()
 	if err != nil {
 		return nil, err
@@ -831,28 +825,28 @@ func (ns *nodeServer) NodeGetInfo(ctx context.Context, req *csi.NodeGetInfoReque
 	if !GlobalConfigVar.DiskAllowAllType {
 		// If it's a Lingjun node, reuse Lingjun detection and report configured supported types
 		if lingjunID != "" {
-			klog.InfoS("lingjun node detected", "lingjunID", lingjunID)
+			logger.V(2).Info("lingjun node detected", "lingjunID", lingjunID)
 			ebsCategory := os.Getenv("EBS_CATEGORY_LINGJUN_SUPPORTED")
 			// Prefer values parsed from kube-system/csi-plugin configmap
 			diskTypes = parseLingjunNodeDiskTypes(ebsCategory)
-			klog.Infof("NodeGetInfo: Lingjun node detected, supported disk types: %v", diskTypes)
+			logger.V(2).Info("Lingjun supported disk types", "diskTypes", diskTypes)
 		} else {
 			// Non-Lingjun: query ECS API for supported types
 			diskTypes, err = GetAvailableDiskTypes(ctx, c, ns.metadata)
 			if err != nil {
 				if hasDiskTypeLabel(node) {
-					klog.ErrorS(err, "NodeGetInfo: failed to get available disk types, will use existing config.")
+					logger.Error(err, "failed to get available disk types, will use existing config")
 				} else {
 					return nil, fmt.Errorf(
 						"failed to get available disk types: %w. "+
 							"You may add labels like node.csi.alibabacloud.com/disktype.cloud_essd=available to node manually", err)
 				}
 			} else {
-				klog.Infof("NodeGetInfo: Supported disk types: %v", diskTypes)
+				logger.V(2).Info("Supported disk types", "diskTypes", diskTypes)
 			}
 		}
 	} else {
-		klog.Warning("NodeGetInfo: DISK_ALLOW_ALL_TYPE is set, you need to ensure the EBS disk type is compatible with the ECS instance type yourself!")
+		logger.Info("DISK_ALLOW_ALL_TYPE is set, you need to ensure the EBS disk type is compatible with the ECS instance type yourself!")
 	}
 
 	patch := patchForNode(node, maxVolumesNum, diskTypes)
@@ -861,9 +855,9 @@ func (ns *nodeServer) NodeGetInfo(ctx context.Context, req *csi.NodeGetInfoReque
 		if err != nil {
 			return nil, fmt.Errorf("failed to update node: %w", err)
 		}
-		klog.Infof("NodeGetInfo: node updated")
+		logger.V(2).Info("node updated")
 	} else {
-		klog.Info("NodeGetInfo: no need to update node")
+		logger.V(2).Info("no need to update node")
 	}
 
 	segments := map[string]string{
@@ -897,24 +891,23 @@ func (ns *nodeServer) NodeExpandVolume(ctx context.Context, req *csi.NodeExpandV
 	logger.V(2).Info("starting", "req", req)
 
 	if req.VolumeCapability != nil && req.VolumeCapability.GetBlock() != nil {
-		klog.V(2).Info("skipping expand for block volume")
+		logger.V(2).Info("skipping expand for block volume")
 		return &csi.NodeExpandVolumeResponse{}, nil
 	}
 
 	volumePath := req.GetVolumePath()
-	diskID := req.GetVolumeId()
 	if strings.Contains(volumePath, BLOCKVOLUMEPREFIX) {
-		klog.Infof("NodeExpandVolume:: Block Volume not Expand FS, volumeId: %s, volumePath: %s", diskID, volumePath)
+		logger.V(2).Info("Block volume not expand FS", "volumePath", volumePath)
 		return &csi.NodeExpandVolumeResponse{}, nil
 	}
 
 	// volume resize in rund type will transfer to guest os
 	isRund, err := checkRundVolumeExpand(req)
 	if isRund && err == nil {
-		klog.Infof("NodeExpandVolume:: Rund Volume ExpandFS Successful, volumeId: %s, volumePath: %s", diskID, volumePath)
+		logger.V(2).Info("Rund volume ExpandFS successful", "volumePath", volumePath)
 		return &csi.NodeExpandVolumeResponse{}, nil
 	} else if isRund && err != nil {
-		klog.Errorf("NodeExpandVolume:: Rund Volume ExpandFS error(%s), volumeId: %s, volumePath: %s", err.Error(), diskID, volumePath)
+		logger.Error(err, "Rund volume ExpandFS failed", "volumePath", volumePath)
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
 
@@ -932,14 +925,14 @@ func (ns *nodeServer) localExpandVolume(ctx context.Context, req *csi.NodeExpand
 		if errors.Is(err, os.ErrNotExist) {
 			return nil, status.Errorf(codes.NotFound, "can't get devicePath for: %s", diskID)
 		}
-		return nil, status.Errorf(codes.Internal, "NodeExpandVolume: VolumeId: %s, get device name error: %s", req.VolumeId, err.Error())
+		return nil, status.Errorf(codes.Internal, "get device name: %v", err)
 	}
 	logger = logger.WithValues("device", devicePath)
 	ctx = klog.NewContext(ctx, logger)
 
 	rootPath, index, err := DefaultDeviceManager.GetDeviceRootAndPartitionIndex(devicePath)
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "GetDeviceRootAndIndex(%s) failed: %v", diskID, err)
+		return nil, status.Errorf(codes.Internal, "GetDeviceRootAndIndex(%s): %v", diskID, err)
 	}
 	if index != "" {
 		err := sfdisk.ExpandPartition(ctx, rootPath, index)
@@ -949,17 +942,15 @@ func (ns *nodeServer) localExpandVolume(ctx context.Context, req *csi.NodeExpand
 		logger.V(2).Info("Successful expand partition", "root", rootPath, "partition", index)
 	}
 
-	klog.V(2).Info("Expand filesystem start", "volumePath", volumePath)
+	logger.V(2).Info("Expand filesystem start", "volumePath", volumePath)
 	// use resizer to expand volume filesystem
 	r := k8smount.NewResizeFs(utilexec.New())
 	ok, err := r.Resize(devicePath, volumePath)
 	if err != nil {
-		klog.Errorf("NodeExpandVolume:: Resize Error, volumeId: %s, devicePath: %s, volumePath: %s, err: %s", diskID, devicePath, volumePath, err.Error())
-		return nil, status.Error(codes.Internal, err.Error())
+		return nil, status.Errorf(codes.Internal, "resize %s: %v", volumePath, err)
 	}
 	if !ok {
-		klog.Errorf("NodeExpandVolume:: Resize failed, volumeId: %s, devicePath: %s, volumePath: %s", diskID, devicePath, volumePath)
-		return nil, status.Error(codes.Internal, "Fail to resize volume fs")
+		return nil, status.Errorf(codes.Internal, "resize %s returned false", volumePath)
 	}
 
 	deviceCapacity := getBlockDeviceCapacity(rootPath)
@@ -969,39 +960,32 @@ func (ns *nodeServer) localExpandVolume(ctx context.Context, req *csi.NodeExpand
 		return nil, status.Errorf(codes.Aborted, "requested %v, but actual block size %v is smaller. Not updated yet?",
 			resource.NewQuantity(requestBytes, resource.BinarySI), resource.NewQuantity(deviceCapacity, resource.BinarySI))
 	}
-	klog.Infof("NodeExpandVolume:: Expand %s to %v successful", diskID, DiskSize{deviceCapacity})
+	logger.V(2).Info("Expand successful", "capacity", DiskSize{deviceCapacity})
 	return &csi.NodeExpandVolumeResponse{
 		CapacityBytes: deviceCapacity,
 	}, nil
 }
 
 // umount path and not remove
-func (ns *nodeServer) unmountStageTarget(targetPath string) error {
-	msgLog := "UnmountStageTarget: Unmount Stage Target: " + targetPath
-	if IsFileExisting(targetPath) {
-		notmounted, err := ns.k8smounter.IsLikelyNotMountPoint(targetPath)
-		if err != nil {
-			klog.Errorf("unmountStageTarget: check mountPoint: %s mountpoint error: %v", targetPath, err)
-			return status.Error(codes.Internal, err.Error())
-		}
-		if !notmounted {
-			err = ns.k8smounter.Unmount(targetPath)
-			if err != nil {
-				klog.Errorf("unmountStageTarget: umount path: %s failed with: %v", targetPath, err)
-				return status.Error(codes.Internal, err.Error())
-			}
-		} else {
-			msgLog = fmt.Sprintf("unmountStageTarget: umount %s Successful", targetPath)
-		}
-	} else {
-		msgLog = fmt.Sprintf("unmountStageTarget: Path %s doesn't exist", targetPath)
+func (ns *nodeServer) unmountStageTarget(logger klog.Logger, targetPath string) error {
+	if !IsFileExisting(targetPath) {
+		logger.V(2).Info("unmountStageTarget: path doesn't exist", "path", targetPath)
+		return nil
 	}
-
-	klog.Info(msgLog)
+	notmounted, err := ns.k8smounter.IsLikelyNotMountPoint(targetPath)
+	if err != nil {
+		return fmt.Errorf("check mountpoint %s: %w", targetPath, err)
+	}
+	if !notmounted {
+		if err = ns.k8smounter.Unmount(targetPath); err != nil {
+			return fmt.Errorf("umount %s: %w", targetPath, err)
+		}
+	}
+	logger.V(2).Info("unmountStageTarget successful", "path", targetPath)
 	return nil
 }
 
-func (ns *nodeServer) mountDeviceToGlobal(capability *csi.VolumeCapability, volumeContext map[string]string, device, sourcePath string) error {
+func (ns *nodeServer) mountDeviceToGlobal(logger klog.Logger, capability *csi.VolumeCapability, volumeContext map[string]string, device, sourcePath string) error {
 	mnt := capability.GetMount()
 	options := append(mnt.MountFlags, "shared")
 	fsType := "ext4"
@@ -1010,7 +994,7 @@ func (ns *nodeServer) mountDeviceToGlobal(capability *csi.VolumeCapability, volu
 	}
 	mountOptions := collectMountOptions(fsType, options)
 	if err := os.MkdirAll(sourcePath, 0755); err != nil {
-		return status.Error(codes.Internal, err.Error())
+		return fmt.Errorf("create sourcePath %s: %w", sourcePath, err)
 	}
 
 	// Set mkfs options for ext3, ext4
@@ -1022,14 +1006,14 @@ func (ns *nodeServer) mountDeviceToGlobal(capability *csi.VolumeCapability, volu
 	// do format-mount or mount
 	diskMounter := &k8smount.SafeFormatAndMount{Interface: ns.k8smounter, Exec: utilexec.New()}
 	if err := utils.FormatAndMount(diskMounter, device, sourcePath, fsType, mkfsOptions, mountOptions, GlobalConfigVar.OmitFilesystemCheck); err != nil {
-		klog.Errorf("mountDeviceToGlobal: FormatAndMount fail with mkfsOptions %s, %s, %s, %s, %s with error: %s", device, sourcePath, fsType, mkfsOptions, mountOptions, err.Error())
-		return status.Error(codes.Internal, err.Error())
+		logger.Error(err, "FormatAndMount failed", "device", device, "source", sourcePath, "fsType", fsType, "mkfsOptions", mkfsOptions, "mountOptions", mountOptions)
+		return fmt.Errorf("FormatAndMount %s to %s: %w", device, sourcePath, err)
 	}
 	return nil
 }
 
-func (ns *nodeServer) unmountDuplicateMountPoint(targetPath, volumeId string) error {
-	klog.Infof("unmountDuplicateMountPoint: start to unmount remains data: %s", targetPath)
+func (ns *nodeServer) unmountDuplicateMountPoint(logger klog.Logger, targetPath, volumeId string) error {
+	logger.V(2).Info("start to unmount remains data", "target", targetPath)
 	pathParts := strings.Split(targetPath, "/")
 	partsLen := len(pathParts)
 	if partsLen > 2 && pathParts[partsLen-1] == "mount" {
@@ -1045,8 +1029,8 @@ func (ns *nodeServer) unmountDuplicateMountPoint(targetPath, volumeId string) er
 		v2Exists := utils.IsFileExisting(globalPathV2)
 		// Community requires the node to be drained before upgrading, but we do not. So clean the V1 mountpoint here if both exists.
 		if v1Exists && v2Exists {
-			klog.Info("unmountDuplicateMountPoint: oldPath & newPath exists at same time")
-			err = ns.forceUnmountPath(globalPathV1)
+			logger.V(2).Info("oldPath & newPath exists at same time")
+			err = ns.forceUnmountPath(logger, globalPathV1)
 		}
 
 		// Now we have either V1 or V2 mountpoint.
@@ -1055,52 +1039,47 @@ func (ns *nodeServer) unmountDuplicateMountPoint(targetPath, volumeId string) er
 		globalPath2 := filepath.Join("/var/lib/container/kubelet/plugins/kubernetes.io/csi/pv/", pathParts[partsLen-2], "/globalmount")
 		globalPath3 := filepath.Join("/var/lib/container/kubelet/plugins/kubernetes.io/csi/", driverName, volSha, "/globalmount")
 		if utils.IsFileExisting(globalPath2) {
-			err = ns.unmountDuplicationPath(globalPath2)
+			err = ns.unmountDuplicationPath(logger, globalPath2)
 		}
 		if utils.IsFileExisting(globalPath3) {
-			err = ns.unmountDuplicationPath(globalPath3)
+			err = ns.unmountDuplicationPath(logger, globalPath3)
 		}
 		return err
 	} else {
-		klog.Warningf("Target Path is illegal format: %s", targetPath)
+		logger.V(1).Info("Target path is illegal format", "target", targetPath)
 	}
 	return nil
 }
 
-func (ns *nodeServer) unmountDuplicationPath(globalPath string) error {
-	// check globalPath2 is mountpoint
+func (ns *nodeServer) unmountDuplicationPath(logger klog.Logger, globalPath string) error {
 	notmounted, err := ns.k8smounter.IsLikelyNotMountPoint(globalPath)
 	if err != nil || notmounted {
-		klog.Warningf("Global Path is not mounted: %s", globalPath)
+		logger.V(1).Info("Global path is not mounted", "path", globalPath)
 		return nil
 	}
 	// check device is used by others
 	refs, err := ns.k8smounter.GetMountRefs(globalPath)
 	if err == nil && !ns.mounter.HasMountRefs(globalPath, refs) {
-		klog.Infof("NodeUnpublishVolume: VolumeId Unmount global path %s for ack with kubelet data disk", globalPath)
+		logger.V(2).Info("Unmount global path for ack with kubelet data disk", "path", globalPath)
 		if err := ns.k8smounter.Unmount(globalPath); err != nil {
-			klog.Errorf("NodeUnpublishVolume: volumeId: unmount global path %s failed with err: %v", globalPath, err)
-			return status.Error(codes.Internal, err.Error())
+			return fmt.Errorf("unmount global path %s: %w", globalPath, err)
 		}
 	} else {
-		klog.Infof("Global Path %s is mounted by others: %v", globalPath, refs)
+		logger.V(2).Info("Global path is mounted by others", "path", globalPath, "refs", refs)
 	}
 	return nil
 }
 
-func (ns *nodeServer) forceUnmountPath(globalPath string) error {
-	// check globalPath2 is mountpoint
+func (ns *nodeServer) forceUnmountPath(logger klog.Logger, globalPath string) error {
 	notmounted, err := ns.k8smounter.IsLikelyNotMountPoint(globalPath)
 	if err != nil || notmounted {
-		klog.Warningf("Global Path is not mounted: %s", globalPath)
+		logger.V(1).Info("Global path is not mounted", "path", globalPath)
 		return nil
 	}
 	if err := ns.k8smounter.Unmount(globalPath); err != nil {
-		klog.Errorf("NodeUnpublishVolume: volumeId: unmount global path %s failed with err: %v", globalPath, err)
-		return status.Error(codes.Internal, err.Error())
-	} else {
-		klog.Infof("forceUmountPath: umount Global Path %s  successful", globalPath)
+		return fmt.Errorf("unmount global path %s: %w", globalPath, err)
 	}
+	logger.V(2).Info("Force unmount global path successful", "path", globalPath)
 	return nil
 }
 
@@ -1122,13 +1101,12 @@ func collectMountOptions(fsType string, mntFlags []string) (options []string) {
 }
 
 // umountRunDVolumes umount runD volumes
-func (ns *nodeServer) umountRunDVolumes(volumePath string) (bool, error) {
+func (ns *nodeServer) umountRunDVolumes(logger klog.Logger, volumePath string) (bool, error) {
 	// check runtime mode
 	if utils.IsMountPointRunv(volumePath) {
 		fileName := filepath.Join(volumePath, utils.CsiPluginRunTimeFlagFile)
 		if err := os.Remove(fileName); err != nil {
-			msg := fmt.Sprintf("NodeUnpublishVolume: Remove Runv File %s with error: %s", fileName, err.Error())
-			return true, status.Error(codes.Internal, msg)
+			return true, fmt.Errorf("remove Runv file %s: %w", fileName, err)
 		}
 		return true, nil
 	}
@@ -1136,18 +1114,18 @@ func (ns *nodeServer) umountRunDVolumes(volumePath string) (bool, error) {
 	mountInfo, isRunD3 := directvolume.IsRunD3VolumePath(volumePath)
 	if isRunD3 {
 		removeRunD3File := func() error {
-			klog.Infof("NodeUnPublishVolume:: start delete mount info for KataVolume: %s", volumePath)
+			logger.V(2).Info("start delete mount info for KataVolume", "path", volumePath)
 			err := directvolume.RemovePVMXattr(volumePath, DiskXattrVirtioBlkName)
 			if err != nil {
-				klog.Warningf("NodeUnPublishVolume:: Remove xattr failed %v", err)
+				logger.V(1).Info("Remove xattr failed", "error", err)
 			}
 			err = directvolume.Remove(volumePath)
 			if err != nil {
-				klog.Errorf("NodeUnPublishVolume:: Failed to remove volumeDevice DirectVolume mount info, potentially disrupting kubelet's next operation: %v", err)
+				logger.Error(err, "Failed to remove volumeDevice DirectVolume mount info, potentially disrupting kubelet's next operation")
 			}
 			err = directvolume.Remove(filepath.Dir(volumePath))
 			if err != nil {
-				klog.Errorf("NodeUnPublishVolume:: Failed to remove volumeMount DirectVolume mount info, potentially disrupting kubelet's next operation: %v", err)
+				logger.Error(err, "Failed to remove volumeMount DirectVolume mount info, potentially disrupting kubelet's next operation")
 			}
 			return err
 		}
@@ -1161,87 +1139,85 @@ func (ns *nodeServer) umountRunDVolumes(volumePath string) (bool, error) {
 		cDriver, err := d.CurrentDriver()
 		if err != nil {
 			if IsNoSuchFileErr(err) {
-				klog.Infof("driver has been removed, device: %s has empty driver", mountInfo.Source)
+				logger.V(2).Info("driver has been removed, device has empty driver", "device", mountInfo.Source)
 				if err = removeRunD3File(); err != nil {
-					return true, status.Error(codes.Internal, err.Error())
+					return true, err
 				}
 				return true, nil
 			}
-			return true, status.Error(codes.Internal, err.Error())
+			return true, err
 		}
-		klog.Infof("current device driver : %v", cDriver)
+		logger.V(2).Info("current device driver", "driver", cDriver)
 		if defaultDrivers.Has(cDriver) || cDriver == "pci-pf-stub" {
 			// pci-pf-stub means the BDF is not used. Maybe the disk is already detached from controller.
 			if err = removeRunD3File(); err != nil {
-				return true, status.Error(codes.Internal, err.Error())
+				return true, err
 			}
 			return true, nil
 		}
 		if !vfioDrivers.Has(cDriver) {
-			return true, status.Error(codes.Internal, "vmoc(DFBus) mode only support vfio, virtio, nvme driver")
+			return true, fmt.Errorf("vmoc(DFBus) mode only support vfio, virtio, nvme driver")
 		}
 		// Check driver usage before unbind
 		if err = d.CheckVFIOUsage(); err != nil {
-			return true, status.Errorf(codes.Internal, "vmoc(DFBus) still being used, return immediately, err: %s", err.Error())
+			return true, fmt.Errorf("vmoc(DFBus) still being used: %w", err)
 		}
 
-		klog.Infof("start to unbind driver: %v of device: %v", cDriver, mountInfo.Source)
+		logger.V(2).Info("start to unbind driver", "driver", cDriver, "device", mountInfo.Source)
 		err = d.UnbindDriver()
 		if err != nil {
-			return true, status.Errorf(codes.Internal, "vmoc(DFBus) unbind err: %s", err.Error())
+			return true, fmt.Errorf("vmoc(DFBus) unbind: %w", err)
 		}
-		klog.Infof("start to rebind the driver of device: %v", mountInfo.Source)
+		logger.V(2).Info("start to rebind driver", "device", mountInfo.Source)
 		if ns.kataBMIOType == DFBus {
 			err = d.BindDriver(DFBusTypeVIRTIO)
 			if err != nil {
-				return true, status.Errorf(codes.Internal, "vmoc(DFBus) bind err: %s", err.Error())
+				return true, fmt.Errorf("vmoc(DFBus) bind: %w", err)
 			}
 		} else {
 			driverType := d.GetPCIDeviceDriverType()
-			klog.InfoS("umountRunDVolumes: rebind target type", "driverType", driverType)
+			logger.V(2).Info("rebind target type", "driverType", driverType)
 			err = d.BindDriver(driverType)
 			if err != nil {
-				return true, status.Errorf(codes.Internal, "vmoc(DFBus) bind err: %s", err.Error())
+				return true, fmt.Errorf("vmoc(DFBus) bind: %w", err)
 			}
 		}
 		if err = removeRunD3File(); err != nil {
-			return true, status.Error(codes.Internal, err.Error())
+			return true, err
 		}
 		return true, nil
 	}
 
-	klog.Infof("NodeUnPublishVolume:: start delete mount info for DirectVolume: %s", volumePath)
+	logger.V(2).Info("start delete mount info for DirectVolume", "path", volumePath)
 	if directvolume.IsRunD2VolumePath(volumePath) {
-		klog.Infof("NodeUnPublishVolume: Path: %s is already mounted in csi runD 2.0 mode", volumePath)
+		logger.V(2).Info("path is already mounted in csi runD 2.0 mode", "path", volumePath)
 		if err := os.Remove(filepath.Join(volumePath, directvolume.RunD2MountInfoFileName)); err != nil {
 			if os.IsNotExist(err) {
 				return false, nil
 			}
-			return true, status.Error(codes.Internal, err.Error())
+			return true, fmt.Errorf("remove RunD2 mount info %s: %w", volumePath, err)
 		}
 		return true, nil
 	}
-	klog.Infof("NodeUnpublishVolume:: volumePath is in runc type, continue to normal umount %s", volumePath)
+	logger.V(2).Info("volumePath is in runc type, continue to normal umount", "path", volumePath)
 	return false, nil
 }
 
-func (ns *nodeServer) mountRunvVolumes(volumeId, sourcePath, targetPath, fsType, mkfsOptions string, isRawBlock bool, mountFlags []string) error {
-	klog.Infof("NodePublishVolume:: Disk Volume %s Mount with runv", volumeId)
+func (ns *nodeServer) mountRunvVolumes(logger klog.Logger, volumeId, sourcePath, targetPath string) error {
+	logger.V(2).Info("Mount with runv")
 	// umount the stage path, which is mounted in Stage (tmpfs)
-	if err := ns.unmountStageTarget(sourcePath); err != nil {
-		klog.Errorf("NodePublishVolume(runv): unmountStageTarget %s with error: %s", sourcePath, err.Error())
-		return status.Error(codes.InvalidArgument, "NodePublishVolume: unmountStageTarget "+sourcePath+" with error: "+err.Error())
+	if err := ns.unmountStageTarget(logger, sourcePath); err != nil {
+		return status.Errorf(codes.InvalidArgument, "runv: unmountStageTarget %s: %v", sourcePath, err)
 	}
-	deviceName, err := ns.ad.GetRootBlockDevice(klog.TODO(), volumeId)
+	deviceName, err := ns.ad.GetRootBlockDevice(logger, volumeId)
 	if err != nil {
-		return status.Errorf(codes.InvalidArgument, "NodePublishVolume: cannot get local deviceName for volume %s: %v", volumeId, err)
+		return status.Errorf(codes.InvalidArgument, "runv: cannot get local deviceName: %v", err)
 	}
 
 	// save volume info to local file
 	mountFile := filepath.Join(targetPath, utils.CsiPluginRunTimeFlagFile)
 	if err := utils.CreateDest(targetPath); err != nil {
-		klog.Errorf("NodePublishVolume(runv): Create Dest %s error: %s", targetPath, err.Error())
-		return status.Error(codes.InvalidArgument, "NodePublishVolume(runv): Create Dest "+targetPath+" with error: "+err.Error())
+		return status.Errorf(codes.InvalidArgument, "runv: create dest %s: %v", targetPath, err)
 	}
 
 	qResponse := QueryResponse{
@@ -1252,8 +1228,7 @@ func (ns *nodeServer) mountRunvVolumes(volumeId, sourcePath, targetPath, fsType,
 		Runtime:    utils.RunvRunTimeTag,
 	}
 	if err := utils.WriteJSONFile(qResponse, mountFile); err != nil {
-		klog.Errorf("NodePublishVolume(runv): Write Json File error: %s", err.Error())
-		return status.Error(codes.InvalidArgument, "NodePublishVolume(runv): Write Json File error: "+err.Error())
+		return status.Errorf(codes.InvalidArgument, "runv: write JSON file: %v", err)
 	}
 	// save volume status to stage json file
 	volumeStatus := map[string]string{}
@@ -1263,14 +1238,13 @@ func (ns *nodeServer) mountRunvVolumes(volumeId, sourcePath, targetPath, fsType,
 		fileName = filepath.Join(filepath.Dir(filepath.Dir(sourcePath)), directvolume.RunD2MountInfoFileName)
 	}
 	if err = utils.AppendJSONData(fileName, volumeStatus); err != nil {
-		klog.Warningf("NodePublishVolume: append runv volume attached info to %s with error: %s", fileName, err.Error())
+		logger.V(1).Info("append runv volume attached info failed", "file", fileName, "error", err)
 	}
 	return nil
 }
 
-func (ns *nodeServer) mountRunDVolumes(volumeId, pvName, sourcePath, targetPath, fsType, mkfsOptions string, isRawBlock, pvmMode bool, mountFlags []string) (bool, error) {
-	klog.Infof("NodePublishVolume:: Disk Volume %s Mounted in RunD csi 3.0/2.0 protocol", volumeId)
-	logger := klog.TODO()
+func (ns *nodeServer) mountRunDVolumes(logger klog.Logger, volumeId, pvName, sourcePath, targetPath, fsType, mkfsOptions string, isRawBlock, pvmMode bool, mountFlags []string) (bool, error) {
+	logger.V(2).Info("Mount in RunD csi 3.0/2.0 protocol")
 	deviceName, err := ns.ad.GetRootBlockDevice(logger, volumeId)
 	if err != nil {
 		logger.V(1).Info("RunD volume device not found", "err", err)
@@ -1278,10 +1252,10 @@ func (ns *nodeServer) mountRunDVolumes(volumeId, pvName, sourcePath, targetPath,
 	}
 
 	if features.FunctionalMutableFeatureGate.Enabled(features.RundCSIProtocol3) {
+		logger := logger.WithValues("protocol", "rund3")
 		// umount the stage path, which is mounted in Stage
-		if err := ns.unmountStageTarget(sourcePath); err != nil {
-			klog.Errorf("NodePublishVolume(rund3.0): unmountStageTarget %s with error: %s", sourcePath, err.Error())
-			return true, status.Error(codes.InvalidArgument, "NodePublishVolume: unmountStageTarget "+sourcePath+" with error: "+err.Error())
+		if err := ns.unmountStageTarget(logger, sourcePath); err != nil {
+			return true, status.Errorf(codes.InvalidArgument, "rund3: unmountStageTarget %s: %v", sourcePath, err)
 		}
 
 		deviceNumber := ""
@@ -1289,18 +1263,17 @@ func (ns *nodeServer) mountRunDVolumes(volumeId, pvName, sourcePath, targetPath,
 			deviceNumber = volumeMount.Source
 		}
 
-		klog.InfoS("mountRunDVolumes: ", "deviceName", deviceName, "deviceNumber", deviceNumber)
+		logger.V(2).Info("device info", "deviceName", deviceName, "deviceNumber", deviceNumber)
 		driver, err := NewDeviceDriver(volumeId, deviceName, deviceNumber, ns.kataBMIOType)
 		if err != nil {
-			klog.Errorf("NodePublishVolume(rund3.0): can't get bdf number of volume:  %s: err: %v", volumeId, err)
-			return true, status.Error(codes.InvalidArgument, "NodePublishVolume: cannot get bdf number of volume: "+volumeId)
+			return true, status.Errorf(codes.InvalidArgument, "rund3: can't get bdf number: %v", err)
 		}
 		cDriver, err := driver.CurrentDriver()
 		if err != nil {
-			return true, status.Errorf(codes.Internal, "NodePublishVolume(rund3.0): can't get current volume driver: %+v", err)
+			return true, status.Errorf(codes.Internal, "rund3: can't get current volume driver: %v", err)
 		}
 		if deviceNumber == driver.GetDeviceNumber() && !pvmMode && vfioDrivers.Has(cDriver) {
-			klog.InfoS("NodePublishVolume(rund3.0): volume are already mounted, return normally", "volumeId", volumeId, "deviceNumber", deviceNumber)
+			logger.V(2).Info("volume already mounted, return normally", "deviceNumber", deviceNumber)
 			return true, nil
 		}
 		deviceType := directvolume.DeviceTypePCI
@@ -1312,12 +1285,12 @@ func (ns *nodeServer) mountRunDVolumes(volumeId, pvName, sourcePath, targetPath,
 		extras["PVName"] = pvName
 		extras["DiskId"] = volumeId
 		if isRawBlock {
-			klog.V(2).Infof("NodePublishVolume(rund3.0): get bdf number by device: %s", deviceName)
+			logger.V(2).Info("get bdf number by device", "device", deviceName)
 			deviceUid := 0
 			deviceGid := 0
 			deviceInfo, err := os.Stat(deviceName)
 			if err != nil {
-				klog.Errorf("NodePublishVolume(rund3.0): can't get device info of volume:  %s: err: %v", volumeId, err)
+				logger.Error(err, "can't get device info")
 			}
 			if stat, ok := deviceInfo.Sys().(*syscall.Stat_t); ok {
 				deviceUid = int(stat.Uid)
@@ -1347,50 +1320,45 @@ func (ns *nodeServer) mountRunDVolumes(volumeId, pvName, sourcePath, targetPath,
 			mountInfo.Source = deviceName
 			err = directvolume.AddMountInfo(directvolume.EnsureVolumeAttributesFileDir(targetPath, isRawBlock), mountInfo)
 			if err != nil {
-				klog.Errorf("NodePublishVolume(rund3.0): Adding runD mount information to DirectVolume within pvm failed: %v", err)
-				return true, err
+				return true, fmt.Errorf("rund3: adding mount info to DirectVolume within pvm: %w", err)
 			}
 			_, err := os.Stat(deviceName)
 			if err != nil {
-				return true, err
+				return true, fmt.Errorf("rund3: stat device %s: %w", deviceName, err)
 			}
 			err = unix.Setxattr(deviceName, DiskXattrVirtioBlkName, []byte("1"), 0)
 			if err != nil {
-				klog.Errorf("NodePublishVolume(rund3.0): Setxattr device: %s, err: %v", deviceName, err)
-				return true, err
+				return true, fmt.Errorf("rund3: setxattr device %s: %w", deviceName, err)
 			}
 			return true, nil
 		}
 
 		if defaultDrivers.Has(cDriver) {
 			if err := driver.UnbindDriver(); err != nil {
-				klog.Errorf("NodePublishVolume(rund3.0): can't unbind current device driver: %s, err: %s", driver.GetDeviceNumber(), err.Error())
-				return true, status.Error(codes.InvalidArgument, "NodePublishVolume: cannot unbind current device driver: "+driver.GetDeviceNumber())
+				return true, status.Errorf(codes.InvalidArgument, "rund3: unbind device driver %s: %v", driver.GetDeviceNumber(), err)
 			}
 			if ns.kataBMIOType == DFBus {
 				if err = driver.BindDriver(DFBusTypeVFIO); err != nil {
-					klog.Errorf("NodePublishVolume(rund3.0): can't bind bdf vfio driver to device: %s err: %s", driver.GetDeviceNumber(), err.Error())
-					return true, status.Error(codes.InvalidArgument, "NodePublishVolume: cannot bind current device driver: "+driver.GetDeviceNumber())
+					return true, status.Errorf(codes.InvalidArgument, "rund3: bind dfbus vfio driver to %s: %v", driver.GetDeviceNumber(), err)
 				}
 			} else {
 				if err = driver.BindDriver(PCITypeVFIO); err != nil {
-					klog.Errorf("NodePublishVolume(rund3.0): can't bind pci vfio driver to device: %s err: %s", driver.GetDeviceNumber(), err.Error())
-					return true, status.Error(codes.InvalidArgument, "NodePublishVolume: cannot bind current device driver: "+driver.GetDeviceNumber())
+					return true, status.Errorf(codes.InvalidArgument, "rund3: bind pci vfio driver to %s: %v", driver.GetDeviceNumber(), err)
 				}
 			}
 		}
 
 		err = directvolume.AddMountInfo(directvolume.EnsureVolumeAttributesFileDir(targetPath, isRawBlock), mountInfo)
 		if err != nil {
-			klog.Errorf("NodePublishVolume(rund3.0): Adding runD mount information to DirectVolume failed: %v", err)
-			return true, err
+			return true, fmt.Errorf("rund3: adding mount info to DirectVolume: %w", err)
 		}
 
-		klog.Info("NodePublishVolume(rund3.0): Adding runD mount information to DirectVolume succeeds, return immediately")
+		logger.V(2).Info("adding runD mount info to DirectVolume succeeds")
 		return true, nil
 	}
 	// (runD2.0) Need write mountOptions(metadata) parameters to file, and run normal runc process
-	klog.Infof("NodePublishVolume(rund): run csi runD protocol 2.0 logic")
+	logger = logger.WithValues("protocol", "rund2")
+	logger.V(2).Info("run csi runD protocol 2.0 logic")
 	volumeData := map[string]string{}
 	volumeData["csi.alibabacloud.com/fsType"] = fsType
 	if len(mountFlags) != 0 {
@@ -1405,7 +1373,7 @@ func (ns *nodeServer) mountRunDVolumes(volumeId, pvName, sourcePath, targetPath,
 		fileName = filepath.Join(filepath.Dir(filepath.Dir(targetPath)), directvolume.RunD2MountInfoFileName)
 	}
 	if err = utils.AppendJSONData(fileName, volumeData); err != nil {
-		klog.Warningf("NodeStageVolume: append volume spec to %s with error: %s", fileName, err.Error())
+		logger.V(1).Info("append volume spec failed", "file", fileName, "error", err)
 	}
 	return false, nil
 
@@ -1413,10 +1381,10 @@ func (ns *nodeServer) mountRunDVolumes(volumeId, pvName, sourcePath, targetPath,
 
 // checkTargetPathMounted check if targetPath is mounted or not
 // targeting for runc and rund-csi 2.0 protocol
-func (ns *nodeServer) checkTargetPathMounted(volumeId, targetPath string) (bool, error) {
+func (ns *nodeServer) checkTargetPathMounted(logger klog.Logger, volumeId, targetPath string) (bool, error) {
 	notMounted, err := ns.k8smounter.IsLikelyNotMountPoint(targetPath)
 	if err != nil && !errors.Is(err, fs.ErrNotExist) {
-		return false, status.Errorf(codes.Internal, "failed to check if %s is not a mount point: %v", targetPath, err)
+		return false, fmt.Errorf("check mount point %s: %w", targetPath, err)
 	}
 	if notMounted {
 		return false, nil
@@ -1424,28 +1392,27 @@ func (ns *nodeServer) checkTargetPathMounted(volumeId, targetPath string) (bool,
 	// if target path is mounted tmpfs, return
 	isTmpfs, err := utils.IsDirTmpfs(ns.k8smounter, targetPath)
 	if err != nil {
-		return false, status.Errorf(codes.Internal, "NodeStageVolume: failed to check %s for tmpfs: %v", targetPath, err)
+		return false, fmt.Errorf("check %s for tmpfs: %w", targetPath, err)
 	}
 	if isTmpfs {
-		klog.Infof("NodeStageVolume: TargetPath(%s) is mounted as tmpfs, not need mount again", targetPath)
+		logger.V(2).Info("target path is mounted as tmpfs, not need mount again", "targetPath", targetPath)
 		return true, nil
 	}
 
 	// check device available
 	deviceName, _, err := k8smount.GetDeviceNameFromMount(ns.k8smounter, targetPath)
 	if err != nil {
-		return false, status.Errorf(codes.Internal, "NodePublishVolume: get device name from mount %s error: %s", targetPath, err.Error())
+		return false, fmt.Errorf("get device name from mount %s: %w", targetPath, err)
 	}
 	if err := CheckDeviceAvailable(deviceName, volumeId, targetPath); err != nil {
-		klog.Errorf("NodeStageVolume: mountPath is mounted %s, but check device available error: %s", targetPath, err.Error())
-		return false, status.Error(codes.Internal, err.Error())
+		return false, fmt.Errorf("%s mounted, but check device available failed: %w", targetPath, err)
 	}
-	klog.Infof("NodeStageVolume:  volumeId: %s, Path: %s is already mounted, device: %s", volumeId, targetPath, deviceName)
+	logger.V(2).Info("already mounted", "targetPath", targetPath, "device", deviceName)
 	return true, nil
 }
 
 // checkMountedOfRunvAndRund check if targetVolume is used by runv or rund-csi3.0
-func (ns *nodeServer) checkMountedOfRunvAndRund(volumeId, targetPath string) bool {
+func (ns *nodeServer) checkMountedOfRunvAndRund(logger klog.Logger, volumeId, targetPath string) bool {
 	// check volume is mounted in runv mode for kubelet restart;
 	fileName := filepath.Join(filepath.Dir(targetPath), utils.VolDataFileName)
 	if strings.HasSuffix(targetPath, "/") {
@@ -1454,25 +1421,25 @@ func (ns *nodeServer) checkMountedOfRunvAndRund(volumeId, targetPath string) boo
 	volumeData, err := utils.LoadJSONData(fileName)
 	if err == nil {
 		if _, ok := volumeData["csi.alibabacloud.com/disk-mounted"]; ok {
-			klog.Infof("NodeStageVolume:  volumeId: %s, Path: %s is already mounted in kata mode", volumeId, targetPath)
+			logger.V(2).Info("already mounted in kata mode", "targetPath", targetPath)
 			return true
 		}
 	}
 
-	device, err := ns.ad.GetRootBlockDevice(klog.TODO(), volumeId)
+	device, err := ns.ad.GetRootBlockDevice(logger, volumeId)
 	if err != nil {
 		// In VFIO mode, an empty device is an expected condition, so the resulting error should be ignored.
-		klog.Warningf("NodeStageVolume: GetVolumeDeviceName failed: %s", err.Error())
+		logger.V(1).Info("GetVolumeDeviceName failed", "error", err)
 	}
 
 	d, err := NewDeviceDriver(volumeId, device, "", ns.kataBMIOType)
 	if err != nil {
-		klog.ErrorS(err, "NodeStageVolume:  Failed to get bdf number", "volumeId", volumeId)
+		logger.Error(err, "failed to get bdf number")
 		return false
 	}
 	cDriver, err := d.CurrentDriver()
 	if err != nil {
-		klog.ErrorS(err, "NodeStageVolume:  Failed to get current driver", "volumeId", volumeId)
+		logger.Error(err, "failed to get current driver")
 		return false
 	}
 	if vfioDrivers.Has(cDriver) {
@@ -1480,7 +1447,7 @@ func (ns *nodeServer) checkMountedOfRunvAndRund(volumeId, targetPath string) boo
 	}
 
 	pvmMounted := directvolume.CheckDevicePVMMounted(device, DiskXattrVirtioBlkName)
-	klog.InfoS("checkMountedOfRunvAndRund: check pvmMounted", "device", device, "pvmMounted", pvmMounted, "driver", cDriver)
+	logger.V(2).Info("check pvmMounted", "device", device, "pvmMounted", pvmMounted, "driver", cDriver)
 	if pvmMounted && defaultDrivers.Has(cDriver) {
 		return true
 	}

--- a/pkg/disk/nodeserver_test.go
+++ b/pkg/disk/nodeserver_test.go
@@ -93,7 +93,7 @@ func TestCheckMountedOfRunvAndRund(t *testing.T) {
 				defer os.RemoveAll(tt.targetPath)
 			}
 
-			mounted, err := ns.checkTargetPathMounted(tt.volumeId, tt.targetPath)
+			mounted, err := ns.checkTargetPathMounted(ktesting.NewLogger(t, ktesting.DefaultConfig), tt.volumeId, tt.targetPath)
 			if tt.expectedErr {
 				assert.Error(t, err)
 			} else {


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Refactors all 6 node-side RPC methods (NodePublishVolume, NodeUnpublishVolume, NodeStageVolume, NodeUnstageVolume, NodeExpandVolume, NodeGetInfo) to use structured logging via `klog.FromContext(ctx)` instead of global `klog.Infof/Errorf/Warningf`. NodeGetInfo is newly added to the `NodeServerWithLog` wrapper.

The `NodeServerWithLog` wrapper already injects method name and volumeID into the context logger, so these are removed from log messages to avoid redundancy.

Helper functions (`unmountStageTarget`, `mountDeviceToGlobal`, `unmountDuplicateMountPoint`, `unmountDuplicationPath`, `forceUnmountPath`, `umountRunDVolumes`, `mountRunvVolumes`, `mountRunDVolumes`, `checkTargetPathMounted`, `checkMountedOfRunvAndRund`) now accept a `klog.Logger` parameter and return `fmt.Errorf` instead of `status.Errorf`, leaving gRPC status code assignment to the RPC methods. `mountRunvVolumes` drops unused parameters (`fsType`, `mkfsOptions`, `isRawBlock`, `mountFlags`).

Log levels: Info at V(2), Warning at V(1), errors use `logger.Error` or are returned via `status.Errorf` without separate logging.

#### Which issue(s) this PR fixes:

NONE

#### Special notes for your reviewer:

No functional changes. Log output will include structured key-value pairs and respect verbosity levels.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```