### PR TITLE
csi-agent: remove python36 and pyyaml to fix CVE scans

### DIFF
--- a/.agents/skills/debug-csi/SKILL.md
+++ b/.agents/skills/debug-csi/SKILL.md
@@ -27,12 +27,23 @@ If there's a `csi` release, it's already a debug version — skip uninstall. Oth
 
 ### Build and push images
 
+When building from a non-VPC environment (e.g. local machine), apply the yum mirror patch first so that container builds can access Alinux repos:
+```bash
+git apply .agents/skills/debug-csi/yum-mirror.diff
+```
+This is a local-only patch — do not commit it. Just revert it if it gets into your way, and apply it again when building again.
+
 ```bash
 PLATFORM=linux/amd64 IMAGE_REPO=<registry>/<namespace> IMAGE_TAG=latest ./build/build-all-multi.sh
 ```
 Refer to `.local/test-values.yaml` for the registry and namespace.
 `IMAGE_TAG` defaults to `latest`; set it to a custom tag (e.g. `v1.35.3-dev`) if needed.
-The script builds and pushes all images: `csi-plugin`, `csi-plugin:init`, `csi-plugin:controller`, `csi-ossfs`, `csi-ossfs2`, `csi-alinas`, and their variants.
+The script builds and pushes all images: `csi-plugin`, `csi-plugin:init`, `csi-plugin:controller`, `csi-agent`, `csi-ossfs`, `csi-ossfs2`, `csi-alinas`, `mount-proxy`.
+
+To build only specific images, set `IMAGES` (space-separated names without tags):
+```bash
+IMAGES="mount-proxy csi-agent" PLATFORM=linux/amd64 IMAGE_REPO=<registry>/<namespace> ./build/build-all-multi.sh
+```
 
 ### Deploy via helm
 
@@ -75,3 +86,7 @@ Docker Hub and other registries outside China are unreliable due to network issu
 ## OSS / OSSFS
 
 For OSSFS-related debugging (fuse pod image config, fuse pod logs, fuse pod lifecycle), read `references/oss.md`.
+
+## NAS / cnfs-nas-daemon
+
+For NAS mount proxy debugging (enabling the proxy, testing cnfs-nas-daemon images, EFC mount flow), read `references/nas.md`.

--- a/.agents/skills/debug-csi/references/nas.md
+++ b/.agents/skills/debug-csi/references/nas.md
@@ -1,0 +1,67 @@
+# NAS / cnfs-nas-daemon Debugging
+
+NAS EFC/CPFS mounts are served by cnfs-nas-daemon (a DaemonSet in `cnfs-system` namespace).
+The CSI plugin sends mount requests over a Unix socket to the daemon, which runs `mount -t alinas`.
+
+## Quick setup
+
+```bash
+# Set up mount proxy with alinas image (default)
+scripts/setup-mount-proxy-debug.sh [image-tag]
+
+# Set up with the all-in-one image
+scripts/setup-mount-proxy-debug.sh [image-tag] aio
+```
+
+This enables the `AlinasMountProxy` feature gate on csi-plugin, patches cnfs-nas-daemon with the
+test image, and restarts the pods.
+
+## Test PV
+
+PV volumeAttributes must trigger the `alinas` fstype. Use `useClient: efcclient`:
+```yaml
+csi:
+  driver: nasplugin.csi.alibabacloud.com
+  volumeHandle: my-nas-pv
+  volumeAttributes:
+    server: "<fs-id>-<suffix>.cn-<region>.nas.aliyuncs.com"
+    path: "/"
+    useClient: "efcclient"
+```
+
+## Architecture
+
+```
+csi-plugin (NodePublishVolume)
+  → Unix socket /run/cnfs/alinas-mounter.sock
+    → cnfs-nas-daemon pod (mount-proxy-server --driver=alinas)
+      → mount -t alinas (EFC client, with auto_fallback_nfs to NFS)
+```
+
+Code path: `useClient: efcclient` → `ClientType=efcclient` → `mountFstype=alinas` → ProxyMounter.
+
+## Finding NAS filesystems
+
+Try `kubectl get pv test-nas-proxy` first to find existing test resources that you can reuse.
+Also prefer creating PV with this name to reuse it next time.
+If not found, try:
+```bash
+aliyun nas DescribeFileSystems --RegionId cn-beijing | jq '.FileSystems.FileSystem[] | {FileSystemId, FileSystemType, Status}'
+aliyun nas DescribeMountTargets --RegionId cn-beijing --FileSystemId <fs-id> | jq '.MountTargets.MountTarget[]'
+```
+
+## Logs
+
+```bash
+kubectl -n cnfs-system logs -l app=cnfs-nas-daemon --tail=50
+kubectl -n kube-system logs -l app=csi-plugin -c csi-plugin --tail=50 | grep -i "proxy\|alinas\|mount"
+```
+
+## Key source files
+
+- `pkg/nas/nodeserver.go` — NodePublishVolume, volumeAttribute parsing, ClientType/MountProtocol determination
+- `pkg/nas/utils.go:doMount()` — fstype routing, subpath auto-creation
+- `pkg/nas/mounter.go` — NasMounter construction (ProxyMounter vs ConnectorMounter vs AdaptorMounter)
+- `pkg/mounter/proxy_mounter.go` — ProxyMounter (sends requests over Unix socket)
+- `pkg/mounter/proxy/server/alinas/driver.go` — server-side alinas mount handler
+- `pkg/features/features.go` — AlinasMountProxy feature gate definition

