### PR TITLE
disk: read block device capacity before filesystem resize

### DIFF
--- a/pkg/disk/nodeserver.go
+++ b/pkg/disk/nodeserver.go
@@ -942,8 +942,10 @@ func (ns *nodeServer) localExpandVolume(ctx context.Context, req *csi.NodeExpand
 		logger.V(2).Info("Successful expand partition", "root", rootPath, "partition", index)
 	}
 
+	deviceCapacity := getBlockDeviceCapacity(rootPath)
+
 	logger.V(2).Info("Expand filesystem start", "volumePath", volumePath)
-	// use resizer to expand volume filesystem
+	// still try resize even if the deviceCapacity is not as large as requested, better than not.
 	r := k8smount.NewResizeFs(utilexec.New())
 	ok, err := r.Resize(devicePath, volumePath)
 	if err != nil {
@@ -953,7 +955,6 @@ func (ns *nodeServer) localExpandVolume(ctx context.Context, req *csi.NodeExpand
 		return nil, status.Errorf(codes.Internal, "resize %s returned false", volumePath)
 	}
 
-	deviceCapacity := getBlockDeviceCapacity(rootPath)
 	if requestBytes > 0 && deviceCapacity < requestBytes {
 		// After calling OpenAPI to expand cloud disk, the size of the underlying block device may not change immediately.
 		// return error and CO will retry later.


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Moves the `getBlockDeviceCapacity` call to before the filesystem resize to eliminate a race condition.

Previously, the cloud provider's async block device expansion could land between `Resize()` and the capacity check, causing the function to report success even though the filesystem was resized on a smaller-than-requested device. By reading the capacity before resize, we capture the actual device size at the time the resize operated.

#### Which issue(s) this PR fixes:

NONE

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
```