### PR TITLE
nas: support AccessMode and readonly field for readonly mounts

### DIFF
--- a/pkg/nas/controllerserver.go
+++ b/pkg/nas/controllerserver.go
@@ -20,6 +20,7 @@ package nas
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/common"
@@ -153,8 +154,21 @@ func (cs *controllerServer) ControllerExpandVolume(ctx context.Context, req *csi
 
 func (cs *controllerServer) ValidateVolumeCapabilities(ctx context.Context, req *csi.ValidateVolumeCapabilitiesRequest) (*csi.ValidateVolumeCapabilitiesResponse, error) {
 	for _, cap := range req.VolumeCapabilities {
-		if cap.GetAccessMode().GetMode() != csi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER {
-			return &csi.ValidateVolumeCapabilitiesResponse{Message: ""}, nil
+		if cap.GetBlock() != nil {
+			return &csi.ValidateVolumeCapabilitiesResponse{
+				Message: "NAS does not support block volumes",
+			}, nil
+		}
+		switch cap.GetAccessMode().GetMode() {
+		case csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
+			csi.VolumeCapability_AccessMode_SINGLE_NODE_READER_ONLY,
+			csi.VolumeCapability_AccessMode_MULTI_NODE_READER_ONLY,
+			csi.VolumeCapability_AccessMode_MULTI_NODE_SINGLE_WRITER,
+			csi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER:
+		default:
+			return &csi.ValidateVolumeCapabilitiesResponse{
+				Message: fmt.Sprintf("unsupported access mode: %v", cap.GetAccessMode().GetMode()),
+			}, nil
 		}
 	}
 	return &csi.ValidateVolumeCapabilitiesResponse{

--- a/pkg/nas/controllerserver_test.go
+++ b/pkg/nas/controllerserver_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/nas/internal"
-	mytesting "github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/testing"
 	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/utils"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
@@ -245,13 +244,16 @@ func TestControllerServer_ValidateVolumeCapabilitiesConfirmed(t *testing.T) {
 	assert.Equal(t, req.VolumeCapabilities, resp.Confirmed.VolumeCapabilities)
 }
 
-func TestControllerServer_ValidateVolumeCapabilitiesNotConfirmed(t *testing.T) {
+func TestControllerServer_ValidateVolumeCapabilitiesReadOnly(t *testing.T) {
 	cs := newMockControllerServer()
 	assert.NotNil(t, cs)
 
 	req := &csi.ValidateVolumeCapabilitiesRequest{
 		VolumeCapabilities: []*csi.VolumeCapability{
 			{
+				AccessType: &csi.VolumeCapability_Mount{
+					Mount: &csi.VolumeCapability_MountVolume{},
+				},
 				AccessMode: &csi.VolumeCapability_AccessMode{
 					Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_READER_ONLY,
 				},
@@ -261,7 +263,50 @@ func TestControllerServer_ValidateVolumeCapabilitiesNotConfirmed(t *testing.T) {
 	resp, err := cs.ValidateVolumeCapabilities(context.Background(), req)
 	assert.NoError(t, err)
 	assert.NotNil(t, resp)
-	mytesting.AssertProtoEqual(t, &csi.ValidateVolumeCapabilitiesResponse{}, resp)
+	assert.Equal(t, req.VolumeCapabilities, resp.Confirmed.VolumeCapabilities)
+}
+
+func TestControllerServer_ValidateVolumeCapabilitiesBlockVolume(t *testing.T) {
+	cs := newMockControllerServer()
+	assert.NotNil(t, cs)
+
+	req := &csi.ValidateVolumeCapabilitiesRequest{
+		VolumeCapabilities: []*csi.VolumeCapability{
+			{
+				AccessType: &csi.VolumeCapability_Block{
+					Block: &csi.VolumeCapability_BlockVolume{},
+				},
+				AccessMode: &csi.VolumeCapability_AccessMode{
+					Mode: csi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER,
+				},
+			},
+		},
+	}
+	resp, err := cs.ValidateVolumeCapabilities(context.Background(), req)
+	assert.NoError(t, err)
+	assert.NotNil(t, resp)
+	assert.Nil(t, resp.Confirmed)
+	assert.Contains(t, resp.Message, "block")
+}
+
+func TestControllerServer_ValidateVolumeCapabilitiesUnsupportedMode(t *testing.T) {
+	cs := newMockControllerServer()
+	assert.NotNil(t, cs)
+
+	req := &csi.ValidateVolumeCapabilitiesRequest{
+		VolumeCapabilities: []*csi.VolumeCapability{
+			{
+				AccessMode: &csi.VolumeCapability_AccessMode{
+					Mode: csi.VolumeCapability_AccessMode_Mode(99),
+				},
+			},
+		},
+	}
+	resp, err := cs.ValidateVolumeCapabilities(context.Background(), req)
+	assert.NoError(t, err)
+	assert.NotNil(t, resp)
+	assert.Nil(t, resp.Confirmed)
+	assert.Contains(t, resp.Message, "unsupported access mode")
 }
 
 func TestControllerServer_ControllerGetCapabilities(t *testing.T) {

--- a/pkg/nas/mounter.go
+++ b/pkg/nas/mounter.go
@@ -1,4 +1,4 @@
-//go:build linux
+//go:build unix
 
 package nas
 

--- a/pkg/nas/nodeserver.go
+++ b/pkg/nas/nodeserver.go
@@ -306,6 +306,15 @@ func (ns *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 		}
 	}
 
+	readOnly := req.GetReadonly()
+	if !readOnly {
+		switch req.GetVolumeCapability().GetAccessMode().GetMode() {
+		case csi.VolumeCapability_AccessMode_MULTI_NODE_READER_ONLY,
+			csi.VolumeCapability_AccessMode_SINGLE_NODE_READER_ONLY:
+			readOnly = true
+		}
+	}
+
 	var runtimeVal string
 	if ns.config.KubeClient != nil {
 		runtimeVal = utils.GetPodRunTime(ctx, req, ns.config.KubeClient)
@@ -314,8 +323,12 @@ func (ns *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 	// running in runc/runv mode
 	if runtimeVal == utils.RunvRunTimeTag {
 		fileName := filepath.Join(mountPath, utils.CsiPluginRunTimeFlagFile)
+		options := opt.Options
+		if readOnly {
+			options = append(options, "ro")
+		}
 		runvOptions := RunvNasOptions{
-			Options:    strings.Join(opt.Options, ","),
+			Options:    strings.Join(options, ","),
 			Server:     opt.Server,
 			ModeType:   opt.ModeType,
 			Mode:       opt.Mode,
@@ -370,6 +383,10 @@ func (ns *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 		}
 	} else if len(opt.Options) == 1 && strings.EqualFold(opt.Options[0], "none") {
 		opt.Options = nil
+	}
+
+	if readOnly {
+		opt.Options = append(opt.Options, "ro")
 	}
 
 	notMounted, err := ns.mounter.IsLikelyNotMountPoint(mountPath)
@@ -433,6 +450,9 @@ func (ns *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 
 	// do losetup nas logical
 	if ns.config.EnableLosetup && opt.MountType == LosetupType {
+		if readOnly {
+			return nil, status.Error(codes.InvalidArgument, "losetup volumes do not support readonly mode")
+		}
 		if err := ns.mountLosetupPv(mountPath, opt, req.VolumeId); err != nil {
 			klog.Errorf("NodePublishVolume: mount losetup volume(%s) error %s", req.VolumeId, err.Error())
 			return nil, errors.New("NodePublishVolume, mount Losetup volume error with: " + err.Error())
@@ -477,7 +497,7 @@ func (ns *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 
 	}
 	// change the mode
-	if opt.Mode != "" && opt.Path != "/" {
+	if opt.Mode != "" && opt.Path != "/" && !readOnly {
 		var args []string
 		if opt.ModeType == "recursive" {
 			args = append(args, "-R")

--- a/pkg/nas/nodeserver.go
+++ b/pkg/nas/nodeserver.go
@@ -37,6 +37,7 @@ import (
 	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/features"
 	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/losetup"
 	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/mounter"
+	mounterutils "github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/mounter/utils"
 	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/nas/internal"
 	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/utils"
 	utilsio "github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/utils/io"
@@ -85,19 +86,19 @@ func newNodeServer(config *internal.NodeConfig) *nodeServer {
 
 // Options struct definition
 type Options struct {
-	Server        string `json:"server"`
-	Accesspoint   string `json:"accesspoint"`
-	Path          string `json:"path"`
-	Vers          string `json:"vers"`
-	Mode          string `json:"mode"`
-	ModeType      string `json:"modeType"`
-	Options       string `json:"options"`
-	MountType     string `json:"mountType"`
-	LoopImageSize int    `json:"loopImageSize"`
-	LoopLock      string `json:"loopLock"`
-	MountProtocol string `json:"mountProtocol"`
-	ClientType    string `json:"clientType"`
-	FSType        string `json:"fsType"`
+	Server        string   `json:"server"`
+	Accesspoint   string   `json:"accesspoint"`
+	Path          string   `json:"path"`
+	Vers          string   `json:"vers"`
+	Mode          string   `json:"mode"`
+	ModeType      string   `json:"modeType"`
+	Options       []string `json:"options"`
+	MountType     string   `json:"mountType"`
+	LoopImageSize int      `json:"loopImageSize"`
+	LoopLock      string   `json:"loopLock"`
+	MountProtocol string   `json:"mountProtocol"`
+	ClientType    string   `json:"clientType"`
+	FSType        string   `json:"fsType"`
 	SysConfigs    []utilsio.SysConfig
 	AkID          string
 	AkSecret      string
@@ -234,7 +235,7 @@ func (ns *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 		case "mode":
 			opt.Mode = value
 		case "options":
-			opt.Options = value
+			opt.Options = mounterutils.SplitMountOptions(value)
 		case "modetype":
 			opt.ModeType = value
 		case "mounttype":
@@ -286,7 +287,10 @@ func (ns *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 
 	// version/options used first in mountOptions
 	if req.VolumeCapability != nil && req.VolumeCapability.GetMount() != nil {
-		mntOptions := req.VolumeCapability.GetMount().MountFlags
+		var mntOptions []string
+		for _, o := range req.VolumeCapability.GetMount().MountFlags {
+			mntOptions = append(mntOptions, mounterutils.SplitMountOptions(o)...)
+		}
 		parseVers, parseOptions := ParseMountFlags(mntOptions)
 		if parseVers != "" {
 			if opt.Vers != "" {
@@ -294,9 +298,9 @@ func (ns *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 			}
 			opt.Vers = parseVers
 		}
-		if parseOptions != "" {
-			if opt.Options != "" {
-				klog.Warningf("NodePublishVolume: Options(%s) (in volumeAttributes) is ignored as Options(%s) also configured in mountOptions", opt.Options, parseOptions)
+		if len(parseOptions) > 0 {
+			if len(opt.Options) > 0 {
+				klog.Warningf("NodePublishVolume: Options(%v) (in volumeAttributes) is ignored as Options(%v) also configured in mountOptions", opt.Options, parseOptions)
 			}
 			opt.Options = parseOptions
 		}
@@ -311,7 +315,7 @@ func (ns *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 	if runtimeVal == utils.RunvRunTimeTag {
 		fileName := filepath.Join(mountPath, utils.CsiPluginRunTimeFlagFile)
 		runvOptions := RunvNasOptions{
-			Options:    opt.Options,
+			Options:    strings.Join(opt.Options, ","),
 			Server:     opt.Server,
 			ModeType:   opt.ModeType,
 			Mode:       opt.Mode,
@@ -358,14 +362,14 @@ func (ns *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 		}
 	}
 	// check options, config defaults for aliyun nas
-	if opt.Options == "" {
+	if len(opt.Options) == 0 {
 		if opt.Vers == "3" {
-			opt.Options = "nolock,proto=tcp,rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2,noresvport"
+			opt.Options = []string{"nolock", "proto=tcp", "rsize=1048576", "wsize=1048576", "hard", "timeo=600", "retrans=2", "noresvport"}
 		} else {
-			opt.Options = "noresvport"
+			opt.Options = []string{"noresvport"}
 		}
-	} else if strings.ToLower(opt.Options) == "none" {
-		opt.Options = ""
+	} else if len(opt.Options) == 1 && strings.EqualFold(opt.Options[0], "none") {
+		opt.Options = nil
 	}
 
 	notMounted, err := ns.mounter.IsLikelyNotMountPoint(mountPath)
@@ -395,7 +399,7 @@ func (ns *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 				Source:     source,
 				DeviceType: directvolume.DeviceTypeNFS,
 				FSType:     "",
-				MountOpts:  []string{opt.Options},
+				MountOpts:  opt.Options,
 				Extra:      map[string]string{},
 			}
 			klog.Info("NodePublishVolume(rund3.0): Starting add mount info to DirectVolume")

--- a/pkg/nas/utils.go
+++ b/pkg/nas/utils.go
@@ -171,11 +171,15 @@ func doMount(m mounter.Mounter, opt *Options, targetPath, volumeId, podUid strin
 		return err
 	}
 	defer os.Remove(tmpPath)
+	// mount without "ro" since we need to create the subpath directory
+	rwOptions := slices.DeleteFunc(slices.Clone(combinedOptions), func(s string) bool {
+		return s == "ro"
+	})
 	if err := m.ExtendedMount(context.Background(), &mounter.MountOperation{
 		Source:   rootSource,
 		Target:   tmpPath,
 		FsType:   mountFstype,
-		Options:  combinedOptions,
+		Options:  rwOptions,
 		Secrets:  secrets,
 		VolumeID: volumeId,
 	}); err != nil {

--- a/pkg/nas/utils.go
+++ b/pkg/nas/utils.go
@@ -25,13 +25,13 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"strings"
 	"time"
 
 	"github.com/alibabacloud-go/tea/tea"
 	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/losetup"
 	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/mounter"
-	mounterutils "github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/mounter/utils"
 	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/nas/cloud"
 	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/nas/interfaces"
 	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/utils"
@@ -87,9 +87,7 @@ func doMount(m mounter.Mounter, opt *Options, targetPath, volumeId, podUid strin
 	} else {
 		source = fmt.Sprintf("%s:%s", opt.Server, opt.Path)
 	}
-	if opt.Options != "" {
-		combinedOptions = append(combinedOptions, opt.Options)
-	}
+	combinedOptions = append(combinedOptions, opt.Options...)
 	if opt.AkID != "" && opt.AkSecret != "" {
 		secrets = map[string]string{
 			akIDKey:     opt.AkID,
@@ -120,7 +118,7 @@ func doMount(m mounter.Mounter, opt *Options, targetPath, volumeId, podUid strin
 	default:
 		//NFS Mount(Capacdity/Performance Extreme Nas、Cpfs2.0, AliNas)
 		versStr := fmt.Sprintf("vers=%s", opt.Vers)
-		if !strings.Contains(opt.Options, versStr) {
+		if !slices.Contains(opt.Options, versStr) {
 			combinedOptions = append(combinedOptions, versStr)
 		}
 		if opt.Accesspoint != "" {
@@ -132,7 +130,7 @@ func doMount(m mounter.Mounter, opt *Options, targetPath, volumeId, podUid strin
 		// Enable compatibility for BMCPFS VPC mount points using the NAS Driver, to support the same usage in ECI.
 		if isCPFS(opt.FSType, opt.Server) && opt.MountProtocol == "efc" {
 			mountFstype = "alinas"
-			combinedOptions = append(combinedOptions, "efc,protocol=efc,net=tcp,fstype=cpfs")
+			combinedOptions = append(combinedOptions, "efc", "protocol=efc", "net=tcp", "fstype=cpfs")
 			if agentMode {
 				isPathNotFound = isEFCPathNotFoundError
 			} else {
@@ -263,39 +261,33 @@ func checkSystemNasConfig() error {
 	return os.WriteFile(TcpSlotTableEntries, []byte(TcpSlotTableEntriesValue), os.ModePerm)
 }
 
-// ParseMountFlags parse mountOptions
-func ParseMountFlags(mntOptions []string) (string, string) {
+// ParseMountFlags parse mountOptions.
+// Input must be pre-split (each element is a single mount option).
+func ParseMountFlags(mntOptions []string) (string, []string) {
 	var vers string
 	var otherOptions []string
-	for _, options := range mntOptions {
-		for _, option := range mounterutils.SplitMountOptions(options) {
-			if option == "" {
-				continue
-			}
-			key, value, found := strings.Cut(option, "=")
-			if found && key == "vers" {
-				vers = value
-			} else {
-				otherOptions = append(otherOptions, option)
-			}
+	for _, option := range mntOptions {
+		if option == "" {
+			continue
+		}
+		key, value, found := strings.Cut(option, "=")
+		if found && key == "vers" {
+			vers = value
+		} else {
+			otherOptions = append(otherOptions, option)
 		}
 	}
 	if vers == "3.0" {
 		vers = "3"
 	}
-	return vers, strings.Join(otherOptions, ",")
+	return vers, otherOptions
 }
 
 func addTLSMountOptions(baseOptions []string) []string {
-	for _, options := range baseOptions {
-		for _, option := range mounterutils.SplitMountOptions(options) {
-			if option == "" {
-				continue
-			}
-			key, _, _ := strings.Cut(option, "=")
-			if key == "tls" {
-				return baseOptions
-			}
+	for _, option := range baseOptions {
+		key, _, _ := strings.Cut(option, "=")
+		if key == "tls" {
+			return baseOptions
 		}
 	}
 	return append(baseOptions, "tls")
@@ -358,7 +350,7 @@ func saveVolumeData(opt *Options, mountPath string) error {
 	volumeData := map[string]string{}
 	volumeData["csi.alibabacloud.com/version"] = opt.Vers
 	if len(opt.Options) != 0 {
-		volumeData["csi.alibabacloud.com/options"] = opt.Options
+		volumeData["csi.alibabacloud.com/options"] = strings.Join(opt.Options, ",")
 	}
 	if len(opt.Server) != 0 {
 		volumeData["csi.alibabacloud.com/server"] = opt.Server

--- a/pkg/nas/utils_test.go
+++ b/pkg/nas/utils_test.go
@@ -25,55 +25,33 @@ import (
 )
 
 func TestParseMountFlags(t *testing.T) {
-	type args struct {
-		mntOptions []string
-	}
 	tests := []struct {
-		name  string
-		args  args
-		want  string
-		want1 string
+		name        string
+		mntOptions  []string
+		wantVers    string
+		wantOptions []string
 	}{
 		{
-			"vers=3",
-			args{[]string{"mnt=/test", "vers=3.0"}},
-			"3", "mnt=/test",
+			"vers=3.0 normalized to 3",
+			[]string{"mnt=/test", "vers=3.0"},
+			"3", []string{"mnt=/test"},
 		},
 		{
-			"vers=3.0",
-			args{[]string{"mnt=/test", "vers=3.0"}},
-			"3", "mnt=/test",
-		},
-		{
-			"vers=4",
-			args{[]string{"mnt=/test", "vers=4"}},
-			"4", "mnt=/test",
-		},
-		{
-			"vers=4.0",
-			args{[]string{"mnt=/test", "vers=4.0"}},
-			"4.0", "mnt=/test",
-		},
-		{
-			"vers=4.1",
-			args{[]string{"mnt=/test", "vers=4.1"}},
-			"4.1", "mnt=/test",
+			"vers=4.1 not normalized",
+			[]string{"mnt=/test", "vers=4.1"},
+			"4.1", []string{"mnt=/test"},
 		},
 		{
 			"no vers",
-			args{[]string{"mnt=/test", "a=b,,c=d"}},
-			"", "mnt=/test,a=b,c=d",
+			[]string{"mnt=/test", "a=b", "c=d"},
+			"", []string{"mnt=/test", "a=b", "c=d"},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, got1 := ParseMountFlags(tt.args.mntOptions)
-			if got != tt.want {
-				t.Errorf("ParseMountFlags() got = %v, want %v", got, tt.want)
-			}
-			if got1 != tt.want1 {
-				t.Errorf("ParseMountFlags() got1 = %v, want %v", got1, tt.want1)
-			}
+			gotVers, gotOptions := ParseMountFlags(tt.mntOptions)
+			assert.Equal(t, tt.wantVers, gotVers)
+			assert.Equal(t, tt.wantOptions, gotOptions)
 		})
 	}
 }
@@ -89,8 +67,8 @@ func Test_addTLSMountOptions(t *testing.T) {
 	}{
 		{
 			"already set tls",
-			args{[]string{"vers=3,tls"}},
-			[]string{"vers=3,tls"},
+			args{[]string{"vers=3", "tls"}},
+			[]string{"vers=3", "tls"},
 		},
 		{
 			"tls not set",


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

The NAS driver currently ignores both `req.Readonly` and `VolumeCapability.AccessMode` for readonly semantics. This PR adds proper support:

- Appends "ro" to mount options when `req.Readonly` is true or the access mode is `READER_ONLY`
- Updates `ValidateVolumeCapabilities` to accept all standard mount-type access modes (previously only accepted `MULTI_NODE_MULTI_WRITER`) and reject block volumes

Also refactors `Options.Options` from a comma-separated string to `[]string` for consistency with the mount infrastructure.

#### Which issue(s) this PR fixes:

NONE

#### Special notes for your reviewer:

Split into two logical commits:
1. Refactor `Options.Options` from `string` to `[]string`
2. Add AccessMode and readonly support

**Potentially confusing points:**

1. **Proxy server still splits options internally (intentional)**
   `addAutoFallbackNFSMountOptions` in the mount-proxy server keeps its own `SplitMountOptions` call, even though the NAS nodeserver now passes pre-split options. The proxy server receives requests from multiple clients (including bmcpfs) that may still send comma-separated strings. Server and client may also be upgraded independently, so the server must remain backward-compatible.

2. **`readOnly` flag does NOT account for user-specified "ro" in mountFlags**
   If a user puts `ro` in SC `mountOptions` but uses a RW access mode, `readOnly` stays `false`. The mount is effectively read-only (kernel honors the option), but `chmod` will still be attempted (fails with EROFS, logged but not fatal). This is acceptable — detecting "ro" from options is not straightforward since users could specify `"ro,rw"` where `ro` doesn't actually mean the mount is read-only (last option wins). Reliably deriving readonly state from options is complex and probably not worthwhile.

3. **Duplicate "ro" option is possible**
   If `ro` is in mountFlags AND the access mode is `ReadOnlyMany`, `opt.Options` will contain `["...", "ro", "ro"]`. The kernel tolerates duplicates. For the same reason as above, deduplicating is not worth the complexity.

4. **Subpath auto-creation strips "ro" for temporary root mount**
   When auto-creating a subpath directory, the code mounts the NAS root without "ro" to a private temp path (kubelet plugin dir, 0700), creates the directory, then unmounts. The final pod-visible mount retains "ro". Safe because the temp mount is never exposed to pods and NAS server-side ACLs still apply.

5. **`ValidateVolumeCapabilities` accepts `SINGLE_NODE_WRITER`**
   Intentional — NAS can serve `ReadWriteOnce` PVCs (the CO enforces the single-node constraint). The newer modes (`SINGLE_NODE_SINGLE_WRITER`, `SINGLE_NODE_MULTI_WRITER`) are not listed because Kubernetes only sends those to drivers that advertise the corresponding capability.

#### Does this PR introduce a user-facing change?

```release-note
NAS driver now respects readonly volume access modes and the readonly field in NodePublishVolume requests.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```