--- a/.agents/skills/debug-csi/scripts/setup-mount-proxy-debug.sh
+++ b/.agents/skills/debug-csi/scripts/setup-mount-proxy-debug.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+set -e
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+VALUES_FILE="$REPO_ROOT/.local/test-values.yaml"
+
+if [ ! -f "$VALUES_FILE" ]; then
+    echo "Error: $VALUES_FILE not found. Run /init-dev-env first." >&2
+    exit 1
+fi
+
+REGISTRY=$(yq '.images.registry' "$VALUES_FILE")
+NAMESPACE=$(yq '.images.controller.repo | split("/") | .[0]' "$VALUES_FILE")
+SECRET_NAME=$(yq '.imagePullSecrets[0]' "$VALUES_FILE")
+
+IMAGE_REPOSITORY_PREFIX="$REGISTRY/$NAMESPACE"
+IMAGE_TAG="${1:-latest}"
+# Default to alinas image; pass "aio" to use mount-proxy (all-in-one) image
+IMAGE_TYPE="${2:-alinas}"
+
+case "$IMAGE_TYPE" in
+    alinas)
+        IMAGE="$IMAGE_REPOSITORY_PREFIX/csi-alinas:$IMAGE_TAG"
+        ARGS='["--socket=/run/cnfs/alinas-mounter.sock", "--driver=alinas"]'
+        ;;
+    aio)
+        IMAGE="$IMAGE_REPOSITORY_PREFIX/mount-proxy:$IMAGE_TAG"
+        ARGS='["--socket=/run/cnfs/alinas-mounter.sock", "--driver=alinas,ossfs,ossfs2"]'
+        ;;
+    *)
+        echo "Unknown image type: $IMAGE_TYPE (use 'alinas' or 'aio')" >&2
+        exit 1
+        ;;
+esac
+
+echo "Registry prefix: $IMAGE_REPOSITORY_PREFIX"
+echo "Image tag:       $IMAGE_TAG"
+echo "Image type:      $IMAGE_TYPE"
+echo "Image:           $IMAGE"
+echo "Pull secret:     $SECRET_NAME"
+
+echo "--- Enabling AlinasMountProxy feature gate on csi-plugin ---"
+CURRENT_ARGS=$(kubectl -n kube-system get ds csi-plugin -o jsonpath='{.spec.template.spec.containers[0].args}')
+if echo "$CURRENT_ARGS" | grep -q "AlinasMountProxy"; then
+    echo "Feature gate already enabled."
+else
+    kubectl -n kube-system patch ds csi-plugin --type=json -p '[
+      {"op": "add", "path": "/spec/template/spec/containers/0/args/-", "value": "--feature-gates=AlinasMountProxy=true"}
+    ]'
+    echo "Waiting for csi-plugin to roll out..."
+    kubectl -n kube-system rollout status ds/csi-plugin --timeout=60s
+fi
+
+echo "--- Patching cnfs-nas-daemon ---"
+kubectl -n cnfs-system patch ds cnfs-nas-daemon --type=strategic -p "
+spec:
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    spec:
+      containers:
+      - name: mount-proxy
+        image: $IMAGE
+        args: $ARGS
+      imagePullSecrets:
+      - name: $SECRET_NAME
+"
+kubectl -n cnfs-system rollout status ds/cnfs-nas-daemon --timeout=120s
+
+echo ""
+echo "Done. cnfs-nas-daemon is now running $IMAGE"
+echo "Test with a PV using 'useClient: efcclient' in volumeAttributes."

