### PR TITLE
Fix vswitch_ids variable scope in cluster setup script

### DIFF
--- a/test/cluster/cluster_setup.sh
+++ b/test/cluster/cluster_setup.sh
@@ -48,7 +48,7 @@ function create-vpc {
 
     local subnet=0
     local zone
-    local -a vswitch_ids
+    vswitch_ids=()
     for zone in $ACK_ZONE; do
         echo "Creating VSwitch for zone $zone"
         local id


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

`vswitch_ids` was declared as `local` in `create-vpc` but referenced in `create-ack-cluster`, so it was always empty when passed to the cluster template. This removes the `local` qualifier so the array is visible to the caller.

#### Which issue(s) this PR fixes:

NONE

#### Special notes for your reviewer:

NONE

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```