--- a/.agents/skills/debug-csi/yum-mirror.diff
+++ b/.agents/skills/debug-csi/yum-mirror.diff
@@ -1,0 +1,23 @@
+diff --git a/build/mount-proxy/Dockerfile b/build/mount-proxy/Dockerfile
+index 38468c4bc..5852a3bc6 100644
+--- a/build/mount-proxy/Dockerfile
++++ b/build/mount-proxy/Dockerfile
+@@ -12,12 +12,18 @@ RUN --mount=type=bind,target=. \
+ 
+ 
+ FROM --platform=$BUILDPLATFORM registry-cn-hangzhou.ack.aliyuncs.com/dev/alinux:3-update AS rpm-builder
++RUN find /etc/yum.repos.d -name '*.repo' -exec \
++    sed -i 's|mirrors\.cloud\.aliyuncs\.com|mirrors.aliyun.com|g' {} + && \
++    yum makecache
+ RUN yum install -y rpm-build
+ RUN --mount=type=bind,source=build/mount-proxy/python3-provider.spec,target=/tmp/python3-provider.spec \
+     rpmbuild -bb /tmp/python3-provider.spec
+ 
+ 
+ FROM registry-cn-hangzhou.ack.aliyuncs.com/dev/alinux:3-update AS alinux-install
++RUN find /etc/yum.repos.d -name '*.repo' -exec \
++    sed -i 's|mirrors\.cloud\.aliyuncs\.com|mirrors.aliyun.com|g' {} + && \
++    yum makecache
+ 
+ #################### OSSFS 1.91 MOUNT-PROXY IMAGE ####################
+ 

--- a/.agents/skills/init-dev-env/SKILL.md
+++ b/.agents/skills/init-dev-env/SKILL.md
@@ -164,11 +164,12 @@ The script reads registry and secret name from `.local/test-values.yaml`, so it 
 
 Prerequisite: user must have run `docker login <registry>` locally first. If credentials are missing, the script tells them to do so.
 
-Run the script to create secrets in both required namespaces:
+Run the script to create secrets in all used namespaces:
 
 ```bash
 scripts/create-image-pull-secret.sh -n kube-system
 scripts/create-image-pull-secret.sh -n ack-csi-fuse
+scripts/create-image-pull-secret.sh -n cnfs-system
 ```
 
 ## Post-setup notes

--- a/build/build-all-multi.sh
+++ b/build/build-all-multi.sh
@@ -20,9 +20,25 @@ BUILD_ARGS=(
 )
 BUILD_ARGS+=("$@")
 
+should_build() {
+    if [ -z "$IMAGES" ]; then
+        return 0
+    fi
+    local name=${1%%:*}
+    for img in $IMAGES; do
+        if [ "$img" = "$name" ]; then
+            return 0
+        fi
+    done
+    return 1
+}
+
 build_image() {
     local image=$1
     shift
+    if ! should_build "$image"; then
+        return 0
+    fi
     buildctl build "${BUILD_ARGS[@]}" "$@" \
         --output "type=image,push=$PUSH,name=${IMAGE_REPO}/${image}"
 }
@@ -32,8 +48,12 @@ build_image "csi-plugin:${IMAGE_TAG}"             "${MAIN_ARGS[@]}"
 build_image "csi-plugin:${IMAGE_TAG}-controller"  "${MAIN_ARGS[@]}" --opt target=csi-controller
 build_image "csi-plugin:${IMAGE_TAG}-init"        "${MAIN_ARGS[@]}" --opt target=init
 
+AGENT_ARGS=(--local dockerfile=build/csi-agent --opt filename=Dockerfile)
+build_image "csi-agent:${IMAGE_TAG}" "${AGENT_ARGS[@]}"
+
 PROXY_ARGS=(--local dockerfile=build/mount-proxy --opt filename=Dockerfile)
 build_image "csi-ossfs:${IMAGE_TAG}"      "${PROXY_ARGS[@]}" --opt target=ossfs
 build_image "csi-ossfs:${IMAGE_TAG}-1.88" "${PROXY_ARGS[@]}" --opt target=ossfs-1.88
 build_image "csi-ossfs2:${IMAGE_TAG}"     "${PROXY_ARGS[@]}" --opt target=ossfs2
 build_image "csi-alinas:${IMAGE_TAG}"     "${PROXY_ARGS[@]}" --opt target=alinas
+build_image "mount-proxy:${IMAGE_TAG}"    "${PROXY_ARGS[@]}" --opt target=aio

--- a/build/csi-agent/Dockerfile
+++ b/build/csi-agent/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM registry-cn-hangzhou.ack.aliyuncs.com/dev/golang:1.26.3 as builder
+FROM --platform=$BUILDPLATFORM registry-cn-hangzhou.ack.aliyuncs.com/dev/golang:1.26.3 AS builder
 WORKDIR /src
 ARG TARGETARCH
 ARG TARGETOS
@@ -8,44 +8,7 @@ RUN --mount=type=bind,target=. \
     export CGO_ENABLED=0 && \
     go build -trimpath \
         -ldflags "-X github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/version.VERSION=${CSI_VERSION}" \
-        -o /out/csi-agent ./cmd/csi-agent && \
-    go build -trimpath -o /out/csi-mount-proxy-server ./cmd/mount-proxy-server
+        -o /out/csi-agent ./cmd/csi-agent
 
-
-FROM registry-cn-hangzhou.ack.aliyuncs.com/dev/alinux:3-update
-
-ARG TARGETPLATFORM
-# The versions specified here are for RPM packages, which may not necessarily align with the image version
-ARG OSSFS_VERSION=v1.91.10.ack.1
-ARG OSSFS2_VERSION=v2.0.7.ack.1
-ARG ALINAS_UTILS_VERSION=1.9-0.20260407144027.3d3855.al8
-ARG EFC_VERSION=1.9-20250822095129.f34347.release
-# v2.1 is exclusive to a specific storage cluster version and the first to support ARM arch.
-# It's temporarily unavailable for all ACK clusters,
-# catering only to ARM for compatibility. An update to all CPFS storage cluster versions is required.
-ARG EFC_ARM_VERSION=2.1-20260318190316.34c388.release
-ARG ALINAS_UTILS_ARM_VERSION=2.1-0.20260316154701.b0a52a.generic
-RUN set -ex; \
-    case "${TARGETPLATFORM}" in \
-        linux/amd64) ARCH="x86_64" ;; \
-        linux/arm64) ARCH="aarch_64" ;; \
-        *) echo "unknown platform"; exit 1 ;; \
-    esac; \
-    yum install -y fuse-devel util-linux mailcap procps python38 tini; \
-    yum install -y https://ack-csiplugin.oss-cn-hangzhou.aliyuncs.com/ossfs/ossfs_${OSSFS_VERSION}_centos8.0_${ARCH}.rpm; \
-    yum install -y https://ack-csiplugin.oss-cn-hangzhou.aliyuncs.com/ossfs2/ossfs2_${OSSFS2_VERSION}_centos8.0_${ARCH}.rpm; \
-    if [ "${ARCH}" = "x86_64" ]; then \
-        yum install -y https://aliyun-alinas-eac.oss-cn-beijing.aliyuncs.com/aliyun-alinas-utils-${ALINAS_UTILS_VERSION}.noarch.rpm; \
-        yum install -y https://aliyun-alinas-eac.oss-cn-beijing.aliyuncs.com/alinas-efc-${EFC_VERSION}.${ARCH}.rpm; \
-    elif [ "${ARCH}" = "aarch_64" ]; then \
-        yum install -y https://aliyun-alinas-eac-cn-wulanchabu.oss-cn-wulanchabu.aliyuncs.com/efc-release/2.1/aliyun-alinas-utils-${ALINAS_UTILS_ARM_VERSION}.aarch64.rpm; \
-        yum install -y https://aliyun-alinas-eac-cn-wulanchabu.oss-cn-wulanchabu.aliyuncs.com/efc-release/2.1/alinas-efc-${EFC_ARM_VERSION}.aarch64.rpm; \
-    fi; \
-    cp -r /etc/aliyun /etc/aliyun-defaults; \
-    yum clean all; \
-    update-alternatives --set python3 /usr/bin/python3.8
-
-
-COPY --link --from=builder /out/csi-mount-proxy-server /usr/local/bin/
-COPY --link --from=builder /out/csi-agent /usr/local/bin/
-ENTRYPOINT [ "tini", "--", "csi-mount-proxy-server", "--driver=alinas,ossfs,ossfs2" ]
+FROM scratch
+COPY --link --from=builder /out/csi-agent /usr/local/bin/csi-agent

--- a/build/mount-proxy/Dockerfile
+++ b/build/mount-proxy/Dockerfile
@@ -10,18 +10,20 @@ RUN --mount=type=bind,target=. \
     go build -o /out/csi-mount-proxy-server ./cmd/mount-proxy-server && \
     go build -o /out/csi-mount-proxy-client ./cmd/mount-proxy-client
 
-FROM registry-cn-hangzhou.ack.aliyuncs.com/dev/alinux:3-update AS alinux-install
 
-# uncomment as needed when testing, makes image larger but build faster by reusing yum cache
-# RUN find /etc/yum.repos.d -name '*.repo' -exec \
-#     sed -i 's|mirrors\.cloud\.aliyuncs\.com|mirrors.aliyun.com|g' {} + && \
-#     yum makecache
+FROM --platform=$BUILDPLATFORM registry-cn-hangzhou.ack.aliyuncs.com/dev/alinux:3-update AS rpm-builder
+RUN yum install -y rpm-build
+RUN --mount=type=bind,source=build/mount-proxy/python3-provider.spec,target=/tmp/python3-provider.spec \
+    rpmbuild -bb /tmp/python3-provider.spec
+
+
+FROM registry-cn-hangzhou.ack.aliyuncs.com/dev/alinux:3-update AS alinux-install
 
 #################### OSSFS 1.91 MOUNT-PROXY IMAGE ####################
 
 FROM alinux-install AS ossfs
 ARG TARGETPLATFORM
-ARG OSSFS_VERSION=v1.91.9.ack.1
+ARG OSSFS_VERSION=v1.91.10.ack.1
 
 # install ossfs
 RUN set -ex; \
@@ -80,7 +82,7 @@ ENTRYPOINT ["csi-mount-proxy-server", "--driver=ossfs"]
 
 FROM alinux-install AS ossfs2
 ARG TARGETPLATFORM
-ARG OSSFS_VERSION=v2.0.5.ack.1
+ARG OSSFS_VERSION=v2.0.7.ack.1
 
 # install ossfs
 # only supports x86_64
@@ -112,13 +114,15 @@ ARG EFC_VERSION=1.9-20250822095129.f34347.release
 ARG EFC_ARM_VERSION=2.1-20260318190316.34c388.release
 ARG ALINAS_UTILS_ARM_VERSION=2.1-0.20260316154701.b0a52a.generic
 
-RUN set -ex; \
+RUN --mount=type=bind,from=rpm-builder,source=/root/rpmbuild/RPMS/noarch,target=/tmp/rpms \
+    echo 'install_weak_deps=False' >> /etc/yum.conf; \
+    set -ex; \
     case "${TARGETPLATFORM}" in \
         linux/amd64) ARCH="x86_64" ;; \
         linux/arm64) ARCH="aarch_64" ;; \
         *) echo "unsupported platform"; exit 1 ;; \
     esac; \
-    yum install -y util-linux procps python38 tini; \
+    yum install -y /tmp/rpms/python3-provider-*.rpm util-linux procps tini; \
     if [ "${ARCH}" = "x86_64" ]; then \
         yum install -y https://aliyun-alinas-eac.oss-cn-beijing.aliyuncs.com/aliyun-alinas-utils-${ALINAS_UTILS_VERSION}.noarch.rpm; \
         yum install -y https://aliyun-alinas-eac.oss-cn-beijing.aliyuncs.com/alinas-efc-${EFC_VERSION}.${ARCH}.rpm; \
@@ -127,7 +131,9 @@ RUN set -ex; \
         yum install -y https://aliyun-alinas-eac-cn-wulanchabu.oss-cn-wulanchabu.aliyuncs.com/efc-release/2.1/alinas-efc-${EFC_ARM_VERSION}.aarch64.rpm; \
     fi; \
     yum clean all; \
-    update-alternatives --set python3 /usr/bin/python3.8
+    # python3-pyyaml is only used by nfsdclnts (NFS server diagnostic tool, irrelevant here).
+    # Remove it to silence CVE scans.
+    rpm -e --nodeps python3-pyyaml
 # alinas-utils generates some dynamic configuration files (such as TLS keys, etc.) under /etc/aliyun/{alinas,cpfs}.
 # So we will mount a hostPath to prevent the loss of these files when the container restarts.
 # On the first launch, /etc/aliyun-defaults will be used to initialize the configurations under /etc/aliyun/{alinas,cpfs}.
@@ -137,3 +143,48 @@ COPY --link --from=builder /out/csi-mount-proxy* /usr/local/bin/
 ENTRYPOINT [ "tini", "--", "csi-mount-proxy-server", "--driver=alinas" ]
 
 #################### ALINAS MOUNT-PROXY IMAGE ####################
+
+#################### ALL-IN-ONE MOUNT-PROXY IMAGE ####################
+# This image is used in pod sidecar injected by our infra where we don't know which driver will be used.
+
+FROM alinux-install AS aio
+
+ARG TARGETPLATFORM
+ARG OSSFS_VERSION=v1.91.10.ack.1
+ARG OSSFS2_VERSION=v2.0.7.ack.1
+ARG ALINAS_UTILS_VERSION=1.9-0.20260407144027.3d3855.al8
+ARG EFC_VERSION=1.9-20250822095129.f34347.release
+# v2.1 is exclusive to a specific storage cluster version and the first to support ARM arch.
+# It's temporarily unavailable for all ACK clusters,
+# catering only to ARM for compatibility. An update to all CPFS storage cluster versions is required.
+ARG EFC_ARM_VERSION=2.1-20260318190316.34c388.release
+ARG ALINAS_UTILS_ARM_VERSION=2.1-0.20260316154701.b0a52a.generic
+
+RUN --mount=type=bind,from=rpm-builder,source=/root/rpmbuild/RPMS/noarch,target=/tmp/rpms \
+    echo 'install_weak_deps=False' >> /etc/yum.conf; \
+    set -ex; \
+    case "${TARGETPLATFORM}" in \
+        linux/amd64) ARCH="x86_64" ;; \
+        linux/arm64) ARCH="aarch_64" ;; \
+        *) echo "unknown platform"; exit 1 ;; \
+    esac; \
+    yum install -y /tmp/rpms/python3-provider-*.rpm fuse-devel util-linux mailcap procps tini; \
+    yum install -y https://ack-csiplugin.oss-cn-hangzhou.aliyuncs.com/ossfs/ossfs_${OSSFS_VERSION}_centos8.0_${ARCH}.rpm; \
+    yum install -y https://ack-csiplugin.oss-cn-hangzhou.aliyuncs.com/ossfs2/ossfs2_${OSSFS2_VERSION}_centos8.0_${ARCH}.rpm; \
+    if [ "${ARCH}" = "x86_64" ]; then \
+        yum install -y https://aliyun-alinas-eac.oss-cn-beijing.aliyuncs.com/aliyun-alinas-utils-${ALINAS_UTILS_VERSION}.noarch.rpm; \
+        yum install -y https://aliyun-alinas-eac.oss-cn-beijing.aliyuncs.com/alinas-efc-${EFC_VERSION}.${ARCH}.rpm; \
+    elif [ "${ARCH}" = "aarch_64" ]; then \
+        yum install -y https://aliyun-alinas-eac-cn-wulanchabu.oss-cn-wulanchabu.aliyuncs.com/efc-release/2.1/aliyun-alinas-utils-${ALINAS_UTILS_ARM_VERSION}.aarch64.rpm; \
+        yum install -y https://aliyun-alinas-eac-cn-wulanchabu.oss-cn-wulanchabu.aliyuncs.com/efc-release/2.1/alinas-efc-${EFC_ARM_VERSION}.aarch64.rpm; \
+    fi; \
+    cp -r /etc/aliyun /etc/aliyun-defaults; \
+    yum clean all; \
+    # python3-pyyaml is only used by nfsdclnts (NFS server diagnostic tool, irrelevant here).
+    # Remove it to silence CVE scans.
+    rpm -e --nodeps python3-pyyaml
+
+COPY --link --from=builder /out/csi-mount-proxy* /usr/local/bin/
+ENTRYPOINT [ "tini", "--", "csi-mount-proxy-server", "--driver=alinas,ossfs,ossfs2" ]
+
+#################### ALL-IN-ONE MOUNT-PROXY IMAGE ####################

--- a/build/mount-proxy/python3-provider.spec
+++ b/build/mount-proxy/python3-provider.spec
@@ -1,0 +1,17 @@
+Name:    python3-provider
+Version: 3.8
+Release: 1
+Summary: Provide python3 via python38 alternatives
+License: Apache-2.0
+BuildArch: noarch
+Requires: python38
+Provides: python3 = 3.8
+Conflicts: python36
+
+%description
+Sets python3 to python3.8 via alternatives.
+
+%post
+alternatives --set python3 /usr/bin/python3.8
+
+%files

--- a/hack/update-versions.sh
+++ b/hack/update-versions.sh
@@ -45,9 +45,9 @@ OSSFS2_IMAGE_TAG_ESC=$(escape_sed "${OSSFS2_IMAGE_TAG}")
 sed -i '' "s/defaultOssfsUpdatedImageTag = \".*\"/defaultOssfsUpdatedImageTag = \"${OSSFS_IMAGE_TAG_ESC}\"/" "${GO_FILE}"
 sed -i '' "s/defaultOssfs2ImageTag.*= \".*\"/defaultOssfs2ImageTag       = \"${OSSFS2_IMAGE_TAG_ESC}\"/" "${GO_FILE}"
 
-# Update csi-agent Dockerfile
-CSI_AGENT_DOCKERFILE="${ROOT_DIR}/build/csi-agent/Dockerfile"
-echo "Updating ${CSI_AGENT_DOCKERFILE}..."
+# Update mount-proxy Dockerfile
+MOUNT_PROXY_DOCKERFILE="${ROOT_DIR}/build/mount-proxy/Dockerfile"
+echo "Updating ${MOUNT_PROXY_DOCKERFILE}..."
 OSSFS_RPM_VERSION_ESC=$(escape_sed "${OSSFS_RPM_VERSION}")
 OSSFS2_RPM_VERSION_ESC=$(escape_sed "${OSSFS2_RPM_VERSION}")
 ALINAS_UTILS_VERSION_ESC=$(escape_sed "${ALINAS_UTILS_VERSION}")
@@ -55,20 +55,14 @@ EFC_VERSION_ESC=$(escape_sed "${EFC_VERSION}")
 EFC_ARM_VERSION_ESC=$(escape_sed "${EFC_ARM_VERSION}")
 ALINAS_UTILS_ARM_VERSION_ESC=$(escape_sed "${ALINAS_UTILS_ARM_VERSION}")
 
-sed -i '' "s/^ARG OSSFS_VERSION=.*/ARG OSSFS_VERSION=${OSSFS_RPM_VERSION_ESC}/" "${CSI_AGENT_DOCKERFILE}"
-sed -i '' "s/^ARG OSSFS2_VERSION=.*/ARG OSSFS2_VERSION=${OSSFS2_RPM_VERSION_ESC}/" "${CSI_AGENT_DOCKERFILE}"
-sed -i '' "s/^ARG ALINAS_UTILS_VERSION=.*/ARG ALINAS_UTILS_VERSION=${ALINAS_UTILS_VERSION_ESC}/" "${CSI_AGENT_DOCKERFILE}"
-sed -i '' "s/^ARG EFC_VERSION=.*/ARG EFC_VERSION=${EFC_VERSION_ESC}/" "${CSI_AGENT_DOCKERFILE}"
-sed -i '' "s/^ARG EFC_ARM_VERSION=.*/ARG EFC_ARM_VERSION=${EFC_ARM_VERSION_ESC}/" "${CSI_AGENT_DOCKERFILE}"
-sed -i '' "s/^ARG ALINAS_UTILS_ARM_VERSION=.*/ARG ALINAS_UTILS_ARM_VERSION=${ALINAS_UTILS_ARM_VERSION_ESC}/" "${CSI_AGENT_DOCKERFILE}"
-
-# Update mount-proxy Dockerfile
-MOUNT_PROXY_DOCKERFILE="${ROOT_DIR}/build/mount-proxy/Dockerfile"
-echo "Updating ${MOUNT_PROXY_DOCKERFILE}..."
-# Update OSSFS_VERSION for ossfs (first occurrence, before ossfs-1.88)
+# Update OSSFS_VERSION for ossfs stage
 sed -i '' "/^FROM.*AS ossfs$/,/^FROM.*AS ossfs-1.88$/ s/^ARG OSSFS_VERSION=.*/ARG OSSFS_VERSION=${OSSFS_RPM_VERSION_ESC}/" "${MOUNT_PROXY_DOCKERFILE}"
-# Update OSSFS_VERSION for ossfs2 (second occurrence, after ossfs-1.88)
+# Update OSSFS_VERSION for ossfs2 stage
 sed -i '' "/^FROM.*AS ossfs2$/,/^FROM.*AS alinas$/ s/^ARG OSSFS_VERSION=.*/ARG OSSFS_VERSION=${OSSFS2_RPM_VERSION_ESC}/" "${MOUNT_PROXY_DOCKERFILE}"
+# Update OSSFS_VERSION and OSSFS2_VERSION for aio stage
+sed -i '' "/^FROM.*AS aio$/,\$ s/^ARG OSSFS_VERSION=.*/ARG OSSFS_VERSION=${OSSFS_RPM_VERSION_ESC}/" "${MOUNT_PROXY_DOCKERFILE}"
+sed -i '' "/^FROM.*AS aio$/,\$ s/^ARG OSSFS2_VERSION=.*/ARG OSSFS2_VERSION=${OSSFS2_RPM_VERSION_ESC}/" "${MOUNT_PROXY_DOCKERFILE}"
+# Update alinas/efc versions (all occurrences)
 sed -i '' "s/^ARG ALINAS_UTILS_VERSION=.*/ARG ALINAS_UTILS_VERSION=${ALINAS_UTILS_VERSION_ESC}/" "${MOUNT_PROXY_DOCKERFILE}"
 sed -i '' "s/^ARG EFC_VERSION=.*/ARG EFC_VERSION=${EFC_VERSION_ESC}/" "${MOUNT_PROXY_DOCKERFILE}"
 sed -i '' "s/^ARG EFC_ARM_VERSION=.*/ARG EFC_ARM_VERSION=${EFC_ARM_VERSION_ESC}/" "${MOUNT_PROXY_DOCKERFILE}"


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

`aliyun-alinas-utils` declares `Requires: python3`, which pulls in `python36` and its baggage (`python3-pip`, `python3-setuptools`, `python3-pyyaml`). However, the actual runtime uses python3.8 via alternatives — `python36` is only there to satisfy the RPM dependency.

This PR:
- Adds a `python3-provider` RPM that satisfies `Requires: python3` using `python38` instead, eliminating `python36` and its dependencies
- Disables weak deps (`install_weak_deps=False`) to prevent `python38-pip` from being installed
- Removes `python3-pyyaml` (only used by `nfsdclnts`, an NFS server diagnostic tool irrelevant to this container) to silence CVE scans
- Moves the runtime environment from `csi-agent` Dockerfile into `mount-proxy` Dockerfile as a new `aio` (all-in-one) target; `csi-agent` Dockerfile now only builds the binary (`FROM scratch`)
- Applies the same python3-provider fix to the standalone `alinas` mount-proxy stage
- Updates `build-all-multi.sh` to build `csi-agent` and `mount-proxy` (aio) images, adds `IMAGES` env var for selective builds
- Updates `hack/update-versions.sh` to target mount-proxy Dockerfile instead of csi-agent
- Bumps ossfs to v1.91.10 and ossfs2 to v2.0.7 in mount-proxy stages (sync with VERSIONS file)

`python3-pyyaml` is version 3.12 from 2016 with no security backports — genuinely unpatched but unexploitable in our context since its only consumer uses `yaml.BaseLoader`.

#### Which issue(s) this PR fixes:

NONE

#### Special notes for your reviewer:

The `python3-provider` RPM is built in a multi-stage Dockerfile step and bind-mounted into the final image install. It declares `Provides: python3`, `Requires: python38`, and runs `alternatives --set python3 /usr/bin/python3.8` in `%post`.

The `csi-agent` image is now a minimal `FROM scratch` with only the binary at `/usr/local/bin/csi-agent`. The full runtime (ossfs + ossfs2 + alinas) lives in the `aio` target of `build/mount-proxy/Dockerfile`.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```