### PR TITLE
cloud: context-aware OpenAPI v2 clients with logging decorators and metrics

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -70,6 +70,7 @@ require (
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/mailru/easyjson v0.9.0 // indirect
 	github.com/mdlayher/netlink v1.7.3-0.20250113171957-fbb4dce95f42 // indirect
 	github.com/mdlayher/socket v0.5.0 // indirect

--- a/main.go
+++ b/main.go
@@ -34,7 +34,9 @@ import (
 	sts20150401 "github.com/alibabacloud-go/sts-20150401/v2/client"
 	alicred_old "github.com/aliyun/credentials-go/credentials"
 	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/bmcpfs"
+	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/cloud"
 	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/cloud/metadata"
+	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/cloud/wrap"
 	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/common"
 	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/credentials"
 	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/disk"
@@ -191,7 +193,7 @@ func main() {
 	if err != nil {
 		klog.ErrorS(err, "failed to get credential for metadata, will not enable OpenAPI")
 	}
-	var ecsClient *ecs20140526.Client
+	var ecsClient cloud.ECSv2Interface
 	var efloClient *eflo_controller20221215.Client
 	if provider != nil {
 		cred := alicred_old.FromCredentialsProvider(provider.GetProviderName(), provider)
@@ -203,12 +205,16 @@ func main() {
 			meta.EnableEFLO(efloClient)
 		}
 
-		ecsClient, err = ecs20140526.NewClient(utils.GetEcsConfig(regionID).SetCredential(cred))
+		var ecsRaw *ecs20140526.Client
+		ecsRaw, err = ecs20140526.NewClient(utils.GetEcsConfig(regionID).SetCredential(cred))
 		if err != nil {
 			klog.ErrorS(err, "failed to get ecsClient")
-		} else if !*useLabeler {
+		} else {
+			ecsClient = wrap.ECS(ecsRaw)
 			// Goes after EFLO, because if EFLO API confirms it's a lingjun instance, we can skip ECS API.
-			meta.EnableOpenAPI(ecsClient)
+			if !*useLabeler {
+				meta.EnableOpenAPI(ecsClient)
+			}
 		}
 
 		stsClient, err := sts20150401.NewClient(utils.GetStsConfig(regionID).SetCredential(cred))

--- a/pkg/cloud/ecsinterface.go
+++ b/pkg/cloud/ecsinterface.go
@@ -1,7 +1,10 @@
 package cloud
 
 import (
+	"context"
+
 	ecs20140526 "github.com/alibabacloud-go/ecs-20140526/v7/client"
+	"github.com/alibabacloud-go/tea/dara"
 	"github.com/aliyun/alibaba-cloud-sdk-go/services/ecs"
 )
 
@@ -20,13 +23,13 @@ type ECSInterface interface {
 }
 
 type ECSv2Interface interface {
-	DescribeInstances(request *ecs20140526.DescribeInstancesRequest) (response *ecs20140526.DescribeInstancesResponse, err error)
-	DescribeInstanceTypes(request *ecs20140526.DescribeInstanceTypesRequest) (response *ecs20140526.DescribeInstanceTypesResponse, err error)
-	DescribeAvailableResource(request *ecs20140526.DescribeAvailableResourceRequest) (response *ecs20140526.DescribeAvailableResourceResponse, err error)
-	DescribeDisks(request *ecs20140526.DescribeDisksRequest) (response *ecs20140526.DescribeDisksResponse, err error)
-	TagResources(request *ecs20140526.TagResourcesRequest) (response *ecs20140526.TagResourcesResponse, err error)
-	UntagResources(request *ecs20140526.UntagResourcesRequest) (response *ecs20140526.UntagResourcesResponse, err error)
-	ModifyDiskSpec(request *ecs20140526.ModifyDiskSpecRequest) (response *ecs20140526.ModifyDiskSpecResponse, err error)
-	ModifyDiskAttribute(request *ecs20140526.ModifyDiskAttributeRequest) (response *ecs20140526.ModifyDiskAttributeResponse, err error)
-	DescribeTasks(request *ecs20140526.DescribeTasksRequest) (response *ecs20140526.DescribeTasksResponse, err error)
+	DescribeInstancesWithContext(ctx context.Context, request *ecs20140526.DescribeInstancesRequest, o *dara.RuntimeOptions) (response *ecs20140526.DescribeInstancesResponse, err error)
+	DescribeInstanceTypesWithContext(ctx context.Context, request *ecs20140526.DescribeInstanceTypesRequest, o *dara.RuntimeOptions) (response *ecs20140526.DescribeInstanceTypesResponse, err error)
+	DescribeAvailableResourceWithContext(ctx context.Context, request *ecs20140526.DescribeAvailableResourceRequest, o *dara.RuntimeOptions) (response *ecs20140526.DescribeAvailableResourceResponse, err error)
+	DescribeDisksWithContext(ctx context.Context, request *ecs20140526.DescribeDisksRequest, o *dara.RuntimeOptions) (response *ecs20140526.DescribeDisksResponse, err error)
+	TagResourcesWithContext(ctx context.Context, request *ecs20140526.TagResourcesRequest, o *dara.RuntimeOptions) (response *ecs20140526.TagResourcesResponse, err error)
+	UntagResourcesWithContext(ctx context.Context, request *ecs20140526.UntagResourcesRequest, o *dara.RuntimeOptions) (response *ecs20140526.UntagResourcesResponse, err error)
+	ModifyDiskSpecWithContext(ctx context.Context, request *ecs20140526.ModifyDiskSpecRequest, o *dara.RuntimeOptions) (response *ecs20140526.ModifyDiskSpecResponse, err error)
+	ModifyDiskAttributeWithContext(ctx context.Context, request *ecs20140526.ModifyDiskAttributeRequest, o *dara.RuntimeOptions) (response *ecs20140526.ModifyDiskAttributeResponse, err error)
+	DescribeTasksWithContext(ctx context.Context, request *ecs20140526.DescribeTasksRequest, o *dara.RuntimeOptions) (response *ecs20140526.DescribeTasksResponse, err error)
 }

--- a/pkg/cloud/ecsmock.go
+++ b/pkg/cloud/ecsmock.go
@@ -5,9 +5,11 @@
 package cloud
 
 import (
+	context "context"
 	reflect "reflect"
 
 	client "github.com/alibabacloud-go/ecs-20140526/v7/client"
+	dara "github.com/alibabacloud-go/tea/dara"
 	ecs "github.com/aliyun/alibaba-cloud-sdk-go/services/ecs"
 	gomock "github.com/golang/mock/gomock"
 )
@@ -223,137 +225,137 @@ func (m *MockECSv2Interface) EXPECT() *MockECSv2InterfaceMockRecorder {
 	return m.recorder
 }
 
-// DescribeAvailableResource mocks base method.
-func (m *MockECSv2Interface) DescribeAvailableResource(request *client.DescribeAvailableResourceRequest) (*client.DescribeAvailableResourceResponse, error) {
+// DescribeAvailableResourceWithContext mocks base method.
+func (m *MockECSv2Interface) DescribeAvailableResourceWithContext(ctx context.Context, request *client.DescribeAvailableResourceRequest, o *dara.RuntimeOptions) (*client.DescribeAvailableResourceResponse, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DescribeAvailableResource", request)
+	ret := m.ctrl.Call(m, "DescribeAvailableResourceWithContext", ctx, request, o)
 	ret0, _ := ret[0].(*client.DescribeAvailableResourceResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// DescribeAvailableResource indicates an expected call of DescribeAvailableResource.
-func (mr *MockECSv2InterfaceMockRecorder) DescribeAvailableResource(request interface{}) *gomock.Call {
+// DescribeAvailableResourceWithContext indicates an expected call of DescribeAvailableResourceWithContext.
+func (mr *MockECSv2InterfaceMockRecorder) DescribeAvailableResourceWithContext(ctx, request, o interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeAvailableResource", reflect.TypeOf((*MockECSv2Interface)(nil).DescribeAvailableResource), request)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeAvailableResourceWithContext", reflect.TypeOf((*MockECSv2Interface)(nil).DescribeAvailableResourceWithContext), ctx, request, o)
 }
 
-// DescribeDisks mocks base method.
-func (m *MockECSv2Interface) DescribeDisks(request *client.DescribeDisksRequest) (*client.DescribeDisksResponse, error) {
+// DescribeDisksWithContext mocks base method.
+func (m *MockECSv2Interface) DescribeDisksWithContext(ctx context.Context, request *client.DescribeDisksRequest, o *dara.RuntimeOptions) (*client.DescribeDisksResponse, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DescribeDisks", request)
+	ret := m.ctrl.Call(m, "DescribeDisksWithContext", ctx, request, o)
 	ret0, _ := ret[0].(*client.DescribeDisksResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// DescribeDisks indicates an expected call of DescribeDisks.
-func (mr *MockECSv2InterfaceMockRecorder) DescribeDisks(request interface{}) *gomock.Call {
+// DescribeDisksWithContext indicates an expected call of DescribeDisksWithContext.
+func (mr *MockECSv2InterfaceMockRecorder) DescribeDisksWithContext(ctx, request, o interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeDisks", reflect.TypeOf((*MockECSv2Interface)(nil).DescribeDisks), request)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeDisksWithContext", reflect.TypeOf((*MockECSv2Interface)(nil).DescribeDisksWithContext), ctx, request, o)
 }
 
-// DescribeInstanceTypes mocks base method.
-func (m *MockECSv2Interface) DescribeInstanceTypes(request *client.DescribeInstanceTypesRequest) (*client.DescribeInstanceTypesResponse, error) {
+// DescribeInstanceTypesWithContext mocks base method.
+func (m *MockECSv2Interface) DescribeInstanceTypesWithContext(ctx context.Context, request *client.DescribeInstanceTypesRequest, o *dara.RuntimeOptions) (*client.DescribeInstanceTypesResponse, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DescribeInstanceTypes", request)
+	ret := m.ctrl.Call(m, "DescribeInstanceTypesWithContext", ctx, request, o)
 	ret0, _ := ret[0].(*client.DescribeInstanceTypesResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// DescribeInstanceTypes indicates an expected call of DescribeInstanceTypes.
-func (mr *MockECSv2InterfaceMockRecorder) DescribeInstanceTypes(request interface{}) *gomock.Call {
+// DescribeInstanceTypesWithContext indicates an expected call of DescribeInstanceTypesWithContext.
+func (mr *MockECSv2InterfaceMockRecorder) DescribeInstanceTypesWithContext(ctx, request, o interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeInstanceTypes", reflect.TypeOf((*MockECSv2Interface)(nil).DescribeInstanceTypes), request)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeInstanceTypesWithContext", reflect.TypeOf((*MockECSv2Interface)(nil).DescribeInstanceTypesWithContext), ctx, request, o)
 }
 
-// DescribeInstances mocks base method.
-func (m *MockECSv2Interface) DescribeInstances(request *client.DescribeInstancesRequest) (*client.DescribeInstancesResponse, error) {
+// DescribeInstancesWithContext mocks base method.
+func (m *MockECSv2Interface) DescribeInstancesWithContext(ctx context.Context, request *client.DescribeInstancesRequest, o *dara.RuntimeOptions) (*client.DescribeInstancesResponse, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DescribeInstances", request)
+	ret := m.ctrl.Call(m, "DescribeInstancesWithContext", ctx, request, o)
 	ret0, _ := ret[0].(*client.DescribeInstancesResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// DescribeInstances indicates an expected call of DescribeInstances.
-func (mr *MockECSv2InterfaceMockRecorder) DescribeInstances(request interface{}) *gomock.Call {
+// DescribeInstancesWithContext indicates an expected call of DescribeInstancesWithContext.
+func (mr *MockECSv2InterfaceMockRecorder) DescribeInstancesWithContext(ctx, request, o interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeInstances", reflect.TypeOf((*MockECSv2Interface)(nil).DescribeInstances), request)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeInstancesWithContext", reflect.TypeOf((*MockECSv2Interface)(nil).DescribeInstancesWithContext), ctx, request, o)
 }
 
-// DescribeTasks mocks base method.
-func (m *MockECSv2Interface) DescribeTasks(request *client.DescribeTasksRequest) (*client.DescribeTasksResponse, error) {
+// DescribeTasksWithContext mocks base method.
+func (m *MockECSv2Interface) DescribeTasksWithContext(ctx context.Context, request *client.DescribeTasksRequest, o *dara.RuntimeOptions) (*client.DescribeTasksResponse, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DescribeTasks", request)
+	ret := m.ctrl.Call(m, "DescribeTasksWithContext", ctx, request, o)
 	ret0, _ := ret[0].(*client.DescribeTasksResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// DescribeTasks indicates an expected call of DescribeTasks.
-func (mr *MockECSv2InterfaceMockRecorder) DescribeTasks(request interface{}) *gomock.Call {
+// DescribeTasksWithContext indicates an expected call of DescribeTasksWithContext.
+func (mr *MockECSv2InterfaceMockRecorder) DescribeTasksWithContext(ctx, request, o interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeTasks", reflect.TypeOf((*MockECSv2Interface)(nil).DescribeTasks), request)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeTasksWithContext", reflect.TypeOf((*MockECSv2Interface)(nil).DescribeTasksWithContext), ctx, request, o)
 }
 
-// ModifyDiskAttribute mocks base method.
-func (m *MockECSv2Interface) ModifyDiskAttribute(request *client.ModifyDiskAttributeRequest) (*client.ModifyDiskAttributeResponse, error) {
+// ModifyDiskAttributeWithContext mocks base method.
+func (m *MockECSv2Interface) ModifyDiskAttributeWithContext(ctx context.Context, request *client.ModifyDiskAttributeRequest, o *dara.RuntimeOptions) (*client.ModifyDiskAttributeResponse, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ModifyDiskAttribute", request)
+	ret := m.ctrl.Call(m, "ModifyDiskAttributeWithContext", ctx, request, o)
 	ret0, _ := ret[0].(*client.ModifyDiskAttributeResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// ModifyDiskAttribute indicates an expected call of ModifyDiskAttribute.
-func (mr *MockECSv2InterfaceMockRecorder) ModifyDiskAttribute(request interface{}) *gomock.Call {
+// ModifyDiskAttributeWithContext indicates an expected call of ModifyDiskAttributeWithContext.
+func (mr *MockECSv2InterfaceMockRecorder) ModifyDiskAttributeWithContext(ctx, request, o interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModifyDiskAttribute", reflect.TypeOf((*MockECSv2Interface)(nil).ModifyDiskAttribute), request)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModifyDiskAttributeWithContext", reflect.TypeOf((*MockECSv2Interface)(nil).ModifyDiskAttributeWithContext), ctx, request, o)
 }
 
-// ModifyDiskSpec mocks base method.
-func (m *MockECSv2Interface) ModifyDiskSpec(request *client.ModifyDiskSpecRequest) (*client.ModifyDiskSpecResponse, error) {
+// ModifyDiskSpecWithContext mocks base method.
+func (m *MockECSv2Interface) ModifyDiskSpecWithContext(ctx context.Context, request *client.ModifyDiskSpecRequest, o *dara.RuntimeOptions) (*client.ModifyDiskSpecResponse, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ModifyDiskSpec", request)
+	ret := m.ctrl.Call(m, "ModifyDiskSpecWithContext", ctx, request, o)
 	ret0, _ := ret[0].(*client.ModifyDiskSpecResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// ModifyDiskSpec indicates an expected call of ModifyDiskSpec.
-func (mr *MockECSv2InterfaceMockRecorder) ModifyDiskSpec(request interface{}) *gomock.Call {
+// ModifyDiskSpecWithContext indicates an expected call of ModifyDiskSpecWithContext.
+func (mr *MockECSv2InterfaceMockRecorder) ModifyDiskSpecWithContext(ctx, request, o interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModifyDiskSpec", reflect.TypeOf((*MockECSv2Interface)(nil).ModifyDiskSpec), request)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModifyDiskSpecWithContext", reflect.TypeOf((*MockECSv2Interface)(nil).ModifyDiskSpecWithContext), ctx, request, o)
 }
 
-// TagResources mocks base method.
-func (m *MockECSv2Interface) TagResources(request *client.TagResourcesRequest) (*client.TagResourcesResponse, error) {
+// TagResourcesWithContext mocks base method.
+func (m *MockECSv2Interface) TagResourcesWithContext(ctx context.Context, request *client.TagResourcesRequest, o *dara.RuntimeOptions) (*client.TagResourcesResponse, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "TagResources", request)
+	ret := m.ctrl.Call(m, "TagResourcesWithContext", ctx, request, o)
 	ret0, _ := ret[0].(*client.TagResourcesResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// TagResources indicates an expected call of TagResources.
-func (mr *MockECSv2InterfaceMockRecorder) TagResources(request interface{}) *gomock.Call {
+// TagResourcesWithContext indicates an expected call of TagResourcesWithContext.
+func (mr *MockECSv2InterfaceMockRecorder) TagResourcesWithContext(ctx, request, o interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TagResources", reflect.TypeOf((*MockECSv2Interface)(nil).TagResources), request)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TagResourcesWithContext", reflect.TypeOf((*MockECSv2Interface)(nil).TagResourcesWithContext), ctx, request, o)
 }
 
-// UntagResources mocks base method.
-func (m *MockECSv2Interface) UntagResources(request *client.UntagResourcesRequest) (*client.UntagResourcesResponse, error) {
+// UntagResourcesWithContext mocks base method.
+func (m *MockECSv2Interface) UntagResourcesWithContext(ctx context.Context, request *client.UntagResourcesRequest, o *dara.RuntimeOptions) (*client.UntagResourcesResponse, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UntagResources", request)
+	ret := m.ctrl.Call(m, "UntagResourcesWithContext", ctx, request, o)
 	ret0, _ := ret[0].(*client.UntagResourcesResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// UntagResources indicates an expected call of UntagResources.
-func (mr *MockECSv2InterfaceMockRecorder) UntagResources(request interface{}) *gomock.Call {
+// UntagResourcesWithContext indicates an expected call of UntagResourcesWithContext.
+func (mr *MockECSv2InterfaceMockRecorder) UntagResourcesWithContext(ctx, request, o interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UntagResources", reflect.TypeOf((*MockECSv2Interface)(nil).UntagResources), request)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UntagResourcesWithContext", reflect.TypeOf((*MockECSv2Interface)(nil).UntagResourcesWithContext), ctx, request, o)
 }

--- a/pkg/cloud/errors.go
+++ b/pkg/cloud/errors.go
@@ -1,0 +1,19 @@
+package cloud
+
+import (
+	"errors"
+
+	"github.com/alibabacloud-go/tea/tea"
+	"k8s.io/utils/ptr"
+)
+
+// ErrorCodeV2 returns the Alibaba error code carried by a v2 SDK error
+// (*tea.SDKError), or "" if err is not (and does not wrap) one. The code is read
+// straight from the SDK error, so callers can match it without depending on the
+// error having been through a logging decorator.
+func ErrorCodeV2(err error) string {
+	if sdk, ok := errors.AsType[*tea.SDKError](err); ok {
+		return ptr.Deref(sdk.Code, "")
+	}
+	return ""
+}

--- a/pkg/cloud/metadata/ecs_instance_type.go
+++ b/pkg/cloud/metadata/ecs_instance_type.go
@@ -1,9 +1,11 @@
 package metadata
 
 import (
+	"context"
 	"fmt"
 
 	ecs20140526 "github.com/alibabacloud-go/ecs-20140526/v7/client"
+	"github.com/alibabacloud-go/tea/dara"
 	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/cloud"
 )
 
@@ -11,11 +13,11 @@ type ECSInstanceTypeMetadata struct {
 	t *ecs20140526.DescribeInstanceTypesResponseBodyInstanceTypesInstanceType
 }
 
-func NewEcsInstanceTypeMetadata(c cloud.ECSv2Interface, instanceType string) (*ECSInstanceTypeMetadata, error) {
+func NewEcsInstanceTypeMetadata(ctx context.Context, c cloud.ECSv2Interface, instanceType string) (*ECSInstanceTypeMetadata, error) {
 	req := ecs20140526.DescribeInstanceTypesRequest{
 		InstanceTypes: []*string{&instanceType},
 	}
-	resp, err := c.DescribeInstanceTypes(&req)
+	resp, err := c.DescribeInstanceTypesWithContext(ctx, &req, &dara.RuntimeOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("failed to describe instance type %s: %w", instanceType, err)
 	}
@@ -71,7 +73,7 @@ func (f *ECSInstanceTypeFetcher) FetchFor(ctx *mcontext, key MetadataKey) (middl
 	if err != nil {
 		return nil, fmt.Errorf("instance type is not available: %w", err)
 	}
-	p, err := NewEcsInstanceTypeMetadata(f.ecsClient, t.(string))
+	p, err := NewEcsInstanceTypeMetadata(ctx, f.ecsClient, t.(string))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cloud/metadata/ecs_instance_type_test.go
+++ b/pkg/cloud/metadata/ecs_instance_type_test.go
@@ -82,7 +82,7 @@ func TestGetEcsInstanceType(t *testing.T) {
 	{
 		res := &ecs20140526.DescribeInstanceTypesResponse{}
 		require.NoError(t, json.Unmarshal([]byte(ecsDescribeInstanceTypesResponseJson), &res.Body))
-		client.EXPECT().DescribeInstanceTypes(gomock.Any()).Return(res, nil)
+		client.EXPECT().DescribeInstanceTypesWithContext(gomock.Any(), gomock.Any(), gomock.Any()).Return(res, nil)
 	}
 
 	m := testMetadata(t, fakeMiddleware{InstanceID: "i-2zec1slzwdzrwmvlr4w2"})
@@ -101,13 +101,13 @@ func TestGetEcsInstanceTypeError(t *testing.T) {
 		{
 			name: "describe_instance_types_error",
 			configClient: func(client *cloud.MockECSv2Interface) {
-				client.EXPECT().DescribeInstanceTypes(gomock.Any()).Return(nil, errors.New("failed to describe instance types"))
+				client.EXPECT().DescribeInstanceTypesWithContext(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, errors.New("failed to describe instance types"))
 			},
 		},
 		{
 			name: "missing_instance_types_field",
 			configClient: func(client *cloud.MockECSv2Interface) {
-				client.EXPECT().DescribeInstanceTypes(gomock.Any()).Return(&ecs20140526.DescribeInstanceTypesResponse{}, nil)
+				client.EXPECT().DescribeInstanceTypesWithContext(gomock.Any(), gomock.Any(), gomock.Any()).Return(&ecs20140526.DescribeInstanceTypesResponse{}, nil)
 			},
 		},
 		{
@@ -118,7 +118,7 @@ func TestGetEcsInstanceTypeError(t *testing.T) {
 						InstanceTypes: &ecs20140526.DescribeInstanceTypesResponseBodyInstanceTypes{},
 					},
 				}
-				client.EXPECT().DescribeInstanceTypes(gomock.Any()).Return(resp, nil)
+				client.EXPECT().DescribeInstanceTypesWithContext(gomock.Any(), gomock.Any(), gomock.Any()).Return(resp, nil)
 			},
 		},
 		{
@@ -134,7 +134,7 @@ func TestGetEcsInstanceTypeError(t *testing.T) {
 						},
 					},
 				}
-				client.EXPECT().DescribeInstanceTypes(gomock.Any()).Return(resp, nil)
+				client.EXPECT().DescribeInstanceTypesWithContext(gomock.Any(), gomock.Any(), gomock.Any()).Return(resp, nil)
 			},
 		},
 	}

--- a/pkg/cloud/metadata/metadata_test.go
+++ b/pkg/cloud/metadata/metadata_test.go
@@ -101,8 +101,8 @@ func TestSessionClearError(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	ecsClient := cloud.NewMockECSv2Interface(ctrl)
 	fakeErr := errors.New("whatever")
-	ecsClient.EXPECT().DescribeInstances(gomock.Any()).Return(nil, fakeErr)
-	ecsClient.EXPECT().DescribeInstances(gomock.Any()).Return(res, nil)
+	ecsClient.EXPECT().DescribeInstancesWithContext(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, fakeErr)
+	ecsClient.EXPECT().DescribeInstancesWithContext(gomock.Any(), gomock.Any(), gomock.Any()).Return(res, nil)
 
 	m := testMetadata(t, fakeMiddleware{InstanceID: "i-2zec1slzwdzrwmvlr4w2"})
 	m.EnableOpenAPI(ecsClient)

--- a/pkg/cloud/metadata/openapi.go
+++ b/pkg/cloud/metadata/openapi.go
@@ -1,12 +1,14 @@
 package metadata
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
 	"strings"
 
 	ecs20140526 "github.com/alibabacloud-go/ecs-20140526/v7/client"
+	"github.com/alibabacloud-go/tea/dara"
 	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/cloud"
 )
 
@@ -14,7 +16,7 @@ type OpenAPIMetadata struct {
 	instance *ecs20140526.DescribeInstancesResponseBodyInstancesInstance
 }
 
-func NewOpenAPIMetadata(c cloud.ECSv2Interface, instanceId string) (*OpenAPIMetadata, error) {
+func NewOpenAPIMetadata(ctx context.Context, c cloud.ECSv2Interface, instanceId string) (*OpenAPIMetadata, error) {
 	ids, err := json.Marshal([]string{instanceId})
 	if err != nil {
 		panic(err)
@@ -23,7 +25,7 @@ func NewOpenAPIMetadata(c cloud.ECSv2Interface, instanceId string) (*OpenAPIMeta
 		InstanceIds: new(string(ids)),
 	}
 
-	instanceResponse, err := c.DescribeInstances(&instanceRequest)
+	instanceResponse, err := c.DescribeInstancesWithContext(ctx, &instanceRequest, &dara.RuntimeOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("failed to describe instance %s: %w", instanceId, err)
 	}
@@ -89,7 +91,7 @@ func (f *OpenAPIFetcher) FetchFor(ctx *mcontext, key MetadataKey) (middleware, e
 	if err != nil {
 		return nil, fmt.Errorf("instance ID is not available: %w", err)
 	}
-	p, err := NewOpenAPIMetadata(f.ecsClient, instanceId.(string))
+	p, err := NewOpenAPIMetadata(ctx, f.ecsClient, instanceId.(string))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cloud/metadata/openapi_test.go
+++ b/pkg/cloud/metadata/openapi_test.go
@@ -53,14 +53,14 @@ func testEcsClient(t *testing.T) *cloud.MockECSv2Interface {
 
 	ctrl := gomock.NewController(t)
 	ecsClient := cloud.NewMockECSv2Interface(ctrl)
-	ecsClient.EXPECT().DescribeInstances(gomock.Any()).Return(res, nil)
+	ecsClient.EXPECT().DescribeInstancesWithContext(gomock.Any(), gomock.Any(), gomock.Any()).Return(res, nil)
 	return ecsClient
 }
 
 func TestGetOpenAPI(t *testing.T) {
 	ecsClient := testEcsClient(t)
 
-	m, err := NewOpenAPIMetadata(ecsClient, "i-2zec1slzwdzrwmvlr4w2")
+	m, err := NewOpenAPIMetadata(t.Context(), ecsClient, "i-2zec1slzwdzrwmvlr4w2")
 	assert.NoError(t, err)
 
 	assert.Equal(t, "cn-beijing-k", MustGet(m, ZoneID))
@@ -75,19 +75,19 @@ func TestGetOpenAPIError(t *testing.T) {
 		{
 			name: "describe_instances_error",
 			configClient: func(client *cloud.MockECSv2Interface) {
-				client.EXPECT().DescribeInstances(gomock.Any()).Return(nil, errors.New("failed to describe instances"))
+				client.EXPECT().DescribeInstancesWithContext(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, errors.New("failed to describe instances"))
 			},
 		},
 		{
 			name: "missing_field",
 			configClient: func(client *cloud.MockECSv2Interface) {
-				client.EXPECT().DescribeInstances(gomock.Any()).Return(&ecs20140526.DescribeInstancesResponse{}, nil)
+				client.EXPECT().DescribeInstancesWithContext(gomock.Any(), gomock.Any(), gomock.Any()).Return(&ecs20140526.DescribeInstancesResponse{}, nil)
 			},
 		},
 		{
 			name: "missing_instance",
 			configClient: func(client *cloud.MockECSv2Interface) {
-				client.EXPECT().DescribeInstances(gomock.Any()).Return(&ecs20140526.DescribeInstancesResponse{
+				client.EXPECT().DescribeInstancesWithContext(gomock.Any(), gomock.Any(), gomock.Any()).Return(&ecs20140526.DescribeInstancesResponse{
 					Body: &ecs20140526.DescribeInstancesResponseBody{
 						Instances: &ecs20140526.DescribeInstancesResponseBodyInstances{
 							Instance: []*ecs20140526.DescribeInstancesResponseBodyInstancesInstance{},

--- a/pkg/cloud/nas_interface.go
+++ b/pkg/cloud/nas_interface.go
@@ -1,14 +1,19 @@
 package cloud
 
-import nas "github.com/alibabacloud-go/nas-20170626/v4/client"
+import (
+	"context"
+
+	nas "github.com/alibabacloud-go/nas-20170626/v4/client"
+	"github.com/alibabacloud-go/tea/dara"
+)
 
 type NasInterface interface {
-	CancelDirQuota(request *nas.CancelDirQuotaRequest) (*nas.CancelDirQuotaResponse, error)
-	CreateAccessPoint(request *nas.CreateAccessPointRequest) (*nas.CreateAccessPointResponse, error)
-	CreateDir(request *nas.CreateDirRequest) (*nas.CreateDirResponse, error)
-	DeleteAccessPoint(request *nas.DeleteAccessPointRequest) (*nas.DeleteAccessPointResponse, error)
-	DescribeAccessPoint(request *nas.DescribeAccessPointRequest) (*nas.DescribeAccessPointResponse, error)
-	DescribeFileSystems(request *nas.DescribeFileSystemsRequest) (*nas.DescribeFileSystemsResponse, error)
-	GetRecycleBinAttribute(request *nas.GetRecycleBinAttributeRequest) (*nas.GetRecycleBinAttributeResponse, error)
-	SetDirQuota(request *nas.SetDirQuotaRequest) (*nas.SetDirQuotaResponse, error)
+	CancelDirQuotaWithContext(ctx context.Context, request *nas.CancelDirQuotaRequest, o *dara.RuntimeOptions) (*nas.CancelDirQuotaResponse, error)
+	CreateAccessPointWithContext(ctx context.Context, request *nas.CreateAccessPointRequest, o *dara.RuntimeOptions) (*nas.CreateAccessPointResponse, error)
+	CreateDirWithContext(ctx context.Context, request *nas.CreateDirRequest, o *dara.RuntimeOptions) (*nas.CreateDirResponse, error)
+	DeleteAccessPointWithContext(ctx context.Context, request *nas.DeleteAccessPointRequest, o *dara.RuntimeOptions) (*nas.DeleteAccessPointResponse, error)
+	DescribeAccessPointWithContext(ctx context.Context, request *nas.DescribeAccessPointRequest, o *dara.RuntimeOptions) (*nas.DescribeAccessPointResponse, error)
+	DescribeFileSystemsWithContext(ctx context.Context, request *nas.DescribeFileSystemsRequest, o *dara.RuntimeOptions) (*nas.DescribeFileSystemsResponse, error)
+	GetRecycleBinAttributeWithContext(ctx context.Context, request *nas.GetRecycleBinAttributeRequest, o *dara.RuntimeOptions) (*nas.GetRecycleBinAttributeResponse, error)
+	SetDirQuotaWithContext(ctx context.Context, request *nas.SetDirQuotaRequest, o *dara.RuntimeOptions) (*nas.SetDirQuotaResponse, error)
 }

--- a/pkg/cloud/nas_mock.go
+++ b/pkg/cloud/nas_mock.go
@@ -5,9 +5,11 @@
 package cloud
 
 import (
+	context "context"
 	reflect "reflect"
 
 	client "github.com/alibabacloud-go/nas-20170626/v4/client"
+	dara "github.com/alibabacloud-go/tea/dara"
 	gomock "github.com/golang/mock/gomock"
 )
 
@@ -34,122 +36,122 @@ func (m *MockNasInterface) EXPECT() *MockNasInterfaceMockRecorder {
 	return m.recorder
 }
 
-// CancelDirQuota mocks base method.
-func (m *MockNasInterface) CancelDirQuota(request *client.CancelDirQuotaRequest) (*client.CancelDirQuotaResponse, error) {
+// CancelDirQuotaWithContext mocks base method.
+func (m *MockNasInterface) CancelDirQuotaWithContext(ctx context.Context, request *client.CancelDirQuotaRequest, o *dara.RuntimeOptions) (*client.CancelDirQuotaResponse, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CancelDirQuota", request)
+	ret := m.ctrl.Call(m, "CancelDirQuotaWithContext", ctx, request, o)
 	ret0, _ := ret[0].(*client.CancelDirQuotaResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// CancelDirQuota indicates an expected call of CancelDirQuota.
-func (mr *MockNasInterfaceMockRecorder) CancelDirQuota(request interface{}) *gomock.Call {
+// CancelDirQuotaWithContext indicates an expected call of CancelDirQuotaWithContext.
+func (mr *MockNasInterfaceMockRecorder) CancelDirQuotaWithContext(ctx, request, o interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CancelDirQuota", reflect.TypeOf((*MockNasInterface)(nil).CancelDirQuota), request)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CancelDirQuotaWithContext", reflect.TypeOf((*MockNasInterface)(nil).CancelDirQuotaWithContext), ctx, request, o)
 }
 
-// CreateAccessPoint mocks base method.
-func (m *MockNasInterface) CreateAccessPoint(request *client.CreateAccessPointRequest) (*client.CreateAccessPointResponse, error) {
+// CreateAccessPointWithContext mocks base method.
+func (m *MockNasInterface) CreateAccessPointWithContext(ctx context.Context, request *client.CreateAccessPointRequest, o *dara.RuntimeOptions) (*client.CreateAccessPointResponse, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateAccessPoint", request)
+	ret := m.ctrl.Call(m, "CreateAccessPointWithContext", ctx, request, o)
 	ret0, _ := ret[0].(*client.CreateAccessPointResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// CreateAccessPoint indicates an expected call of CreateAccessPoint.
-func (mr *MockNasInterfaceMockRecorder) CreateAccessPoint(request interface{}) *gomock.Call {
+// CreateAccessPointWithContext indicates an expected call of CreateAccessPointWithContext.
+func (mr *MockNasInterfaceMockRecorder) CreateAccessPointWithContext(ctx, request, o interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateAccessPoint", reflect.TypeOf((*MockNasInterface)(nil).CreateAccessPoint), request)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateAccessPointWithContext", reflect.TypeOf((*MockNasInterface)(nil).CreateAccessPointWithContext), ctx, request, o)
 }
 
-// CreateDir mocks base method.
-func (m *MockNasInterface) CreateDir(request *client.CreateDirRequest) (*client.CreateDirResponse, error) {
+// CreateDirWithContext mocks base method.
+func (m *MockNasInterface) CreateDirWithContext(ctx context.Context, request *client.CreateDirRequest, o *dara.RuntimeOptions) (*client.CreateDirResponse, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateDir", request)
+	ret := m.ctrl.Call(m, "CreateDirWithContext", ctx, request, o)
 	ret0, _ := ret[0].(*client.CreateDirResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// CreateDir indicates an expected call of CreateDir.
-func (mr *MockNasInterfaceMockRecorder) CreateDir(request interface{}) *gomock.Call {
+// CreateDirWithContext indicates an expected call of CreateDirWithContext.
+func (mr *MockNasInterfaceMockRecorder) CreateDirWithContext(ctx, request, o interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateDir", reflect.TypeOf((*MockNasInterface)(nil).CreateDir), request)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateDirWithContext", reflect.TypeOf((*MockNasInterface)(nil).CreateDirWithContext), ctx, request, o)
 }
 
-// DeleteAccessPoint mocks base method.
-func (m *MockNasInterface) DeleteAccessPoint(request *client.DeleteAccessPointRequest) (*client.DeleteAccessPointResponse, error) {
+// DeleteAccessPointWithContext mocks base method.
+func (m *MockNasInterface) DeleteAccessPointWithContext(ctx context.Context, request *client.DeleteAccessPointRequest, o *dara.RuntimeOptions) (*client.DeleteAccessPointResponse, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteAccessPoint", request)
+	ret := m.ctrl.Call(m, "DeleteAccessPointWithContext", ctx, request, o)
 	ret0, _ := ret[0].(*client.DeleteAccessPointResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// DeleteAccessPoint indicates an expected call of DeleteAccessPoint.
-func (mr *MockNasInterfaceMockRecorder) DeleteAccessPoint(request interface{}) *gomock.Call {
+// DeleteAccessPointWithContext indicates an expected call of DeleteAccessPointWithContext.
+func (mr *MockNasInterfaceMockRecorder) DeleteAccessPointWithContext(ctx, request, o interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteAccessPoint", reflect.TypeOf((*MockNasInterface)(nil).DeleteAccessPoint), request)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteAccessPointWithContext", reflect.TypeOf((*MockNasInterface)(nil).DeleteAccessPointWithContext), ctx, request, o)
 }
 
-// DescribeAccessPoint mocks base method.
-func (m *MockNasInterface) DescribeAccessPoint(request *client.DescribeAccessPointRequest) (*client.DescribeAccessPointResponse, error) {
+// DescribeAccessPointWithContext mocks base method.
+func (m *MockNasInterface) DescribeAccessPointWithContext(ctx context.Context, request *client.DescribeAccessPointRequest, o *dara.RuntimeOptions) (*client.DescribeAccessPointResponse, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DescribeAccessPoint", request)
+	ret := m.ctrl.Call(m, "DescribeAccessPointWithContext", ctx, request, o)
 	ret0, _ := ret[0].(*client.DescribeAccessPointResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// DescribeAccessPoint indicates an expected call of DescribeAccessPoint.
-func (mr *MockNasInterfaceMockRecorder) DescribeAccessPoint(request interface{}) *gomock.Call {
+// DescribeAccessPointWithContext indicates an expected call of DescribeAccessPointWithContext.
+func (mr *MockNasInterfaceMockRecorder) DescribeAccessPointWithContext(ctx, request, o interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeAccessPoint", reflect.TypeOf((*MockNasInterface)(nil).DescribeAccessPoint), request)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeAccessPointWithContext", reflect.TypeOf((*MockNasInterface)(nil).DescribeAccessPointWithContext), ctx, request, o)
 }
 
-// DescribeFileSystems mocks base method.
-func (m *MockNasInterface) DescribeFileSystems(request *client.DescribeFileSystemsRequest) (*client.DescribeFileSystemsResponse, error) {
+// DescribeFileSystemsWithContext mocks base method.
+func (m *MockNasInterface) DescribeFileSystemsWithContext(ctx context.Context, request *client.DescribeFileSystemsRequest, o *dara.RuntimeOptions) (*client.DescribeFileSystemsResponse, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DescribeFileSystems", request)
+	ret := m.ctrl.Call(m, "DescribeFileSystemsWithContext", ctx, request, o)
 	ret0, _ := ret[0].(*client.DescribeFileSystemsResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// DescribeFileSystems indicates an expected call of DescribeFileSystems.
-func (mr *MockNasInterfaceMockRecorder) DescribeFileSystems(request interface{}) *gomock.Call {
+// DescribeFileSystemsWithContext indicates an expected call of DescribeFileSystemsWithContext.
+func (mr *MockNasInterfaceMockRecorder) DescribeFileSystemsWithContext(ctx, request, o interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeFileSystems", reflect.TypeOf((*MockNasInterface)(nil).DescribeFileSystems), request)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeFileSystemsWithContext", reflect.TypeOf((*MockNasInterface)(nil).DescribeFileSystemsWithContext), ctx, request, o)
 }
 
-// GetRecycleBinAttribute mocks base method.
-func (m *MockNasInterface) GetRecycleBinAttribute(request *client.GetRecycleBinAttributeRequest) (*client.GetRecycleBinAttributeResponse, error) {
+// GetRecycleBinAttributeWithContext mocks base method.
+func (m *MockNasInterface) GetRecycleBinAttributeWithContext(ctx context.Context, request *client.GetRecycleBinAttributeRequest, o *dara.RuntimeOptions) (*client.GetRecycleBinAttributeResponse, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetRecycleBinAttribute", request)
+	ret := m.ctrl.Call(m, "GetRecycleBinAttributeWithContext", ctx, request, o)
 	ret0, _ := ret[0].(*client.GetRecycleBinAttributeResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetRecycleBinAttribute indicates an expected call of GetRecycleBinAttribute.
-func (mr *MockNasInterfaceMockRecorder) GetRecycleBinAttribute(request interface{}) *gomock.Call {
+// GetRecycleBinAttributeWithContext indicates an expected call of GetRecycleBinAttributeWithContext.
+func (mr *MockNasInterfaceMockRecorder) GetRecycleBinAttributeWithContext(ctx, request, o interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRecycleBinAttribute", reflect.TypeOf((*MockNasInterface)(nil).GetRecycleBinAttribute), request)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRecycleBinAttributeWithContext", reflect.TypeOf((*MockNasInterface)(nil).GetRecycleBinAttributeWithContext), ctx, request, o)
 }
 
-// SetDirQuota mocks base method.
-func (m *MockNasInterface) SetDirQuota(request *client.SetDirQuotaRequest) (*client.SetDirQuotaResponse, error) {
+// SetDirQuotaWithContext mocks base method.
+func (m *MockNasInterface) SetDirQuotaWithContext(ctx context.Context, request *client.SetDirQuotaRequest, o *dara.RuntimeOptions) (*client.SetDirQuotaResponse, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetDirQuota", request)
+	ret := m.ctrl.Call(m, "SetDirQuotaWithContext", ctx, request, o)
 	ret0, _ := ret[0].(*client.SetDirQuotaResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// SetDirQuota indicates an expected call of SetDirQuota.
-func (mr *MockNasInterfaceMockRecorder) SetDirQuota(request interface{}) *gomock.Call {
+// SetDirQuotaWithContext indicates an expected call of SetDirQuotaWithContext.
+func (mr *MockNasInterfaceMockRecorder) SetDirQuotaWithContext(ctx, request, o interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetDirQuota", reflect.TypeOf((*MockNasInterface)(nil).SetDirQuota), request)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetDirQuotaWithContext", reflect.TypeOf((*MockNasInterface)(nil).SetDirQuotaWithContext), ctx, request, o)
 }

--- a/pkg/cloud/wrap/ecsv2.go
+++ b/pkg/cloud/wrap/ecsv2.go
@@ -1,0 +1,63 @@
+package wrap
+
+import (
+	"context"
+
+	ecs "github.com/alibabacloud-go/ecs-20140526/v7/client"
+	"github.com/alibabacloud-go/tea/dara"
+	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/cloud"
+)
+
+// loggingECSv2 decorates a cloud.ECSv2Interface so that every call is logged and
+// its error transformed (see logV2). Because it implements the interface, the
+// compiler forces a wrapper for each method.
+type loggingECSv2 struct {
+	inner cloud.ECSv2Interface
+}
+
+var _ cloud.ECSv2Interface = (*loggingECSv2)(nil)
+
+// ECS wraps an ECS v2 client with call-boundary logging, metrics and error
+// transformation. Wrap once at construction and pass the result wherever a
+// cloud.ECSv2Interface is expected.
+func ECS(inner cloud.ECSv2Interface) cloud.ECSv2Interface {
+	return &loggingECSv2{
+		inner: inner,
+	}
+}
+
+func (c *loggingECSv2) DescribeInstancesWithContext(ctx context.Context, req *ecs.DescribeInstancesRequest, o *dara.RuntimeOptions) (*ecs.DescribeInstancesResponse, error) {
+	return logV2(ctx, "ecs", "DescribeInstances", req, o, c.inner.DescribeInstancesWithContext)
+}
+
+func (c *loggingECSv2) DescribeInstanceTypesWithContext(ctx context.Context, req *ecs.DescribeInstanceTypesRequest, o *dara.RuntimeOptions) (*ecs.DescribeInstanceTypesResponse, error) {
+	return logV2(ctx, "ecs", "DescribeInstanceTypes", req, o, c.inner.DescribeInstanceTypesWithContext)
+}
+
+func (c *loggingECSv2) DescribeAvailableResourceWithContext(ctx context.Context, req *ecs.DescribeAvailableResourceRequest, o *dara.RuntimeOptions) (*ecs.DescribeAvailableResourceResponse, error) {
+	return logV2(ctx, "ecs", "DescribeAvailableResource", req, o, c.inner.DescribeAvailableResourceWithContext)
+}
+
+func (c *loggingECSv2) DescribeDisksWithContext(ctx context.Context, req *ecs.DescribeDisksRequest, o *dara.RuntimeOptions) (*ecs.DescribeDisksResponse, error) {
+	return logV2(ctx, "ecs", "DescribeDisks", req, o, c.inner.DescribeDisksWithContext)
+}
+
+func (c *loggingECSv2) TagResourcesWithContext(ctx context.Context, req *ecs.TagResourcesRequest, o *dara.RuntimeOptions) (*ecs.TagResourcesResponse, error) {
+	return logV2(ctx, "ecs", "TagResources", req, o, c.inner.TagResourcesWithContext)
+}
+
+func (c *loggingECSv2) UntagResourcesWithContext(ctx context.Context, req *ecs.UntagResourcesRequest, o *dara.RuntimeOptions) (*ecs.UntagResourcesResponse, error) {
+	return logV2(ctx, "ecs", "UntagResources", req, o, c.inner.UntagResourcesWithContext)
+}
+
+func (c *loggingECSv2) ModifyDiskSpecWithContext(ctx context.Context, req *ecs.ModifyDiskSpecRequest, o *dara.RuntimeOptions) (*ecs.ModifyDiskSpecResponse, error) {
+	return logV2(ctx, "ecs", "ModifyDiskSpec", req, o, c.inner.ModifyDiskSpecWithContext)
+}
+
+func (c *loggingECSv2) ModifyDiskAttributeWithContext(ctx context.Context, req *ecs.ModifyDiskAttributeRequest, o *dara.RuntimeOptions) (*ecs.ModifyDiskAttributeResponse, error) {
+	return logV2(ctx, "ecs", "ModifyDiskAttribute", req, o, c.inner.ModifyDiskAttributeWithContext)
+}
+
+func (c *loggingECSv2) DescribeTasksWithContext(ctx context.Context, req *ecs.DescribeTasksRequest, o *dara.RuntimeOptions) (*ecs.DescribeTasksResponse, error) {
+	return logV2(ctx, "ecs", "DescribeTasks", req, o, c.inner.DescribeTasksWithContext)
+}

--- a/pkg/cloud/wrap/error.go
+++ b/pkg/cloud/wrap/error.go
@@ -4,18 +4,16 @@ import (
 	"fmt"
 )
 
-type ErrorCode string
-
-func (e ErrorCode) Error() string {
-	return "Alibaba Cloud error: " + string(e)
-}
-
 type aliError interface {
 	error
 	Message() string
 	ErrorCode() string
 }
 
+// briefAliError gives an SDK error a brief, stable message (no requestID) so
+// that a repeating error renders identically, for efficient k8s event
+// aggregation. It keeps the underlying error in the chain, so errors.As still
+// reaches the SDK error (and thus cloud.ErrorCodeV2 works through it).
 type briefAliError struct {
 	err aliError
 }
@@ -24,6 +22,6 @@ func (e briefAliError) Error() string {
 	return fmt.Sprintf("OpenAPI returned error: %s (%s)", e.err.Message(), e.err.ErrorCode())
 }
 
-func (e briefAliError) Unwrap() []error {
-	return []error{e.err, ErrorCode(e.err.ErrorCode())}
+func (e briefAliError) Unwrap() error {
+	return e.err
 }

--- a/pkg/cloud/wrap/metric.go
+++ b/pkg/cloud/wrap/metric.go
@@ -1,0 +1,17 @@
+package wrap
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var (
+	APIRequestsTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "alibaba_cloud", Subsystem: "api", Name: "requests_total",
+		Help: "Number of Alibaba Cloud API calls",
+	}, []string{"product", "action", "code"})
+
+	APIDurationSecondsTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "alibaba_cloud", Subsystem: "api", Name: "duration_seconds_total",
+		Help: "Elapsed time for Alibaba Cloud API calls",
+	}, []string{"product", "action", "code"})
+)

--- a/pkg/cloud/wrap/nasv2.go
+++ b/pkg/cloud/wrap/nasv2.go
@@ -1,0 +1,57 @@
+package wrap
+
+import (
+	"context"
+
+	nas "github.com/alibabacloud-go/nas-20170626/v4/client"
+	"github.com/alibabacloud-go/tea/dara"
+	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/cloud"
+)
+
+// loggingNAS decorates a cloud.NasInterface so that every call is logged,
+// metered and its error transformed (see logV2). Because it implements the
+// interface, the compiler forces a wrapper for each method.
+type loggingNAS struct {
+	inner cloud.NasInterface
+}
+
+var _ cloud.NasInterface = (*loggingNAS)(nil)
+
+// NAS wraps a NAS v2 client with call-boundary logging, metrics and error
+// transformation. Wrap once at construction and pass the result wherever a
+// cloud.NasInterface is expected.
+func NAS(inner cloud.NasInterface) cloud.NasInterface {
+	return &loggingNAS{inner: inner}
+}
+
+func (c *loggingNAS) CancelDirQuotaWithContext(ctx context.Context, req *nas.CancelDirQuotaRequest, o *dara.RuntimeOptions) (*nas.CancelDirQuotaResponse, error) {
+	return logV2(ctx, "nas", "CancelDirQuota", req, o, c.inner.CancelDirQuotaWithContext)
+}
+
+func (c *loggingNAS) CreateAccessPointWithContext(ctx context.Context, req *nas.CreateAccessPointRequest, o *dara.RuntimeOptions) (*nas.CreateAccessPointResponse, error) {
+	return logV2(ctx, "nas", "CreateAccessPoint", req, o, c.inner.CreateAccessPointWithContext)
+}
+
+func (c *loggingNAS) CreateDirWithContext(ctx context.Context, req *nas.CreateDirRequest, o *dara.RuntimeOptions) (*nas.CreateDirResponse, error) {
+	return logV2(ctx, "nas", "CreateDir", req, o, c.inner.CreateDirWithContext)
+}
+
+func (c *loggingNAS) DeleteAccessPointWithContext(ctx context.Context, req *nas.DeleteAccessPointRequest, o *dara.RuntimeOptions) (*nas.DeleteAccessPointResponse, error) {
+	return logV2(ctx, "nas", "DeleteAccessPoint", req, o, c.inner.DeleteAccessPointWithContext)
+}
+
+func (c *loggingNAS) DescribeAccessPointWithContext(ctx context.Context, req *nas.DescribeAccessPointRequest, o *dara.RuntimeOptions) (*nas.DescribeAccessPointResponse, error) {
+	return logV2(ctx, "nas", "DescribeAccessPoint", req, o, c.inner.DescribeAccessPointWithContext)
+}
+
+func (c *loggingNAS) DescribeFileSystemsWithContext(ctx context.Context, req *nas.DescribeFileSystemsRequest, o *dara.RuntimeOptions) (*nas.DescribeFileSystemsResponse, error) {
+	return logV2(ctx, "nas", "DescribeFileSystems", req, o, c.inner.DescribeFileSystemsWithContext)
+}
+
+func (c *loggingNAS) GetRecycleBinAttributeWithContext(ctx context.Context, req *nas.GetRecycleBinAttributeRequest, o *dara.RuntimeOptions) (*nas.GetRecycleBinAttributeResponse, error) {
+	return logV2(ctx, "nas", "GetRecycleBinAttribute", req, o, c.inner.GetRecycleBinAttributeWithContext)
+}
+
+func (c *loggingNAS) SetDirQuotaWithContext(ctx context.Context, req *nas.SetDirQuotaRequest, o *dara.RuntimeOptions) (*nas.SetDirQuotaResponse, error) {
+	return logV2(ctx, "nas", "SetDirQuota", req, o, c.inner.SetDirQuotaWithContext)
+}

--- a/pkg/cloud/wrap/sdkv1_test.go
+++ b/pkg/cloud/wrap/sdkv1_test.go
@@ -45,15 +45,14 @@ func TestV1_Error(t *testing.T) {
 	req := ecs.CreateDescribeDisksRequest()
 	resp, err := V1(logger, ecsClient.DescribeDisks)(req)
 
+	// errors.As still reaches the SDK error through the brief wrapper, so the code
+	// is readable via the SDK's own ErrorCode() method (as V1 call sites do).
 	var svrErr *alierrors.ServerError
 	assert.ErrorAs(t, err, &svrErr)
-	assert.ErrorIs(t, err, ErrorCode("TestErrorCode"))
-	var code ErrorCode
-	assert.ErrorAs(t, err, &code)
-	assert.Equal(t, ErrorCode("TestErrorCode"), code)
+	assert.Equal(t, "TestErrorCode", svrErr.ErrorCode())
 	assert.Equal(t, "test-request-id-in-error", svrErr.RequestId())
+	// brief, stable message (no requestID) for k8s event aggregation
 	assert.ErrorContains(t, err, "OpenAPI returned error: Message in Unit Test. (TestErrorCode)")
-	assert.ErrorContains(t, code, "Alibaba Cloud error: TestErrorCode")
 	assert.Nil(t, resp)
 }
 

--- a/pkg/cloud/wrap/sdkv2.go
+++ b/pkg/cloud/wrap/sdkv2.go
@@ -1,13 +1,14 @@
 package wrap
 
 import (
+	"context"
 	"encoding/json"
-	"reflect"
-	"strings"
 	"time"
 
+	"github.com/alibabacloud-go/tea/dara"
 	"github.com/alibabacloud-go/tea/tea"
-	"github.com/go-logr/logr"
+	"github.com/prometheus/client_golang/prometheus"
+	"k8s.io/klog/v2"
 	"k8s.io/utils/ptr"
 )
 
@@ -34,22 +35,21 @@ func (e *teaError) Unwrap() error {
 	return e.SDKError
 }
 
+// transformV2ErrorForLog wraps a direct tea SDK error in a briefAliError (stable
+// message for k8s event aggregation) and returns its code and request ID for logging.
 func transformV2ErrorForLog(errIn error) (code, requestID string, err error) {
 	err = errIn
 	// Intentionally not using errors.As, we should only deal with direct SDK errors.
 	// Don't throw away other wrappers.
 	if teaerr, ok := err.(*tea.SDKError); ok {
 		e2 := &teaError{SDKError: teaerr}
-		if teaerr.Code != nil {
-			code = *teaerr.Code
-		}
-		if teaerr.Data != nil && (*teaerr.Data)[0] == '{' { // likely a json object
+		code = ptr.Deref(teaerr.Code, "")
+		if teaerr.Data != nil && len(*teaerr.Data) > 0 && (*teaerr.Data)[0] == '{' { // likely a json object
 			var data struct {
 				Message   string
 				RequestId string
 			}
-			errJson := json.Unmarshal([]byte(*teaerr.Data), &data)
-			if errJson == nil {
+			if json.Unmarshal([]byte(*teaerr.Data), &data) == nil {
 				requestID = data.RequestId
 				e2.message = data.Message
 			}
@@ -59,41 +59,29 @@ func transformV2ErrorForLog(errIn error) (code, requestID string, err error) {
 	return
 }
 
+// v2Resp is satisfied by every OpenAPI v2 response type; GetHeaders carries the request ID.
 type v2Resp interface {
 	comparable
 	GetHeaders() map[string]*string
 }
 
-func V2[TReq any, TResp v2Resp](logger logr.Logger, f func(TReq) (TResp, error)) func(TReq) (TResp, error) {
-	t := reflect.TypeFor[TReq]()
-	if t.Kind() == reflect.Pointer {
-		t = t.Elem()
+// logV2 runs one OpenAPI v2 call, logging it at the boundary (logger comes from ctx),
+// recording metrics, and transforming the error for stable message.
+func logV2[TReq any, TResp v2Resp](ctx context.Context, product, action string, req TReq, o *dara.RuntimeOptions, f func(context.Context, TReq, *dara.RuntimeOptions) (TResp, error)) (TResp, error) {
+	logger := klog.FromContext(ctx).WithCallDepth(2).WithValues("action", action)
+	if logger.V(5).Enabled() {
+		logger.V(3).Info("OpenAPI start", "request", req)
+	} else {
+		logger.V(3).Info("OpenAPI start")
 	}
-	action := strings.TrimSuffix(t.Name(), "Request")
-	logger = logger.WithValues("api", action)
-
-	return func(req TReq) (TResp, error) {
-		helper, logger := logger.WithCallStackHelper()
-		helper()
-		logger.V(5).Info("OpenAPI trace", "request", req)
-
-		return v2Impl(logger, func() (TResp, error) { return f(req) })
-	}
-}
-
-func v2Impl[TResp v2Resp](logger logr.Logger, f func() (TResp, error)) (TResp, error) {
-	helper, logger := logger.WithCallStackHelper()
-	helper()
-
-	logger.V(3).Info("OpenAPI start")
 
 	t := time.Now()
-	resp, err := f()
-	logger.V(5).Info("OpenAPI trace", "response", resp, "error", err)
+	resp, err := f(ctx, req, o)
 
 	level := 2
-	duration := time.Since(t)
-	attrs := []any{"elapsed", duration}
+	attrs := make([]any, 0, 8)
+	elapsed := time.Since(t)
+	attrs = append(attrs, "elapsed", elapsed)
 
 	var respZero TResp
 	var reqID string
@@ -101,24 +89,35 @@ func v2Impl[TResp v2Resp](logger logr.Logger, f func() (TResp, error)) (TResp, e
 		header := resp.GetHeaders()
 		reqID = ptr.Deref(header["x-acs-request-id"], "")
 	}
+	var code = "OK"
 	if err != nil {
 		level = 1
-		code, r, e := transformV2ErrorForLog(err)
+		var r string
+		code, r, err = transformV2ErrorForLog(err)
 		if code != "" {
 			attrs = append(attrs, "errorCode", code)
 		} else {
-			// No error code, just log entire error
 			attrs = append(attrs, "error", err)
+			code = "Unknown"
 		}
 		if r != "" {
 			reqID = r
 		}
-		err = e
 	}
 	if reqID != "" {
 		attrs = append(attrs, "requestID", reqID)
 	}
+	if logger.V(5).Enabled() {
+		attrs = append(attrs, "response", resp)
+	}
 	logger.V(level).Info("OpenAPI finish", attrs...)
-	return resp, err
 
+	labels := prometheus.Labels{
+		"product": product,
+		"action":  action,
+		"code":    code,
+	}
+	APIRequestsTotal.With(labels).Inc()
+	APIDurationSecondsTotal.With(labels).Add(elapsed.Seconds())
+	return resp, err
 }

--- a/pkg/cloud/wrap/sdkv2_test.go
+++ b/pkg/cloud/wrap/sdkv2_test.go
@@ -6,17 +6,16 @@ import (
 
 	openapiutil "github.com/alibabacloud-go/darabonba-openapi/v2/utils"
 	nas20170626 "github.com/alibabacloud-go/nas-20170626/v4/client"
+	"github.com/alibabacloud-go/tea/dara"
 	"github.com/alibabacloud-go/tea/tea"
 	"github.com/golang/mock/gomock"
 	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/cloud"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"k8s.io/klog/v2/ktesting"
 )
 
 func TestV2_OK(t *testing.T) {
-	logger := ktesting.NewLogger(t, ktesting.DefaultConfig)
-
 	ctrl := gomock.NewController(t)
 	nasClient := cloud.NewMockNasInterface(ctrl)
 
@@ -29,16 +28,21 @@ func TestV2_OK(t *testing.T) {
 			RequestId: new("test-request-id"),
 		},
 	}
-	nasClient.EXPECT().CreateDir(gomock.Any()).Return(resp, nil)
+	nasClient.EXPECT().CreateDirWithContext(gomock.Any(), gomock.Any(), gomock.Any()).Return(resp, nil)
 
-	resp, err := V2(logger, nasClient.CreateDir)(req)
+	reqs := testutil.ToFloat64(APIRequestsTotal.WithLabelValues("nas", "CreateDir", "OK"))
+	dur := testutil.ToFloat64(APIDurationSecondsTotal.WithLabelValues("nas", "CreateDir", "OK"))
+
+	resp, err := NAS(nasClient).CreateDirWithContext(t.Context(), req, &dara.RuntimeOptions{})
 	assert.NoError(t, err)
 	assert.Equal(t, "test-request-id", *resp.Body.RequestId)
+
+	// the successful call is counted (code=OK) with its elapsed time recorded
+	assert.Equal(t, reqs+1, testutil.ToFloat64(APIRequestsTotal.WithLabelValues("nas", "CreateDir", "OK")))
+	assert.Greater(t, testutil.ToFloat64(APIDurationSecondsTotal.WithLabelValues("nas", "CreateDir", "OK")), dur)
 }
 
 func TestV2_Error(t *testing.T) {
-	logger := ktesting.NewLogger(t, ktesting.DefaultConfig)
-
 	ctrl := gomock.NewController(t)
 	nasClient := cloud.NewMockNasInterface(ctrl)
 
@@ -47,48 +51,50 @@ func TestV2_Error(t *testing.T) {
 		Message: new("we don't use this"),
 		Data:    new(`{"Message":"Message in Unit Test.","RequestId":"test-request-id"}`),
 	}
-	nasClient.EXPECT().CreateDir(gomock.Any()).Return(&nas20170626.CreateDirResponse{}, expectedErr)
+	nasClient.EXPECT().CreateDirWithContext(gomock.Any(), gomock.Any(), gomock.Any()).Return(&nas20170626.CreateDirResponse{}, expectedErr)
+
+	reqs := testutil.ToFloat64(APIRequestsTotal.WithLabelValues("nas", "CreateDir", "TestErrorCode"))
 
 	req := &nas20170626.CreateDirRequest{}
-	resp, err := V2(logger, nasClient.CreateDir)(req)
+	resp, err := NAS(nasClient).CreateDirWithContext(t.Context(), req, &dara.RuntimeOptions{})
 
+	// errors.As still reaches the SDK error through the brief wrapper, so the code
+	// is readable without depending on the transform having run.
 	var teaErr *tea.SDKError
 	assert.ErrorAs(t, err, &teaErr)
-	assert.ErrorIs(t, err, ErrorCode("TestErrorCode"))
-	var code ErrorCode
-	assert.ErrorAs(t, err, &code)
-	assert.Equal(t, ErrorCode("TestErrorCode"), code)
+	assert.Equal(t, "TestErrorCode", cloud.ErrorCodeV2(err))
+	// brief, stable message (no requestID) for k8s event aggregation
 	assert.ErrorContains(t, err, "OpenAPI returned error: Message in Unit Test. (TestErrorCode)")
-	assert.ErrorContains(t, code, "Alibaba Cloud error: TestErrorCode")
 	assert.Nil(t, resp.Body)
+
+	// the failed call is counted under its Alibaba error code
+	assert.Equal(t, reqs+1, testutil.ToFloat64(APIRequestsTotal.WithLabelValues("nas", "CreateDir", "TestErrorCode")))
 }
 
 func TestV2_ErrorUnknown(t *testing.T) {
-	logger := ktesting.NewLogger(t, ktesting.DefaultConfig)
-
 	ctrl := gomock.NewController(t)
 	nasClient := cloud.NewMockNasInterface(ctrl)
 
 	expectedErr := errors.New("unknown error")
-	nasClient.EXPECT().CreateDir(gomock.Any()).Return(nil, expectedErr)
+	nasClient.EXPECT().CreateDirWithContext(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, expectedErr)
 
 	req := &nas20170626.CreateDirRequest{}
-	resp, err := V2(logger, nasClient.CreateDir)(req)
+	resp, err := NAS(nasClient).CreateDirWithContext(t.Context(), req, &dara.RuntimeOptions{})
 
 	assert.ErrorIs(t, err, expectedErr)
+	assert.Equal(t, "", cloud.ErrorCodeV2(err))
 	assert.Nil(t, resp)
 }
 
 func TestV2_Manual(t *testing.T) {
 	// Comment this out when testing manually, and add your findings to other cases.
 	t.Skip("Only for manual test")
-	logger := ktesting.NewLogger(t, ktesting.DefaultConfig)
 	client, err := nas20170626.NewClient(&openapiutil.Config{
 		RegionId:        new("cn-hangzhou"),
 		AccessKeyId:     new("not an access key"),
 		AccessKeySecret: new("not an access key"),
 	})
 	require.NoError(t, err)
-	_, err = V2(logger, client.CreateDir)(&nas20170626.CreateDirRequest{})
+	_, err = NAS(client).CreateDirWithContext(t.Context(), &nas20170626.CreateDirRequest{}, &dara.RuntimeOptions{})
 	require.ErrorContains(t, err, "OpenAPI returned error: Specified access key is not found or invalid. (InvalidAccessKeyId)")
 }

--- a/pkg/disk/desc/task.go
+++ b/pkg/disk/desc/task.go
@@ -1,9 +1,11 @@
 package desc
 
 import (
+	"context"
 	"strings"
 
 	ecs20140526 "github.com/alibabacloud-go/ecs-20140526/v7/client"
+	"github.com/alibabacloud-go/tea/dara"
 	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/cloud"
 	"k8s.io/utils/ptr"
 )
@@ -19,7 +21,9 @@ func (c Task) Describe(ids []string) (Response[*ecs20140526.DescribeTasksRespons
 	}
 
 	ret := Response[*ecs20140526.DescribeTasksResponseBodyTaskSetTask]{}
-	resp, err := c.Client.DescribeTasks(req)
+	// Task polling is shared across multiple waiters via the batched waiter, so it
+	// is not tied to any single request's context.
+	resp, err := c.Client.DescribeTasksWithContext(context.Background(), req, &dara.RuntimeOptions{})
 	if err != nil {
 		return ret, err
 	}

--- a/pkg/disk/modify.go
+++ b/pkg/disk/modify.go
@@ -8,9 +8,9 @@ import (
 	"time"
 
 	ecs20140526 "github.com/alibabacloud-go/ecs-20140526/v7/client"
+	"github.com/alibabacloud-go/tea/dara"
 	"github.com/go-logr/logr"
 	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/cloud"
-	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/cloud/wrap"
 	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/disk/desc"
 	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/disk/waitstatus"
 	"google.golang.org/grpc/codes"
@@ -20,7 +20,7 @@ import (
 )
 
 const (
-	NoChangeInDiskCategoryAndPerformanceLevel wrap.ErrorCode = "NoChangeInDiskCategoryAndPerformanceLevel"
+	NoChangeInDiskCategoryAndPerformanceLevel = "NoChangeInDiskCategoryAndPerformanceLevel"
 )
 
 type ModifyParameters struct {
@@ -86,14 +86,14 @@ func (m *ModifyServer) waitForTask(ctx context.Context, logger logr.Logger, task
 	return task, nil
 }
 
-func (m *ModifyServer) retrieveTask(logger logr.Logger, diskID string) (*ecs20140526.DescribeTasksResponseBodyTaskSetTask, error) {
+func (m *ModifyServer) retrieveTask(ctx context.Context, diskID string) (*ecs20140526.DescribeTasksResponseBodyTaskSetTask, error) {
 	req := &ecs20140526.DescribeTasksRequest{
 		PageSize:    new(int32(1)),
 		ResourceIds: []*string{&diskID},
 		TaskAction:  new("ModifyDiskSpec"),
 	}
 
-	resp, err := wrap.V2(logger, m.ecsClient.DescribeTasks)(req)
+	resp, err := m.ecsClient.DescribeTasksWithContext(ctx, req, &dara.RuntimeOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -104,7 +104,7 @@ func (m *ModifyServer) retrieveTask(logger logr.Logger, diskID string) (*ecs2014
 	return task, nil
 }
 
-func mapModifySpecCode(code wrap.ErrorCode) codes.Code {
+func mapModifySpecCode(code string) codes.Code {
 	switch code {
 	case "InvalidDiskId.NotFound":
 		return codes.NotFound
@@ -148,11 +148,11 @@ func (m *ModifyServer) verifyModifyDiskSpec(ctx context.Context, logger logr.Log
 			m.runningTaskIDs.Delete(diskID)
 		}
 
-		_, err = wrap.V2(logger, m.ecsClient.ModifyDiskSpec)(req)
+		_, err = m.ecsClient.ModifyDiskSpecWithContext(ctx, req, &dara.RuntimeOptions{})
 		if err == nil { // should not happen for dry run
 			return true, status.Errorf(codes.Internal, "dry run ModifyDiskSpec succeeds unexpectedly")
 		}
-		if code, ok := errors.AsType[wrap.ErrorCode](err); ok {
+		if code := cloud.ErrorCodeV2(err); code != "" {
 			switch code {
 			case NoChangeInDiskCategoryAndPerformanceLevel:
 				logger.V(2).Info("disk spec clean")
@@ -162,7 +162,7 @@ func (m *ModifyServer) verifyModifyDiskSpec(ctx context.Context, logger logr.Log
 			case "InvalidStatus.DiskNotReady", IncorrectDiskStatus:
 				// Already modifying? This can happen if CSI was restarted and runningTaskIDs lost
 				logger.V(2).Info("maybe disk is being modified, recovering previous task")
-				task, taskErr := m.retrieveTask(logger, diskID)
+				task, taskErr := m.retrieveTask(ctx, diskID)
 				if taskErr != nil {
 					return true, fmt.Errorf("retrieve task failed: %w", taskErr)
 				}
@@ -185,10 +185,10 @@ func (m *ModifyServer) verifyModifyDiskSpec(ctx context.Context, logger logr.Log
 
 func (m *ModifyServer) modifyDiskSpec(ctx context.Context, logger logr.Logger, req *ecs20140526.ModifyDiskSpecRequest) error {
 	diskID := ptr.Deref(req.DiskId, "")
-	resp, err := wrap.V2(logger, m.ecsClient.ModifyDiskSpec)(req)
+	resp, err := m.ecsClient.ModifyDiskSpecWithContext(ctx, req, &dara.RuntimeOptions{})
 	if err != nil {
 		var grpcCode = codes.Internal
-		if code, ok := errors.AsType[wrap.ErrorCode](err); ok {
+		if code := cloud.ErrorCodeV2(err); code != "" {
 			switch code {
 			case NoChangeInDiskCategoryAndPerformanceLevel:
 				logger.V(2).Info("disk spec not changed")
@@ -232,12 +232,12 @@ func (m *ModifyServer) modifyDiskAttribute(ctx context.Context, logger logr.Logg
 			BurstingEnabled: &burstingEnabled,
 		}
 
-		_, err = wrap.V2(logger, m.ecsClient.ModifyDiskAttribute)(req)
+		_, err = m.ecsClient.ModifyDiskAttributeWithContext(ctx, req, &dara.RuntimeOptions{})
 		if err == nil {
 			logger.V(2).Info("modified disk bursting enabled", "enabled", burstingEnabled)
 			return nil
 		}
-		if errors.Is(err, wrap.ErrorCode("BurstingEnabledForModifyingDiskUnsupported")) {
+		if cloud.ErrorCodeV2(err) == "BurstingEnabledForModifyingDiskUnsupported" {
 			// TODO: ECS will optimize this, and we may remove this retry in the future
 			logger.V(2).Info("disk still modifying, retrying")
 			select {
@@ -287,7 +287,7 @@ func (m *ModifyServer) Modify(ctx context.Context, diskID string, params ModifyP
 			TagKey:       params.RemoveTags,
 		}
 
-		_, err := wrap.V2(logger, m.ecsClient.UntagResources)(req)
+		_, err := m.ecsClient.UntagResourcesWithContext(ctx, req, &dara.RuntimeOptions{})
 		if err != nil {
 			return fmt.Errorf("error while untagging disk %s: %w", diskID, err)
 		}
@@ -301,7 +301,7 @@ func (m *ModifyServer) Modify(ctx context.Context, diskID string, params ModifyP
 			Tag:          params.Tags,
 		}
 
-		_, err := wrap.V2(logger, m.ecsClient.TagResources)(req)
+		_, err := m.ecsClient.TagResourcesWithContext(ctx, req, &dara.RuntimeOptions{})
 		if err != nil {
 			return fmt.Errorf("error while tagging disk %s: %w", diskID, err)
 		}

--- a/pkg/disk/modify_test.go
+++ b/pkg/disk/modify_test.go
@@ -60,28 +60,28 @@ func TestModify_HappyPath(t *testing.T) {
 	// 1. verifyModifyDiskSpec: dry-run returns DryRunOperation → dirty=true.
 	// Assert the exact request: the empty PerformanceLevel must be omitted,
 	// otherwise ECS rejects it with InvalidDiskCategory.NotSupported.
-	c.EXPECT().ModifyDiskSpec(&ecs20140526.ModifyDiskSpecRequest{
+	c.EXPECT().ModifyDiskSpecWithContext(gomock.Any(), &ecs20140526.ModifyDiskSpecRequest{
 		DiskId:          new("d-test"),
 		DiskCategory:    new("cloud_auto"),
 		ProvisionedIops: new(int64(1000)),
 		DryRun:          new(true),
-	}).Return(nil, sdkError("DryRunOperation"))
+	}, gomock.Any()).Return(nil, sdkError("DryRunOperation"))
 
 	// 2. UntagResources
-	c.EXPECT().UntagResources(gomock.Any()).Return(&ecs20140526.UntagResourcesResponse{}, nil)
+	c.EXPECT().UntagResourcesWithContext(gomock.Any(), gomock.Any(), gomock.Any()).Return(&ecs20140526.UntagResourcesResponse{}, nil)
 
 	// 3. TagResources
-	c.EXPECT().TagResources(gomock.Any()).Return(&ecs20140526.TagResourcesResponse{}, nil)
+	c.EXPECT().TagResourcesWithContext(gomock.Any(), gomock.Any(), gomock.Any()).Return(&ecs20140526.TagResourcesResponse{}, nil)
 
 	// 4. modifyDiskSpec: actual call returns a task ID
-	c.EXPECT().ModifyDiskSpec(gomock.Any()).Return(&ecs20140526.ModifyDiskSpecResponse{
+	c.EXPECT().ModifyDiskSpecWithContext(gomock.Any(), gomock.Any(), gomock.Any()).Return(&ecs20140526.ModifyDiskSpecResponse{
 		Body: &ecs20140526.ModifyDiskSpecResponseBody{
 			TaskId: new("t-123"),
 		},
 	}, nil)
 
 	// 5. modifyDiskAttribute
-	c.EXPECT().ModifyDiskAttribute(gomock.Any()).Return(&ecs20140526.ModifyDiskAttributeResponse{}, nil)
+	c.EXPECT().ModifyDiskAttributeWithContext(gomock.Any(), gomock.Any(), gomock.Any()).Return(&ecs20140526.ModifyDiskAttributeResponse{}, nil)
 
 	_, ctx := ktesting.NewTestContext(t)
 	err := m.Modify(ctx, "d-test", ModifyParameters{
@@ -106,16 +106,16 @@ func TestModify_NoChange(t *testing.T) {
 	c, m := newTestModifyServer(t)
 
 	// verifyModifyDiskSpec: dry-run returns NoChange → dirty=false, skip modifySpec
-	c.EXPECT().ModifyDiskSpec(gomock.Any()).Return(nil, sdkError(string(NoChangeInDiskCategoryAndPerformanceLevel)))
+	c.EXPECT().ModifyDiskSpecWithContext(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, sdkError(string(NoChangeInDiskCategoryAndPerformanceLevel)))
 
 	// UntagResources
-	c.EXPECT().UntagResources(gomock.Any()).Return(&ecs20140526.UntagResourcesResponse{}, nil)
+	c.EXPECT().UntagResourcesWithContext(gomock.Any(), gomock.Any(), gomock.Any()).Return(&ecs20140526.UntagResourcesResponse{}, nil)
 
 	// TagResources
-	c.EXPECT().TagResources(gomock.Any()).Return(&ecs20140526.TagResourcesResponse{}, nil)
+	c.EXPECT().TagResourcesWithContext(gomock.Any(), gomock.Any(), gomock.Any()).Return(&ecs20140526.TagResourcesResponse{}, nil)
 
 	// modifyDiskAttribute
-	c.EXPECT().ModifyDiskAttribute(gomock.Any()).Return(&ecs20140526.ModifyDiskAttributeResponse{}, nil)
+	c.EXPECT().ModifyDiskAttributeWithContext(gomock.Any(), gomock.Any(), gomock.Any()).Return(&ecs20140526.ModifyDiskAttributeResponse{}, nil)
 
 	_, ctx := ktesting.NewTestContext(t)
 	err := m.Modify(ctx, "d-test", ModifyParameters{
@@ -134,10 +134,10 @@ func TestModify_RecoverTask(t *testing.T) {
 	c, m := newTestModifyServer(t)
 
 	// Round 1: dry-run returns IncorrectDiskStatus → try to recover task
-	dryRun := c.EXPECT().ModifyDiskSpec(gomock.Any()).Return(nil, sdkError(IncorrectDiskStatus))
+	dryRun := c.EXPECT().ModifyDiskSpecWithContext(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, sdkError(IncorrectDiskStatus))
 
 	// retrieveTask finds a processing task
-	c.EXPECT().DescribeTasks(gomock.Any()).Return(&ecs20140526.DescribeTasksResponse{
+	c.EXPECT().DescribeTasksWithContext(gomock.Any(), gomock.Any(), gomock.Any()).Return(&ecs20140526.DescribeTasksResponse{
 		Body: &ecs20140526.DescribeTasksResponseBody{
 			TaskSet: &ecs20140526.DescribeTasksResponseBodyTaskSet{
 				Task: []*ecs20140526.DescribeTasksResponseBodyTaskSetTask{
@@ -151,10 +151,10 @@ func TestModify_RecoverTask(t *testing.T) {
 	// (the default finishedTaskWaiter handles this)
 
 	// Round 2: dry-run now passes
-	c.EXPECT().ModifyDiskSpec(gomock.Any()).Return(nil, sdkError("DryRunOperation"))
+	c.EXPECT().ModifyDiskSpecWithContext(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, sdkError("DryRunOperation"))
 
 	// Actual ModifyDiskSpec
-	c.EXPECT().ModifyDiskSpec(gomock.Any()).Return(&ecs20140526.ModifyDiskSpecResponse{
+	c.EXPECT().ModifyDiskSpecWithContext(gomock.Any(), gomock.Any(), gomock.Any()).Return(&ecs20140526.ModifyDiskSpecResponse{
 		Body: &ecs20140526.ModifyDiskSpecResponseBody{
 			TaskId: new("t-new"),
 		},
@@ -171,7 +171,7 @@ func TestModify_DiskInCoolingPeriod(t *testing.T) {
 	c, m := newTestModifyServer(t)
 
 	// verifyModifyDiskSpec: dry-run returns DiskInCoolingPeriod → FailedPrecondition
-	c.EXPECT().ModifyDiskSpec(gomock.Any()).Return(nil, sdkError("DiskInCoolingPeriod"))
+	c.EXPECT().ModifyDiskSpecWithContext(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, sdkError("DiskInCoolingPeriod"))
 
 	_, ctx := ktesting.NewTestContext(t)
 	err := m.Modify(ctx, "d-test", ModifyParameters{
@@ -207,9 +207,9 @@ func TestModify_ModifyDiskSpecErrors(t *testing.T) {
 			c, m := newTestModifyServer(t)
 
 			// dry-run passes
-			c.EXPECT().ModifyDiskSpec(gomock.Any()).Return(nil, sdkError("DryRunOperation"))
+			c.EXPECT().ModifyDiskSpecWithContext(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, sdkError("DryRunOperation"))
 			// actual call fails
-			c.EXPECT().ModifyDiskSpec(gomock.Any()).Return(nil, sdkError(tt.errorCode))
+			c.EXPECT().ModifyDiskSpecWithContext(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, sdkError(tt.errorCode))
 
 			_, ctx := ktesting.NewTestContext(t)
 			err := m.Modify(ctx, "d-test", ModifyParameters{
@@ -226,9 +226,9 @@ func TestModify_TaskTimeoutThenRetry(t *testing.T) {
 
 	// --- First call: task times out ---
 	// dry-run passes
-	c.EXPECT().ModifyDiskSpec(gomock.Any()).Return(nil, sdkError("DryRunOperation"))
+	c.EXPECT().ModifyDiskSpecWithContext(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, sdkError("DryRunOperation"))
 	// actual call returns task
-	c.EXPECT().ModifyDiskSpec(gomock.Any()).Return(&ecs20140526.ModifyDiskSpecResponse{
+	c.EXPECT().ModifyDiskSpecWithContext(gomock.Any(), gomock.Any(), gomock.Any()).Return(&ecs20140526.ModifyDiskSpecResponse{
 		Body: &ecs20140526.ModifyDiskSpecResponseBody{
 			TaskId: new("t-slow"),
 		},
@@ -260,9 +260,9 @@ func TestModify_TaskTimeoutThenRetry(t *testing.T) {
 	m.taskWaiter = finishedTaskWaiter()
 
 	// verifyModifyDiskSpec: waitForTask on "t-slow" succeeds (finished), then dry-run passes
-	c.EXPECT().ModifyDiskSpec(gomock.Any()).Return(nil, sdkError("DryRunOperation"))
+	c.EXPECT().ModifyDiskSpecWithContext(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, sdkError("DryRunOperation"))
 	// actual call returns a new task
-	c.EXPECT().ModifyDiskSpec(gomock.Any()).Return(&ecs20140526.ModifyDiskSpecResponse{
+	c.EXPECT().ModifyDiskSpecWithContext(gomock.Any(), gomock.Any(), gomock.Any()).Return(&ecs20140526.ModifyDiskSpecResponse{
 		Body: &ecs20140526.ModifyDiskSpecResponseBody{
 			TaskId: new("t-new"),
 		},
@@ -286,8 +286,8 @@ func TestModify_TagsOnly(t *testing.T) {
 	c, m := newTestModifyServer(t)
 
 	// Only UntagResources + TagResources, no ModifyDiskSpec or ModifyDiskAttribute
-	c.EXPECT().UntagResources(gomock.Any()).Return(&ecs20140526.UntagResourcesResponse{}, nil)
-	c.EXPECT().TagResources(gomock.Any()).Return(&ecs20140526.TagResourcesResponse{}, nil)
+	c.EXPECT().UntagResourcesWithContext(gomock.Any(), gomock.Any(), gomock.Any()).Return(&ecs20140526.UntagResourcesResponse{}, nil)
+	c.EXPECT().TagResourcesWithContext(gomock.Any(), gomock.Any(), gomock.Any()).Return(&ecs20140526.TagResourcesResponse{}, nil)
 
 	_, ctx := ktesting.NewTestContext(t)
 	err := m.Modify(ctx, "d-test", ModifyParameters{

--- a/pkg/disk/nodeserver.go
+++ b/pkg/disk/nodeserver.go
@@ -881,7 +881,7 @@ func (ns *nodeServer) NodeGetInfo(ctx context.Context, req *csi.NodeGetInfoReque
 				return nil, status.Errorf(codes.Internal, "cannot determine disk quantity: %v", err)
 			}
 		} else {
-			unmanaged, err := getUnmanagedDiskCount(getNode, ns.ecsV2, instanceID, regionID, utilsio.RealDevTmpFS{})
+			unmanaged, err := getUnmanagedDiskCount(ctx, getNode, ns.ecsV2, instanceID, regionID, utilsio.RealDevTmpFS{})
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/disk/utils.go
+++ b/pkg/disk/utils.go
@@ -37,6 +37,7 @@ import (
 	"time"
 
 	ecs20140526 "github.com/alibabacloud-go/ecs-20140526/v7/client"
+	"github.com/alibabacloud-go/tea/dara"
 	"github.com/aliyun/alibaba-cloud-sdk-go/sdk"
 	v1_credentials "github.com/aliyun/alibaba-cloud-sdk-go/sdk/auth/credentials"
 	aliyunep "github.com/aliyun/alibaba-cloud-sdk-go/sdk/endpoints"
@@ -841,7 +842,7 @@ func GetAvailableDiskTypes(ctx context.Context, c cloud.ECSv2Interface, instance
 		ResourceType:        new("disk"),
 		RegionId:            &regionID,
 	}
-	resp, err := c.DescribeAvailableResource(req)
+	resp, err := c.DescribeAvailableResourceWithContext(ctx, req, &dara.RuntimeOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("failed to DescribeAvailableResource(%s) for instance type %s: %w", zoneID, instanceType, err)
 	}
@@ -855,7 +856,7 @@ func GetAvailableDiskTypes(ctx context.Context, c cloud.ECSv2Interface, instance
 		Scope:               new("region"),
 		RegionId:            &regionID,
 	}
-	respRegional, err := c.DescribeAvailableResource(reqRegional)
+	respRegional, err := c.DescribeAvailableResourceWithContext(ctx, reqRegional, &dara.RuntimeOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("failed to DescribeAvailableResource(region) for instance type %s: %w", instanceType, err)
 	}
@@ -1066,7 +1067,7 @@ func updateVolumeContext(volumeContext map[string]string) map[string]string {
 
 // GetAttachedCloudDisks queries ECS (v2 API) for cloud disks attached to the
 // given instance, excluding detaching disks and local-only categories.
-func GetAttachedCloudDisks(ecsClient cloud.ECSv2Interface, instanceID, regionID string) ([]string, error) {
+func GetAttachedCloudDisks(ctx context.Context, ecsClient cloud.ECSv2Interface, instanceID, regionID string) ([]string, error) {
 	req := &ecs20140526.DescribeDisksRequest{
 		InstanceId: &instanceID,
 		RegionId:   &regionID,
@@ -1074,7 +1075,7 @@ func GetAttachedCloudDisks(ecsClient cloud.ECSv2Interface, instanceID, regionID 
 	}
 	var ids []string
 	for {
-		resp, err := ecsClient.DescribeDisks(req)
+		resp, err := ecsClient.DescribeDisksWithContext(ctx, req, &dara.RuntimeOptions{})
 		if err != nil {
 			return nil, fmt.Errorf("DescribeDisks: %w", err)
 		}
@@ -1134,7 +1135,7 @@ func getVolumeCountFromLabelerAnnotation(node *v1.Node) (int, error) {
 	return n, nil
 }
 
-func getUnmanagedDiskCount(getNode func() (*v1.Node, error), ecs cloud.ECSv2Interface, instanceID, regionID string, dev utilsio.DiskLister) (int, error) {
+func getUnmanagedDiskCount(ctx context.Context, getNode func() (*v1.Node, error), ecs cloud.ECSv2Interface, instanceID, regionID string, dev utilsio.DiskLister) (int, error) {
 	// An attached disk is not managed by us if:
 	// 1. it is not in node.Status.VolumesInUse or node.Status.VolumesAttached; and
 	// 2. it does not have the xattr set.
@@ -1155,7 +1156,7 @@ func getUnmanagedDiskCount(getNode func() (*v1.Node, error), ecs cloud.ECSv2Inte
 	// disappear from ListDisks after OpenAPI;
 	// ECS OpenAPI should goes before getNode because the just attached disk should
 	// appear in node before OpenAPI;
-	attachedDisks, err := GetAttachedCloudDisks(ecs, instanceID, regionID)
+	attachedDisks, err := GetAttachedCloudDisks(ctx, ecs, instanceID, regionID)
 	if err != nil {
 		return 0, err
 	}

--- a/pkg/disk/utils_test.go
+++ b/pkg/disk/utils_test.go
@@ -27,6 +27,7 @@ import (
 	"testing"
 
 	ecs20140526 "github.com/alibabacloud-go/ecs-20140526/v7/client"
+	"github.com/alibabacloud-go/tea/dara"
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	gomock "github.com/golang/mock/gomock"
 	fakesnapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v8/clientset/versioned/fake"
@@ -248,7 +249,7 @@ func TestGetUnmanagedDiskCount(t *testing.T) {
 
 	var describeDisksResp ecs20140526.DescribeDisksResponse
 	cloud.UnmarshalV2Response([]byte(DescribeDisksResponse), &describeDisksResp)
-	c.EXPECT().DescribeDisks(gomock.Any()).Return(&describeDisksResp, nil)
+	c.EXPECT().DescribeDisksWithContext(gomock.Any(), gomock.Any(), gomock.Any()).Return(&describeDisksResp, nil)
 
 	dev := MockDisks{base: t.TempDir() + "/dev"}
 	assert.NoError(t, os.MkdirAll(dev.base, 0755))
@@ -261,7 +262,7 @@ func TestGetUnmanagedDiskCount(t *testing.T) {
 	dev.AddDisk(t, "node-for-testinglocaldisk", []byte(longDiskID))
 
 	getNode := func() (*corev1.Node, error) { return testNode(), nil }
-	count, err := getUnmanagedDiskCount(getNode, c, "i-2ze0yyw7rf00yz9fttpg", "cn-beijing", &dev)
+	count, err := getUnmanagedDiskCount(t.Context(), getNode, c, "i-2ze0yyw7rf00yz9fttpg", "cn-beijing", &dev)
 	assert.NoError(t, err)
 	assert.Equal(t, 2, count) // 1 system disk (d-2ze49fivxwkwxl36o1d3) + 1 manually attached (d-2zeh74nnxxrobxz49eug)
 }
@@ -387,7 +388,7 @@ func TestGetAvailableDiskTypes(t *testing.T) {
 			_, ctx := ktesting.NewTestContext(t)
 			ctrl := gomock.NewController(t)
 			c := cloud.NewMockECSv2Interface(ctrl)
-			c.EXPECT().DescribeAvailableResource(gomock.Any()).DoAndReturn(func(req *ecs20140526.DescribeAvailableResourceRequest) (*ecs20140526.DescribeAvailableResourceResponse, error) {
+			c.EXPECT().DescribeAvailableResourceWithContext(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, req *ecs20140526.DescribeAvailableResourceRequest, _ *dara.RuntimeOptions) (*ecs20140526.DescribeAvailableResourceResponse, error) {
 				var descRes ecs20140526.DescribeAvailableResourceResponse
 				if ptr.Deref(req.ZoneId, "") != "" {
 					cloud.UnmarshalV2Response([]byte(tc.resp), &descRes)

--- a/pkg/labeler/labeler_test.go
+++ b/pkg/labeler/labeler_test.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	ecsv2 "github.com/alibabacloud-go/ecs-20140526/v7/client"
+	"github.com/alibabacloud-go/tea/dara"
 	"github.com/golang/mock/gomock"
 	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/cloud"
 	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/disk"
@@ -36,10 +37,10 @@ func testRunOnce_FullPipelineSync(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	ecsMock := cloud.NewMockECSv2Interface(ctrl)
 
-	ecsMock.EXPECT().DescribeInstanceTypes(gomock.Any()).
+	ecsMock.EXPECT().DescribeInstanceTypesWithContext(gomock.Any(), gomock.Any(), gomock.Any()).
 		Return(describeInstanceTypesV2Resp("ecs.g7.large", 8), nil).AnyTimes()
-	ecsMock.EXPECT().DescribeAvailableResource(gomock.Any()).DoAndReturn(
-		func(req *ecsv2.DescribeAvailableResourceRequest) (*ecsv2.DescribeAvailableResourceResponse, error) {
+	ecsMock.EXPECT().DescribeAvailableResourceWithContext(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, req *ecsv2.DescribeAvailableResourceRequest, _ *dara.RuntimeOptions) (*ecsv2.DescribeAvailableResourceResponse, error) {
 			scope := ""
 			if req.Scope != nil {
 				scope = *req.Scope
@@ -53,7 +54,7 @@ func testRunOnce_FullPipelineSync(t *testing.T) {
 			}
 			return makeAvailResp(zoneID, "cloud_essd"), nil
 		}).AnyTimes()
-	ecsMock.EXPECT().DescribeDisks(gomock.Any()).Return(&ecsv2.DescribeDisksResponse{
+	ecsMock.EXPECT().DescribeDisksWithContext(gomock.Any(), gomock.Any(), gomock.Any()).Return(&ecsv2.DescribeDisksResponse{
 		Body: &ecsv2.DescribeDisksResponseBody{
 			Disks: &ecsv2.DescribeDisksResponseBodyDisks{
 				Disk: []*ecsv2.DescribeDisksResponseBodyDisksDisk{

--- a/pkg/labeler/reconcile.go
+++ b/pkg/labeler/reconcile.go
@@ -141,7 +141,7 @@ func (r *Reconciler) reconcile(ctx context.Context, logger klog.Logger, nodeName
 		return err
 	}
 
-	attachedDisks, err := disk.GetAttachedCloudDisks(r.ECS, instanceID, r.RegionID)
+	attachedDisks, err := disk.GetAttachedCloudDisks(ctx, r.ECS, instanceID, r.RegionID)
 	if err != nil {
 		return fmt.Errorf("describe disks for %s: %w", instanceID, err)
 	}

--- a/pkg/labeler/reconcile_test.go
+++ b/pkg/labeler/reconcile_test.go
@@ -1,11 +1,13 @@
 package labeler
 
 import (
+	"context"
 	"errors"
 	"testing"
 
 	ecsv2 "github.com/alibabacloud-go/ecs-20140526/v7/client"
 	eflo_controller20221215 "github.com/alibabacloud-go/eflo-controller-20221215/v3/client"
+	"github.com/alibabacloud-go/tea/dara"
 	"github.com/golang/mock/gomock"
 	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/cloud"
 	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/disk"
@@ -217,7 +219,7 @@ func TestReconcile_Lingjun(t *testing.T) {
 		},
 	}, nil)
 
-	f.ecs.EXPECT().DescribeDisks(gomock.Any()).
+	f.ecs.EXPECT().DescribeDisksWithContext(gomock.Any(), gomock.Any(), gomock.Any()).
 		Return(&ecsv2.DescribeDisksResponse{
 			Body: &ecsv2.DescribeDisksResponseBody{
 				Disks: &ecsv2.DescribeDisksResponseBodyDisks{
@@ -271,12 +273,12 @@ func TestReconcile_FullPatch(t *testing.T) {
 	}
 	f := newTestFixture(t, node)
 
-	f.ecs.EXPECT().DescribeInstanceTypes(gomock.Any()).
+	f.ecs.EXPECT().DescribeInstanceTypesWithContext(gomock.Any(), gomock.Any(), gomock.Any()).
 		Return(describeInstanceTypesV2Resp("ecs.g7.large", 8), nil)
 
 	// zonal call: expect ZoneId == "cn-test-a" (from node label, not providerID).
-	f.ecs.EXPECT().DescribeAvailableResource(gomock.Any()).DoAndReturn(
-		func(req *ecsv2.DescribeAvailableResourceRequest) (*ecsv2.DescribeAvailableResourceResponse, error) {
+	f.ecs.EXPECT().DescribeAvailableResourceWithContext(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, req *ecsv2.DescribeAvailableResourceRequest, _ *dara.RuntimeOptions) (*ecsv2.DescribeAvailableResourceResponse, error) {
 			assert.Equal(t, "ecs.g7.large", ptr.Deref(req.InstanceType, ""))
 			assert.Equal(t, "DataDisk", ptr.Deref(req.DestinationResource, ""))
 			assert.Equal(t, "disk", ptr.Deref(req.ResourceType, ""))
@@ -284,14 +286,14 @@ func TestReconcile_FullPatch(t *testing.T) {
 			assert.NotEqual(t, "region", ptr.Deref(req.Scope, ""))
 			return makeAvailResp("cn-test-a", "cloud_essd"), nil
 		})
-	f.ecs.EXPECT().DescribeAvailableResource(gomock.Any()).DoAndReturn(
-		func(req *ecsv2.DescribeAvailableResourceRequest) (*ecsv2.DescribeAvailableResourceResponse, error) {
+	f.ecs.EXPECT().DescribeAvailableResourceWithContext(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, req *ecsv2.DescribeAvailableResourceRequest, _ *dara.RuntimeOptions) (*ecsv2.DescribeAvailableResourceResponse, error) {
 			assert.Equal(t, "region", ptr.Deref(req.Scope, ""))
 			assert.Equal(t, "", ptr.Deref(req.ZoneId, ""), "regional call must not carry ZoneId")
 			return makeAvailResp("", "cloud_regional_disk_auto"), nil
 		})
 
-	f.ecs.EXPECT().DescribeDisks(gomock.Any()).
+	f.ecs.EXPECT().DescribeDisksWithContext(gomock.Any(), gomock.Any(), gomock.Any()).
 		Return(&ecsv2.DescribeDisksResponse{
 			Body: &ecsv2.DescribeDisksResponseBody{
 				Disks: &ecsv2.DescribeDisksResponseBodyDisks{
@@ -343,7 +345,7 @@ func TestReconcile_APIErrors(t *testing.T) {
 				Spec: v1.NodeSpec{ProviderID: "cn-test.i-bp1ecs"},
 			},
 			setupMocks: func(ecs *cloud.MockECSv2Interface, eflo *cloud.MockEFLOInterface) {
-				ecs.EXPECT().DescribeInstanceTypes(gomock.Any()).Return(nil, errAPI)
+				ecs.EXPECT().DescribeInstanceTypesWithContext(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, errAPI)
 			},
 			wantErr:        true,
 			wantErrContain: "get disk quantity for ecs.g7.large",
@@ -361,9 +363,9 @@ func TestReconcile_APIErrors(t *testing.T) {
 				Spec: v1.NodeSpec{ProviderID: "cn-test.i-bp1ecs2"},
 			},
 			setupMocks: func(ecs *cloud.MockECSv2Interface, eflo *cloud.MockEFLOInterface) {
-				ecs.EXPECT().DescribeInstanceTypes(gomock.Any()).
+				ecs.EXPECT().DescribeInstanceTypesWithContext(gomock.Any(), gomock.Any(), gomock.Any()).
 					Return(describeInstanceTypesV2Resp("ecs.g7.large", 8), nil)
-				ecs.EXPECT().DescribeAvailableResource(gomock.Any()).Return(nil, errAPI).AnyTimes()
+				ecs.EXPECT().DescribeAvailableResourceWithContext(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, errAPI).AnyTimes()
 			},
 			wantErr:        true,
 			wantErrContain: "get disk types for ecs.g7.large/cn-test-a",
@@ -381,13 +383,13 @@ func TestReconcile_APIErrors(t *testing.T) {
 				Spec: v1.NodeSpec{ProviderID: "cn-test.i-bp1ecs3"},
 			},
 			setupMocks: func(ecs *cloud.MockECSv2Interface, eflo *cloud.MockEFLOInterface) {
-				ecs.EXPECT().DescribeInstanceTypes(gomock.Any()).
+				ecs.EXPECT().DescribeInstanceTypesWithContext(gomock.Any(), gomock.Any(), gomock.Any()).
 					Return(describeInstanceTypesV2Resp("ecs.g7.large", 8), nil)
-				ecs.EXPECT().DescribeAvailableResource(gomock.Any()).
+				ecs.EXPECT().DescribeAvailableResourceWithContext(gomock.Any(), gomock.Any(), gomock.Any()).
 					Return(makeAvailResp("cn-test-a", "cloud_essd"), nil)
-				ecs.EXPECT().DescribeAvailableResource(gomock.Any()).
+				ecs.EXPECT().DescribeAvailableResourceWithContext(gomock.Any(), gomock.Any(), gomock.Any()).
 					Return(makeAvailResp("", "cloud_essd"), nil)
-				ecs.EXPECT().DescribeDisks(gomock.Any()).Return(nil, errAPI)
+				ecs.EXPECT().DescribeDisksWithContext(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, errAPI)
 			},
 			wantErr:        true,
 			wantErrContain: "describe disks for",

--- a/pkg/metric/metric.go
+++ b/pkg/metric/metric.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/go-logr/logr"
+	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/cloud/wrap"
 	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/utils"
 	"github.com/prometheus/client_golang/prometheus"
 	versioncollector "github.com/prometheus/client_golang/prometheus/collectors/version"
@@ -63,7 +64,8 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	reg := prometheus.NewRegistry()
 	reg.MustRegister(
 		versioncollector.NewCollector("alibaba_cloud_csi_driver"),
-		&csiCollector, &CsiGrpcExecTimeCollector)
+		&csiCollector, &CsiGrpcExecTimeCollector,
+		wrap.APIRequestsTotal, wrap.APIDurationSecondsTotal)
 	handler := promhttp.InstrumentMetricHandler(reg, promhttp.HandlerFor(
 		prometheus.Gatherers{reg, legacyregistry.DefaultGatherer},
 		promhttp.HandlerOpts{

--- a/pkg/nas/accesspoint_controller.go
+++ b/pkg/nas/accesspoint_controller.go
@@ -4,21 +4,20 @@ package nas
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"path"
 	"path/filepath"
 	"strconv"
 
+	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/cloud"
 	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/cloud/metadata"
-	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/cloud/wrap"
 	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/nas/interfaces"
 
 	sdk "github.com/alibabacloud-go/nas-20170626/v4/client"
 	"github.com/alibabacloud-go/tea/tea"
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	cnfsv1beta1 "github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/cnfs/v1beta1"
-	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/nas/cloud"
+	nascloud "github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/nas/cloud"
 	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/nas/internal"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -122,7 +121,7 @@ func (c *accesspointController) createAccesspoint(ctx context.Context, name, bas
 	}
 	// Only standard filesystems support AccessPoint.
 	filesystemType := cnfs.Status.FsAttributes.FilesystemType
-	if filesystemType != cloud.FilesystemTypeStandard {
+	if filesystemType != nascloud.FilesystemTypeStandard {
 		return nil, status.Error(codes.InvalidArgument, "only filesystems of standard type support accesspoint")
 	}
 	vpcId := cnfs.Status.FsAttributes.VpcID
@@ -135,7 +134,7 @@ func (c *accesspointController) createAccesspoint(ctx context.Context, name, bas
 	}
 
 	req := &sdk.CreateAccessPointRequest{
-		AccessGroup:     tea.String(cloud.DefaultAccessGroup),
+		AccessGroup:     tea.String(nascloud.DefaultAccessGroup),
 		FileSystemId:    &filesystemId,
 		VpcId:           &vpcId,
 		VswId:           &vswId,
@@ -215,7 +214,7 @@ func (c *accesspointController) DeleteVolume(ctx context.Context, req *csi.Delet
 	if attributes["volumeCapacity"] == "true" {
 		apInfo, err := c.nasClient.DescribeAccesspoint(ctx, filesystemId, accesspointId)
 		if err != nil {
-			if errors.Is(err, wrap.ErrorCode("NotFound")) {
+			if cloud.ErrorCodeV2(err) == "NotFound" {
 				klog.Infof("accesspoint %s already deleted", accesspointId)
 				return &csi.DeleteVolumeResponse{}, nil
 			}

--- a/pkg/nas/cloud/nas_client_factory.go
+++ b/pkg/nas/cloud/nas_client_factory.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"strconv"
 
+	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/cloud/wrap"
 	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/nas/interfaces"
 	"golang.org/x/time/rate"
 	"k8s.io/klog/v2"
@@ -44,7 +45,7 @@ func (fac *NasClientFactory) V2(region string) (interfaces.NasClientV2Interface,
 	return &NasClientV2{
 		region:  region,
 		limiter: fac.limiter,
-		client:  client,
+		client:  wrap.NAS(client),
 	}, nil
 }
 

--- a/pkg/nas/cloud/nas_client_v2.go
+++ b/pkg/nas/cloud/nas_client_v2.go
@@ -9,10 +9,10 @@ import (
 
 	openapi "github.com/alibabacloud-go/darabonba-openapi/v2/client"
 	sdk "github.com/alibabacloud-go/nas-20170626/v4/client"
+	"github.com/alibabacloud-go/tea/dara"
 	"github.com/alibabacloud-go/tea/tea"
 	alicred_old "github.com/aliyun/credentials-go/credentials"
 	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/cloud"
-	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/cloud/wrap"
 	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/credentials"
 	utilshttp "github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/utils/http"
 	"golang.org/x/time/rate"
@@ -91,7 +91,7 @@ func (c *NasClientV2) CreateDir(ctx context.Context, req *sdk.CreateDirRequest) 
 	if err := c.wait(ctx, logger); err != nil {
 		return err
 	}
-	_, err := wrap.V2(logger, c.client.CreateDir)(req)
+	_, err := c.client.CreateDirWithContext(ctx, req, &dara.RuntimeOptions{})
 	return err
 }
 
@@ -102,7 +102,7 @@ func (c *NasClientV2) SetDirQuota(ctx context.Context, req *sdk.SetDirQuotaReque
 	if err := c.wait(ctx, logger); err != nil {
 		return err
 	}
-	resp, err := wrap.V2(logger, c.client.SetDirQuota)(req)
+	resp, err := c.client.SetDirQuotaWithContext(ctx, req, &dara.RuntimeOptions{})
 	if err == nil && resp.Body != nil && !tea.BoolValue(resp.Body.Success) {
 		err = ErrNotSuccess
 	}
@@ -114,13 +114,13 @@ func (c *NasClientV2) CancelDirQuota(ctx context.Context, req *sdk.CancelDirQuot
 	if err := c.wait(ctx, logger); err != nil {
 		return err
 	}
-	resp, err := wrap.V2(logger, c.client.CancelDirQuota)(req)
+	resp, err := c.client.CancelDirQuotaWithContext(ctx, req, &dara.RuntimeOptions{})
 	if err == nil {
 		if resp.Body != nil && !tea.BoolValue(resp.Body.Success) {
 			err = ErrNotSuccess
 		}
 	} else {
-		if errors.Is(err, wrap.ErrorCode("InvalidParameter.QuotaNotExistOnPath")) {
+		if cloud.ErrorCodeV2(err) == "InvalidParameter.QuotaNotExistOnPath" {
 			// ignore err if quota not exists
 			err = nil
 		}
@@ -134,7 +134,7 @@ func (c *NasClientV2) GetRecycleBinAttribute(ctx context.Context, filesystemId s
 		return nil, err
 	}
 	req := &sdk.GetRecycleBinAttributeRequest{FileSystemId: &filesystemId}
-	return wrap.V2(logger, c.client.GetRecycleBinAttribute)(req)
+	return c.client.GetRecycleBinAttributeWithContext(ctx, req, &dara.RuntimeOptions{})
 }
 
 func (c *NasClientV2) CreateAccesspoint(ctx context.Context, req *sdk.CreateAccessPointRequest) (*sdk.CreateAccessPointResponse, error) {
@@ -142,7 +142,7 @@ func (c *NasClientV2) CreateAccesspoint(ctx context.Context, req *sdk.CreateAcce
 	if err := c.wait(ctx, logger); err != nil {
 		return nil, err
 	}
-	return wrap.V2(logger, c.client.CreateAccessPoint)(req)
+	return c.client.CreateAccessPointWithContext(ctx, req, &dara.RuntimeOptions{})
 }
 
 func (c *NasClientV2) DeleteAccesspoint(ctx context.Context, filesystemId, accessPointId string) error {
@@ -154,7 +154,7 @@ func (c *NasClientV2) DeleteAccesspoint(ctx context.Context, filesystemId, acces
 		AccessPointId: &accessPointId,
 		FileSystemId:  &filesystemId,
 	}
-	_, err := wrap.V2(logger, c.client.DeleteAccessPoint)(req)
+	_, err := c.client.DeleteAccessPointWithContext(ctx, req, &dara.RuntimeOptions{})
 	return err
 }
 
@@ -163,10 +163,10 @@ func (c *NasClientV2) DescribeAccesspoint(ctx context.Context, filesystemId, acc
 	if err := c.wait(ctx, logger); err != nil {
 		return nil, err
 	}
-	return wrap.V2(logger, c.client.DescribeAccessPoint)(&sdk.DescribeAccessPointRequest{
+	return c.client.DescribeAccessPointWithContext(ctx, &sdk.DescribeAccessPointRequest{
 		AccessPointId: &accessPointId,
 		FileSystemId:  &filesystemId,
-	})
+	}, &dara.RuntimeOptions{})
 }
 
 func (c *NasClientV2) DescribeFileSystems(ctx context.Context, filesystemID string) (*sdk.DescribeFileSystemsResponse, error) {
@@ -174,7 +174,7 @@ func (c *NasClientV2) DescribeFileSystems(ctx context.Context, filesystemID stri
 	if err := c.wait(ctx, logger); err != nil {
 		return nil, err
 	}
-	return wrap.V2(logger, c.client.DescribeFileSystems)(&sdk.DescribeFileSystemsRequest{
+	return c.client.DescribeFileSystemsWithContext(ctx, &sdk.DescribeFileSystemsRequest{
 		FileSystemId: &filesystemID,
-	})
+	}, &dara.RuntimeOptions{})
 }

--- a/pkg/nas/cloud/nas_client_v2_test.go
+++ b/pkg/nas/cloud/nas_client_v2_test.go
@@ -22,7 +22,7 @@ func TestNewNasClientV2(t *testing.T) {
 func TestCreateDirSuccess(t *testing.T) {
 	t.Parallel()
 	client := newNasClientV2ForTest(t, func(mockNas *cloud.MockNasInterface) {
-		mockNas.EXPECT().CreateDir(gomock.Any()).Return(
+		mockNas.EXPECT().CreateDirWithContext(gomock.Any(), gomock.Any(), gomock.Any()).Return(
 			&nas.CreateDirResponse{
 				Headers:    make(map[string]*string),
 				StatusCode: tea.Int32(201),
@@ -47,7 +47,7 @@ func newNasClientV2ForTest(t *testing.T, mockExpects func(*cloud.MockNasInterfac
 func TestCreateDirError(t *testing.T) {
 	t.Parallel()
 	client := newNasClientV2ForTest(t, func(mockNas *cloud.MockNasInterface) {
-		mockNas.EXPECT().CreateDir(gomock.Any()).Return(
+		mockNas.EXPECT().CreateDirWithContext(gomock.Any(), gomock.Any(), gomock.Any()).Return(
 			&nas.CreateDirResponse{
 				Headers:    make(map[string]*string),
 				StatusCode: tea.Int32(403),
@@ -65,7 +65,7 @@ func TestCreateDirError(t *testing.T) {
 func TestSetDirQuotaSuccess(t *testing.T) {
 	t.Parallel()
 	client := newNasClientV2ForTest(t, func(mockNas *cloud.MockNasInterface) {
-		mockNas.EXPECT().SetDirQuota(gomock.Any()).Return(
+		mockNas.EXPECT().SetDirQuotaWithContext(gomock.Any(), gomock.Any(), gomock.Any()).Return(
 			&nas.SetDirQuotaResponse{
 				Headers:    make(map[string]*string),
 				StatusCode: tea.Int32(201),
@@ -81,7 +81,7 @@ func TestSetDirQuotaSuccess(t *testing.T) {
 func TestSetDirQuotaFailure(t *testing.T) {
 	t.Parallel()
 	client := newNasClientV2ForTest(t, func(mockNas *cloud.MockNasInterface) {
-		mockNas.EXPECT().SetDirQuota(gomock.Any()).Return(
+		mockNas.EXPECT().SetDirQuotaWithContext(gomock.Any(), gomock.Any(), gomock.Any()).Return(
 			&nas.SetDirQuotaResponse{
 				Headers:    make(map[string]*string),
 				StatusCode: tea.Int32(404),
@@ -97,7 +97,7 @@ func TestSetDirQuotaFailure(t *testing.T) {
 func TestSetDirQuotaError(t *testing.T) {
 	t.Parallel()
 	client := newNasClientV2ForTest(t, func(mockNas *cloud.MockNasInterface) {
-		mockNas.EXPECT().SetDirQuota(gomock.Any()).Return(
+		mockNas.EXPECT().SetDirQuotaWithContext(gomock.Any(), gomock.Any(), gomock.Any()).Return(
 			&nas.SetDirQuotaResponse{
 				Headers:    make(map[string]*string),
 				StatusCode: tea.Int32(404),
@@ -118,7 +118,7 @@ func TestSetDirQuotaError(t *testing.T) {
 func TestCancelDirQuotaSuccess(t *testing.T) {
 	t.Parallel()
 	client := newNasClientV2ForTest(t, func(mockNas *cloud.MockNasInterface) {
-		mockNas.EXPECT().CancelDirQuota(gomock.Any()).Return(
+		mockNas.EXPECT().CancelDirQuotaWithContext(gomock.Any(), gomock.Any(), gomock.Any()).Return(
 			&nas.CancelDirQuotaResponse{
 				Headers:    make(map[string]*string),
 				StatusCode: tea.Int32(201),
@@ -135,7 +135,7 @@ func TestCancelDirQuotaSuccess(t *testing.T) {
 func TestCancelDirQuotaFailure(t *testing.T) {
 	t.Parallel()
 	client := newNasClientV2ForTest(t, func(mockNas *cloud.MockNasInterface) {
-		mockNas.EXPECT().CancelDirQuota(gomock.Any()).Return(
+		mockNas.EXPECT().CancelDirQuotaWithContext(gomock.Any(), gomock.Any(), gomock.Any()).Return(
 			&nas.CancelDirQuotaResponse{
 				Headers:    make(map[string]*string),
 				StatusCode: tea.Int32(201),
@@ -152,7 +152,7 @@ func TestCancelDirQuotaFailure(t *testing.T) {
 func TestCancelDirQuotaError(t *testing.T) {
 	t.Parallel()
 	client := newNasClientV2ForTest(t, func(mockNas *cloud.MockNasInterface) {
-		mockNas.EXPECT().CancelDirQuota(gomock.Any()).Return(
+		mockNas.EXPECT().CancelDirQuotaWithContext(gomock.Any(), gomock.Any(), gomock.Any()).Return(
 			&nas.CancelDirQuotaResponse{
 				Headers:    make(map[string]*string),
 				StatusCode: tea.Int32(404),
@@ -173,7 +173,7 @@ func TestCancelDirQuotaError(t *testing.T) {
 func TestCancelDirQuotaIgnoreQuotaNotExistsError(t *testing.T) {
 	t.Parallel()
 	client := newNasClientV2ForTest(t, func(mockNas *cloud.MockNasInterface) {
-		mockNas.EXPECT().CancelDirQuota(gomock.Any()).Return(
+		mockNas.EXPECT().CancelDirQuotaWithContext(gomock.Any(), gomock.Any(), gomock.Any()).Return(
 			&nas.CancelDirQuotaResponse{
 				Headers:    make(map[string]*string),
 				StatusCode: tea.Int32(404),
@@ -194,7 +194,7 @@ func TestCancelDirQuotaIgnoreQuotaNotExistsError(t *testing.T) {
 func TestGetRecycleBinAttributeSuccess(t *testing.T) {
 	t.Parallel()
 	client := newNasClientV2ForTest(t, func(mockNas *cloud.MockNasInterface) {
-		mockNas.EXPECT().GetRecycleBinAttribute(gomock.Any()).Return(
+		mockNas.EXPECT().GetRecycleBinAttributeWithContext(gomock.Any(), gomock.Any(), gomock.Any()).Return(
 			&nas.GetRecycleBinAttributeResponse{
 				Headers:    make(map[string]*string),
 				StatusCode: tea.Int32(201),
@@ -208,7 +208,7 @@ func TestGetRecycleBinAttributeSuccess(t *testing.T) {
 func TestGetRecycleBinAttributeError(t *testing.T) {
 	t.Parallel()
 	client := newNasClientV2ForTest(t, func(mockNas *cloud.MockNasInterface) {
-		mockNas.EXPECT().GetRecycleBinAttribute(gomock.Any()).Return(
+		mockNas.EXPECT().GetRecycleBinAttributeWithContext(gomock.Any(), gomock.Any(), gomock.Any()).Return(
 			&nas.GetRecycleBinAttributeResponse{
 				Headers:    make(map[string]*string),
 				StatusCode: tea.Int32(400),
@@ -226,7 +226,7 @@ func TestGetRecycleBinAttributeError(t *testing.T) {
 func TestCreateAccessPointSuccess(t *testing.T) {
 	t.Parallel()
 	client := newNasClientV2ForTest(t, func(mockNas *cloud.MockNasInterface) {
-		mockNas.EXPECT().CreateAccessPoint(gomock.Any()).Return(
+		mockNas.EXPECT().CreateAccessPointWithContext(gomock.Any(), gomock.Any(), gomock.Any()).Return(
 			&nas.CreateAccessPointResponse{
 				Headers:    make(map[string]*string),
 				StatusCode: tea.Int32(201),
@@ -240,7 +240,7 @@ func TestCreateAccessPointSuccess(t *testing.T) {
 func TestCreateAccessPointError(t *testing.T) {
 	t.Parallel()
 	client := newNasClientV2ForTest(t, func(mockNas *cloud.MockNasInterface) {
-		mockNas.EXPECT().CreateAccessPoint(gomock.Any()).Return(
+		mockNas.EXPECT().CreateAccessPointWithContext(gomock.Any(), gomock.Any(), gomock.Any()).Return(
 			&nas.CreateAccessPointResponse{
 				Headers:    make(map[string]*string),
 				StatusCode: tea.Int32(403),
@@ -258,7 +258,7 @@ func TestCreateAccessPointError(t *testing.T) {
 func TestDeleteAccessPointSuccess(t *testing.T) {
 	t.Parallel()
 	client := newNasClientV2ForTest(t, func(mockNas *cloud.MockNasInterface) {
-		mockNas.EXPECT().DeleteAccessPoint(gomock.Any()).Return(
+		mockNas.EXPECT().DeleteAccessPointWithContext(gomock.Any(), gomock.Any(), gomock.Any()).Return(
 			&nas.DeleteAccessPointResponse{
 				Headers:    make(map[string]*string),
 				StatusCode: tea.Int32(201),
@@ -272,7 +272,7 @@ func TestDeleteAccessPointSuccess(t *testing.T) {
 func TestDeleteAccessPointError(t *testing.T) {
 	t.Parallel()
 	client := newNasClientV2ForTest(t, func(mockNas *cloud.MockNasInterface) {
-		mockNas.EXPECT().DeleteAccessPoint(gomock.Any()).Return(
+		mockNas.EXPECT().DeleteAccessPointWithContext(gomock.Any(), gomock.Any(), gomock.Any()).Return(
 			&nas.DeleteAccessPointResponse{
 				Headers:    make(map[string]*string),
 				StatusCode: tea.Int32(404),
@@ -290,7 +290,7 @@ func TestDeleteAccessPointError(t *testing.T) {
 func TestDescribeAccessPointSuccess(t *testing.T) {
 	t.Parallel()
 	client := newNasClientV2ForTest(t, func(mockNas *cloud.MockNasInterface) {
-		mockNas.EXPECT().DescribeAccessPoint(gomock.Any()).Return(
+		mockNas.EXPECT().DescribeAccessPointWithContext(gomock.Any(), gomock.Any(), gomock.Any()).Return(
 			&nas.DescribeAccessPointResponse{
 				Headers:    make(map[string]*string),
 				StatusCode: tea.Int32(201),
@@ -304,7 +304,7 @@ func TestDescribeAccessPointSuccess(t *testing.T) {
 func TestDescribeAccessPointError(t *testing.T) {
 	t.Parallel()
 	client := newNasClientV2ForTest(t, func(mockNas *cloud.MockNasInterface) {
-		mockNas.EXPECT().DescribeAccessPoint(gomock.Any()).Return(
+		mockNas.EXPECT().DescribeAccessPointWithContext(gomock.Any(), gomock.Any(), gomock.Any()).Return(
 			&nas.DescribeAccessPointResponse{
 				Headers:    make(map[string]*string),
 				StatusCode: tea.Int32(404),

--- a/pkg/nas/interfaces/nas_client_v2_mock.go
+++ b/pkg/nas/interfaces/nas_client_v2_mock.go
@@ -17,47 +17,47 @@ func NewMockNasClientV2Interface(ctrl *gomock.Controller) *MockNasClientV2Interf
 }
 
 func (n *MockNasClientV2Interface) CreateDir(ctx context.Context, req *sdk.CreateDirRequest) error {
-	_, err := n.client.CreateDir(req)
+	_, err := n.client.CreateDirWithContext(ctx, req, nil)
 	return err
 }
 
 func (n *MockNasClientV2Interface) SetDirQuota(ctx context.Context, req *sdk.SetDirQuotaRequest) error {
-	_, err := n.client.SetDirQuota(req)
+	_, err := n.client.SetDirQuotaWithContext(ctx, req, nil)
 	return err
 }
 
 func (n *MockNasClientV2Interface) CancelDirQuota(ctx context.Context, req *sdk.CancelDirQuotaRequest) error {
-	_, err := n.client.CancelDirQuota(req)
+	_, err := n.client.CancelDirQuotaWithContext(ctx, req, nil)
 	return err
 }
 
 func (n *MockNasClientV2Interface) GetRecycleBinAttribute(ctx context.Context, filesystemId string) (*sdk.GetRecycleBinAttributeResponse, error) {
-	return n.client.GetRecycleBinAttribute(&sdk.GetRecycleBinAttributeRequest{
+	return n.client.GetRecycleBinAttributeWithContext(ctx, &sdk.GetRecycleBinAttributeRequest{
 		FileSystemId: &filesystemId,
-	})
+	}, nil)
 }
 
 func (n *MockNasClientV2Interface) CreateAccesspoint(ctx context.Context, req *sdk.CreateAccessPointRequest) (*sdk.CreateAccessPointResponse, error) {
-	return n.client.CreateAccessPoint(req)
+	return n.client.CreateAccessPointWithContext(ctx, req, nil)
 }
 
 func (n *MockNasClientV2Interface) DeleteAccesspoint(ctx context.Context, filesystemId, accessPointId string) error {
-	_, err := n.client.DeleteAccessPoint(&sdk.DeleteAccessPointRequest{
+	_, err := n.client.DeleteAccessPointWithContext(ctx, &sdk.DeleteAccessPointRequest{
 		AccessPointId: &accessPointId,
 		FileSystemId:  &filesystemId,
-	})
+	}, nil)
 	return err
 }
 
 func (n *MockNasClientV2Interface) DescribeAccesspoint(ctx context.Context, filesystemId, accessPointId string) (*sdk.DescribeAccessPointResponse, error) {
-	return n.client.DescribeAccessPoint(&sdk.DescribeAccessPointRequest{
+	return n.client.DescribeAccessPointWithContext(ctx, &sdk.DescribeAccessPointRequest{
 		AccessPointId: &accessPointId,
 		FileSystemId:  &filesystemId,
-	})
+	}, nil)
 }
 
 func (n *MockNasClientV2Interface) DescribeFileSystems(ctx context.Context, filesystemID string) (*sdk.DescribeFileSystemsResponse, error) {
-	return n.client.DescribeFileSystems(&sdk.DescribeFileSystemsRequest{
+	return n.client.DescribeFileSystemsWithContext(ctx, &sdk.DescribeFileSystemsRequest{
 		FileSystemId: &filesystemID,
-	})
+	}, nil)
 }

--- a/vendor/github.com/kylelemons/godebug/LICENSE
+++ b/vendor/github.com/kylelemons/godebug/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/github.com/kylelemons/godebug/diff/diff.go
+++ b/vendor/github.com/kylelemons/godebug/diff/diff.go
@@ -1,0 +1,186 @@
+// Copyright 2013 Google Inc.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package diff implements a linewise diff algorithm.
+package diff
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+)
+
+// Chunk represents a piece of the diff.  A chunk will not have both added and
+// deleted lines.  Equal lines are always after any added or deleted lines.
+// A Chunk may or may not have any lines in it, especially for the first or last
+// chunk in a computation.
+type Chunk struct {
+	Added   []string
+	Deleted []string
+	Equal   []string
+}
+
+func (c *Chunk) empty() bool {
+	return len(c.Added) == 0 && len(c.Deleted) == 0 && len(c.Equal) == 0
+}
+
+// Diff returns a string containing a line-by-line unified diff of the linewise
+// changes required to make A into B.  Each line is prefixed with '+', '-', or
+// ' ' to indicate if it should be added, removed, or is correct respectively.
+func Diff(A, B string) string {
+	aLines := strings.Split(A, "\n")
+	bLines := strings.Split(B, "\n")
+
+	chunks := DiffChunks(aLines, bLines)
+
+	buf := new(bytes.Buffer)
+	for _, c := range chunks {
+		for _, line := range c.Added {
+			fmt.Fprintf(buf, "+%s\n", line)
+		}
+		for _, line := range c.Deleted {
+			fmt.Fprintf(buf, "-%s\n", line)
+		}
+		for _, line := range c.Equal {
+			fmt.Fprintf(buf, " %s\n", line)
+		}
+	}
+	return strings.TrimRight(buf.String(), "\n")
+}
+
+// DiffChunks uses an O(D(N+M)) shortest-edit-script algorithm
+// to compute the edits required from A to B and returns the
+// edit chunks.
+func DiffChunks(a, b []string) []Chunk {
+	// algorithm: http://www.xmailserver.org/diff2.pdf
+
+	// We'll need these quantities a lot.
+	alen, blen := len(a), len(b) // M, N
+
+	// At most, it will require len(a) deletions and len(b) additions
+	// to transform a into b.
+	maxPath := alen + blen // MAX
+	if maxPath == 0 {
+		// degenerate case: two empty lists are the same
+		return nil
+	}
+
+	// Store the endpoint of the path for diagonals.
+	// We store only the a index, because the b index on any diagonal
+	// (which we know during the loop below) is aidx-diag.
+	// endpoint[maxPath] represents the 0 diagonal.
+	//
+	// Stated differently:
+	// endpoint[d] contains the aidx of a furthest reaching path in diagonal d
+	endpoint := make([]int, 2*maxPath+1) // V
+
+	saved := make([][]int, 0, 8) // Vs
+	save := func() {
+		dup := make([]int, len(endpoint))
+		copy(dup, endpoint)
+		saved = append(saved, dup)
+	}
+
+	var editDistance int // D
+dLoop:
+	for editDistance = 0; editDistance <= maxPath; editDistance++ {
+		// The 0 diag(onal) represents equality of a and b.  Each diagonal to
+		// the left is numbered one lower, to the right is one higher, from
+		// -alen to +blen.  Negative diagonals favor differences from a,
+		// positive diagonals favor differences from b.  The edit distance to a
+		// diagonal d cannot be shorter than d itself.
+		//
+		// The iterations of this loop cover either odds or evens, but not both,
+		// If odd indices are inputs, even indices are outputs and vice versa.
+		for diag := -editDistance; diag <= editDistance; diag += 2 { // k
+			var aidx int // x
+			switch {
+			case diag == -editDistance:
+				// This is a new diagonal; copy from previous iter
+				aidx = endpoint[maxPath-editDistance+1] + 0
+			case diag == editDistance:
+				// This is a new diagonal; copy from previous iter
+				aidx = endpoint[maxPath+editDistance-1] + 1
+			case endpoint[maxPath+diag+1] > endpoint[maxPath+diag-1]:
+				// diagonal d+1 was farther along, so use that
+				aidx = endpoint[maxPath+diag+1] + 0
+			default:
+				// diagonal d-1 was farther (or the same), so use that
+				aidx = endpoint[maxPath+diag-1] + 1
+			}
+			// On diagonal d, we can compute bidx from aidx.
+			bidx := aidx - diag // y
+			// See how far we can go on this diagonal before we find a difference.
+			for aidx < alen && bidx < blen && a[aidx] == b[bidx] {
+				aidx++
+				bidx++
+			}
+			// Store the end of the current edit chain.
+			endpoint[maxPath+diag] = aidx
+			// If we've found the end of both inputs, we're done!
+			if aidx >= alen && bidx >= blen {
+				save() // save the final path
+				break dLoop
+			}
+		}
+		save() // save the current path
+	}
+	if editDistance == 0 {
+		return nil
+	}
+	chunks := make([]Chunk, editDistance+1)
+
+	x, y := alen, blen
+	for d := editDistance; d > 0; d-- {
+		endpoint := saved[d]
+		diag := x - y
+		insert := diag == -d || (diag != d && endpoint[maxPath+diag-1] < endpoint[maxPath+diag+1])
+
+		x1 := endpoint[maxPath+diag]
+		var x0, xM, kk int
+		if insert {
+			kk = diag + 1
+			x0 = endpoint[maxPath+kk]
+			xM = x0
+		} else {
+			kk = diag - 1
+			x0 = endpoint[maxPath+kk]
+			xM = x0 + 1
+		}
+		y0 := x0 - kk
+
+		var c Chunk
+		if insert {
+			c.Added = b[y0:][:1]
+		} else {
+			c.Deleted = a[x0:][:1]
+		}
+		if xM < x1 {
+			c.Equal = a[xM:][:x1-xM]
+		}
+
+		x, y = x0, y0
+		chunks[d] = c
+	}
+	if x > 0 {
+		chunks[0].Equal = a[:x]
+	}
+	if chunks[0].empty() {
+		chunks = chunks[1:]
+	}
+	if len(chunks) == 0 {
+		return nil
+	}
+	return chunks
+}

--- a/vendor/github.com/prometheus/client_golang/prometheus/testutil/lint.go
+++ b/vendor/github.com/prometheus/client_golang/prometheus/testutil/lint.go
@@ -1,0 +1,46 @@
+// Copyright 2020 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testutil
+
+import (
+	"fmt"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil/promlint"
+)
+
+// CollectAndLint registers the provided Collector with a newly created pedantic
+// Registry. It then calls GatherAndLint with that Registry and with the
+// provided metricNames.
+func CollectAndLint(c prometheus.Collector, metricNames ...string) ([]promlint.Problem, error) {
+	reg := prometheus.NewPedanticRegistry()
+	if err := reg.Register(c); err != nil {
+		return nil, fmt.Errorf("registering collector failed: %w", err)
+	}
+	return GatherAndLint(reg, metricNames...)
+}
+
+// GatherAndLint gathers all metrics from the provided Gatherer and checks them
+// with the linter in the promlint package. If any metricNames are provided,
+// only metrics with those names are checked.
+func GatherAndLint(g prometheus.Gatherer, metricNames ...string) ([]promlint.Problem, error) {
+	got, err := g.Gather()
+	if err != nil {
+		return nil, fmt.Errorf("gathering metrics failed: %w", err)
+	}
+	if metricNames != nil {
+		got = filterMetrics(got, metricNames)
+	}
+	return promlint.NewWithMetricFamilies(got).Lint()
+}

--- a/vendor/github.com/prometheus/client_golang/prometheus/testutil/promlint/problem.go
+++ b/vendor/github.com/prometheus/client_golang/prometheus/testutil/promlint/problem.go
@@ -1,0 +1,33 @@
+// Copyright 2020 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package promlint
+
+import dto "github.com/prometheus/client_model/go"
+
+// A Problem is an issue detected by a linter.
+type Problem struct {
+	// The name of the metric indicated by this Problem.
+	Metric string
+
+	// A description of the issue for this Problem.
+	Text string
+}
+
+// newProblem is helper function to create a Problem.
+func newProblem(mf *dto.MetricFamily, text string) Problem {
+	return Problem{
+		Metric: mf.GetName(),
+		Text:   text,
+	}
+}

--- a/vendor/github.com/prometheus/client_golang/prometheus/testutil/promlint/promlint.go
+++ b/vendor/github.com/prometheus/client_golang/prometheus/testutil/promlint/promlint.go
@@ -1,0 +1,123 @@
+// Copyright 2020 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package promlint provides a linter for Prometheus metrics.
+package promlint
+
+import (
+	"errors"
+	"io"
+	"sort"
+
+	dto "github.com/prometheus/client_model/go"
+	"github.com/prometheus/common/expfmt"
+)
+
+// A Linter is a Prometheus metrics linter.  It identifies issues with metric
+// names, types, and metadata, and reports them to the caller.
+type Linter struct {
+	// The linter will read metrics in the Prometheus text format from r and
+	// then lint it, _and_ it will lint the metrics provided directly as
+	// MetricFamily proto messages in mfs. Note, however, that the current
+	// constructor functions New and NewWithMetricFamilies only ever set one
+	// of them.
+	r   io.Reader
+	mfs []*dto.MetricFamily
+
+	customValidations []Validation
+}
+
+// New creates a new Linter that reads an input stream of Prometheus metrics in
+// the Prometheus text exposition format.
+func New(r io.Reader) *Linter {
+	return &Linter{
+		r: r,
+	}
+}
+
+// NewWithMetricFamilies creates a new Linter that reads from a slice of
+// MetricFamily protobuf messages.
+func NewWithMetricFamilies(mfs []*dto.MetricFamily) *Linter {
+	return &Linter{
+		mfs: mfs,
+	}
+}
+
+// AddCustomValidations adds custom validations to the linter.
+func (l *Linter) AddCustomValidations(vs ...Validation) {
+	if l.customValidations == nil {
+		l.customValidations = make([]Validation, 0, len(vs))
+	}
+	l.customValidations = append(l.customValidations, vs...)
+}
+
+// Lint performs a linting pass, returning a slice of Problems indicating any
+// issues found in the metrics stream. The slice is sorted by metric name
+// and issue description.
+func (l *Linter) Lint() ([]Problem, error) {
+	var problems []Problem
+
+	if l.r != nil {
+		d := expfmt.NewDecoder(l.r, expfmt.NewFormat(expfmt.TypeTextPlain))
+
+		mf := &dto.MetricFamily{}
+		for {
+			if err := d.Decode(mf); err != nil {
+				if errors.Is(err, io.EOF) {
+					break
+				}
+
+				return nil, err
+			}
+
+			problems = append(problems, l.lint(mf)...)
+		}
+	}
+	for _, mf := range l.mfs {
+		problems = append(problems, l.lint(mf)...)
+	}
+
+	// Ensure deterministic output.
+	sort.SliceStable(problems, func(i, j int) bool {
+		if problems[i].Metric == problems[j].Metric {
+			return problems[i].Text < problems[j].Text
+		}
+		return problems[i].Metric < problems[j].Metric
+	})
+
+	return problems, nil
+}
+
+// lint is the entry point for linting a single metric.
+func (l *Linter) lint(mf *dto.MetricFamily) []Problem {
+	var problems []Problem
+
+	for _, fn := range defaultValidations {
+		errs := fn(mf)
+		for _, err := range errs {
+			problems = append(problems, newProblem(mf, err.Error()))
+		}
+	}
+
+	if l.customValidations != nil {
+		for _, fn := range l.customValidations {
+			errs := fn(mf)
+			for _, err := range errs {
+				problems = append(problems, newProblem(mf, err.Error()))
+			}
+		}
+	}
+
+	// TODO(mdlayher): lint rules for specific metrics types.
+	return problems
+}

--- a/vendor/github.com/prometheus/client_golang/prometheus/testutil/promlint/validation.go
+++ b/vendor/github.com/prometheus/client_golang/prometheus/testutil/promlint/validation.go
@@ -1,0 +1,34 @@
+// Copyright 2020 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package promlint
+
+import (
+	dto "github.com/prometheus/client_model/go"
+
+	"github.com/prometheus/client_golang/prometheus/testutil/promlint/validations"
+)
+
+type Validation = func(mf *dto.MetricFamily) []error
+
+var defaultValidations = []Validation{
+	validations.LintHelp,
+	validations.LintMetricUnits,
+	validations.LintCounter,
+	validations.LintHistogramSummaryReserved,
+	validations.LintMetricTypeInName,
+	validations.LintReservedChars,
+	validations.LintCamelCase,
+	validations.LintUnitAbbreviations,
+	validations.LintDuplicateMetric,
+}

--- a/vendor/github.com/prometheus/client_golang/prometheus/testutil/promlint/validations/counter_validations.go
+++ b/vendor/github.com/prometheus/client_golang/prometheus/testutil/promlint/validations/counter_validations.go
@@ -1,0 +1,40 @@
+// Copyright 2020 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validations
+
+import (
+	"errors"
+	"strings"
+
+	dto "github.com/prometheus/client_model/go"
+)
+
+// LintCounter detects issues specific to counters, as well as patterns that should
+// only be used with counters.
+func LintCounter(mf *dto.MetricFamily) []error {
+	var problems []error
+
+	isCounter := mf.GetType() == dto.MetricType_COUNTER
+	isUntyped := mf.GetType() == dto.MetricType_UNTYPED
+	hasTotalSuffix := strings.HasSuffix(mf.GetName(), "_total")
+
+	switch {
+	case isCounter && !hasTotalSuffix:
+		problems = append(problems, errors.New(`counter metrics should have "_total" suffix`))
+	case !isUntyped && !isCounter && hasTotalSuffix:
+		problems = append(problems, errors.New(`non-counter metrics should not have "_total" suffix`))
+	}
+
+	return problems
+}

--- a/vendor/github.com/prometheus/client_golang/prometheus/testutil/promlint/validations/duplicate_validations.go
+++ b/vendor/github.com/prometheus/client_golang/prometheus/testutil/promlint/validations/duplicate_validations.go
@@ -1,0 +1,37 @@
+// Copyright 2024 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validations
+
+import (
+	"errors"
+	"reflect"
+
+	dto "github.com/prometheus/client_model/go"
+)
+
+// LintDuplicateMetric detects duplicate metric.
+func LintDuplicateMetric(mf *dto.MetricFamily) []error {
+	var problems []error
+
+	for i, m := range mf.Metric {
+		for _, k := range mf.Metric[i+1:] {
+			if reflect.DeepEqual(m.Label, k.Label) {
+				problems = append(problems, errors.New("metric not unique"))
+				break
+			}
+		}
+	}
+
+	return problems
+}

--- a/vendor/github.com/prometheus/client_golang/prometheus/testutil/promlint/validations/generic_name_validations.go
+++ b/vendor/github.com/prometheus/client_golang/prometheus/testutil/promlint/validations/generic_name_validations.go
@@ -1,0 +1,101 @@
+// Copyright 2020 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validations
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+
+	dto "github.com/prometheus/client_model/go"
+)
+
+var camelCase = regexp.MustCompile(`[a-z][A-Z]`)
+
+// LintMetricUnits detects issues with metric unit names.
+func LintMetricUnits(mf *dto.MetricFamily) []error {
+	var problems []error
+
+	unit, base, ok := metricUnits(*mf.Name)
+	if !ok {
+		// No known units detected.
+		return nil
+	}
+
+	// Unit is already a base unit.
+	if unit == base {
+		return nil
+	}
+
+	problems = append(problems, fmt.Errorf("use base unit %q instead of %q", base, unit))
+
+	return problems
+}
+
+// LintMetricTypeInName detects when the metric type is included in the metric name.
+func LintMetricTypeInName(mf *dto.MetricFamily) []error {
+	if mf.GetType() == dto.MetricType_UNTYPED {
+		return nil
+	}
+
+	var problems []error
+
+	n := strings.ToLower(mf.GetName())
+	typename := strings.ToLower(mf.GetType().String())
+
+	if strings.Contains(n, "_"+typename+"_") || strings.HasSuffix(n, "_"+typename) {
+		problems = append(problems, fmt.Errorf(`metric name should not include type '%s'`, typename))
+	}
+
+	return problems
+}
+
+// LintReservedChars detects colons in metric names.
+func LintReservedChars(mf *dto.MetricFamily) []error {
+	var problems []error
+	if strings.Contains(mf.GetName(), ":") {
+		problems = append(problems, errors.New("metric names should not contain ':'"))
+	}
+	return problems
+}
+
+// LintCamelCase detects metric names and label names written in camelCase.
+func LintCamelCase(mf *dto.MetricFamily) []error {
+	var problems []error
+	if camelCase.FindString(mf.GetName()) != "" {
+		problems = append(problems, errors.New("metric names should be written in 'snake_case' not 'camelCase'"))
+	}
+
+	for _, m := range mf.GetMetric() {
+		for _, l := range m.GetLabel() {
+			if camelCase.FindString(l.GetName()) != "" {
+				problems = append(problems, errors.New("label names should be written in 'snake_case' not 'camelCase'"))
+			}
+		}
+	}
+	return problems
+}
+
+// LintUnitAbbreviations detects abbreviated units in the metric name.
+func LintUnitAbbreviations(mf *dto.MetricFamily) []error {
+	var problems []error
+	n := strings.ToLower(mf.GetName())
+	for _, s := range unitAbbreviations {
+		if strings.Contains(n, "_"+s+"_") || strings.HasSuffix(n, "_"+s) {
+			problems = append(problems, errors.New("metric names should not contain abbreviated units"))
+		}
+	}
+	return problems
+}

--- a/vendor/github.com/prometheus/client_golang/prometheus/testutil/promlint/validations/help_validations.go
+++ b/vendor/github.com/prometheus/client_golang/prometheus/testutil/promlint/validations/help_validations.go
@@ -1,0 +1,32 @@
+// Copyright 2020 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validations
+
+import (
+	"errors"
+
+	dto "github.com/prometheus/client_model/go"
+)
+
+// LintHelp detects issues related to the help text for a metric.
+func LintHelp(mf *dto.MetricFamily) []error {
+	var problems []error
+
+	// Expect all metrics to have help text available.
+	if mf.Help == nil {
+		problems = append(problems, errors.New("no help text"))
+	}
+
+	return problems
+}

--- a/vendor/github.com/prometheus/client_golang/prometheus/testutil/promlint/validations/histogram_validations.go
+++ b/vendor/github.com/prometheus/client_golang/prometheus/testutil/promlint/validations/histogram_validations.go
@@ -1,0 +1,63 @@
+// Copyright 2020 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validations
+
+import (
+	"errors"
+	"strings"
+
+	dto "github.com/prometheus/client_model/go"
+)
+
+// LintHistogramSummaryReserved detects when other types of metrics use names or labels
+// reserved for use by histograms and/or summaries.
+func LintHistogramSummaryReserved(mf *dto.MetricFamily) []error {
+	// These rules do not apply to untyped metrics.
+	t := mf.GetType()
+	if t == dto.MetricType_UNTYPED {
+		return nil
+	}
+
+	var problems []error
+
+	isHistogram := t == dto.MetricType_HISTOGRAM
+	isSummary := t == dto.MetricType_SUMMARY
+
+	n := mf.GetName()
+
+	if !isHistogram && strings.HasSuffix(n, "_bucket") {
+		problems = append(problems, errors.New(`non-histogram metrics should not have "_bucket" suffix`))
+	}
+	if !isHistogram && !isSummary && strings.HasSuffix(n, "_count") {
+		problems = append(problems, errors.New(`non-histogram and non-summary metrics should not have "_count" suffix`))
+	}
+	if !isHistogram && !isSummary && strings.HasSuffix(n, "_sum") {
+		problems = append(problems, errors.New(`non-histogram and non-summary metrics should not have "_sum" suffix`))
+	}
+
+	for _, m := range mf.GetMetric() {
+		for _, l := range m.GetLabel() {
+			ln := l.GetName()
+
+			if !isHistogram && ln == "le" {
+				problems = append(problems, errors.New(`non-histogram metrics should not have "le" label`))
+			}
+			if !isSummary && ln == "quantile" {
+				problems = append(problems, errors.New(`non-summary metrics should not have "quantile" label`))
+			}
+		}
+	}
+
+	return problems
+}

--- a/vendor/github.com/prometheus/client_golang/prometheus/testutil/promlint/validations/units.go
+++ b/vendor/github.com/prometheus/client_golang/prometheus/testutil/promlint/validations/units.go
@@ -1,0 +1,118 @@
+// Copyright 2020 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validations
+
+import "strings"
+
+// Units and their possible prefixes recognized by this library.  More can be
+// added over time as needed.
+var (
+	// map a unit to the appropriate base unit.
+	units = map[string]string{
+		// Base units.
+		"amperes": "amperes",
+		"bytes":   "bytes",
+		"celsius": "celsius", // Also allow Celsius because it is common in typical Prometheus use cases.
+		"grams":   "grams",
+		"joules":  "joules",
+		"kelvin":  "kelvin", // SI base unit, used in special cases (e.g. color temperature, scientific measurements).
+		"meters":  "meters", // Both American and international spelling permitted.
+		"metres":  "metres",
+		"seconds": "seconds",
+		"volts":   "volts",
+
+		// Non base units.
+		// Time.
+		"minutes": "seconds",
+		"hours":   "seconds",
+		"days":    "seconds",
+		"weeks":   "seconds",
+		// Temperature.
+		"kelvins":    "kelvin",
+		"fahrenheit": "celsius",
+		"rankine":    "celsius",
+		// Length.
+		"inches": "meters",
+		"yards":  "meters",
+		"miles":  "meters",
+		// Bytes.
+		"bits": "bytes",
+		// Energy.
+		"calories": "joules",
+		// Mass.
+		"pounds": "grams",
+		"ounces": "grams",
+	}
+
+	unitPrefixes = []string{
+		"pico",
+		"nano",
+		"micro",
+		"milli",
+		"centi",
+		"deci",
+		"deca",
+		"hecto",
+		"kilo",
+		"kibi",
+		"mega",
+		"mibi",
+		"giga",
+		"gibi",
+		"tera",
+		"tebi",
+		"peta",
+		"pebi",
+	}
+
+	// Common abbreviations that we'd like to discourage.
+	unitAbbreviations = []string{
+		"s",
+		"ms",
+		"us",
+		"ns",
+		"sec",
+		"b",
+		"kb",
+		"mb",
+		"gb",
+		"tb",
+		"pb",
+		"m",
+		"h",
+		"d",
+	}
+)
+
+// metricUnits attempts to detect known unit types used as part of a metric name,
+// e.g. "foo_bytes_total" or "bar_baz_milligrams".
+func metricUnits(m string) (unit, base string, ok bool) {
+	ss := strings.Split(m, "_")
+
+	for _, s := range ss {
+		if base, found := units[s]; found {
+			return s, base, true
+		}
+
+		for _, p := range unitPrefixes {
+			if strings.HasPrefix(s, p) {
+				if base, found := units[s[len(p):]]; found {
+					return s, base, true
+				}
+			}
+		}
+	}
+
+	return "", "", false
+}

--- a/vendor/github.com/prometheus/client_golang/prometheus/testutil/testutil.go
+++ b/vendor/github.com/prometheus/client_golang/prometheus/testutil/testutil.go
@@ -1,0 +1,334 @@
+// Copyright 2018 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package testutil provides helpers to test code using the prometheus package
+// of client_golang.
+//
+// While writing unit tests to verify correct instrumentation of your code, it's
+// a common mistake to mostly test the instrumentation library instead of your
+// own code. Rather than verifying that a prometheus.Counter's value has changed
+// as expected or that it shows up in the exposition after registration, it is
+// in general more robust and more faithful to the concept of unit tests to use
+// mock implementations of the prometheus.Counter and prometheus.Registerer
+// interfaces that simply assert that the Add or Register methods have been
+// called with the expected arguments. However, this might be overkill in simple
+// scenarios. The ToFloat64 function is provided for simple inspection of a
+// single-value metric, but it has to be used with caution.
+//
+// End-to-end tests to verify all or larger parts of the metrics exposition can
+// be implemented with the CollectAndCompare or GatherAndCompare functions. The
+// most appropriate use is not so much testing instrumentation of your code, but
+// testing custom prometheus.Collector implementations and in particular whole
+// exporters, i.e. programs that retrieve telemetry data from a 3rd party source
+// and convert it into Prometheus metrics.
+//
+// In a similar pattern, CollectAndLint and GatherAndLint can be used to detect
+// metrics that have issues with their name, type, or metadata without being
+// necessarily invalid, e.g. a counter with a name missing the “_total” suffix.
+package testutil
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/kylelemons/godebug/diff"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/prometheus/common/expfmt"
+	"github.com/prometheus/common/model"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/internal"
+)
+
+// ToFloat64 collects all Metrics from the provided Collector. It expects that
+// this results in exactly one Metric being collected, which must be a Gauge,
+// Counter, or Untyped. In all other cases, ToFloat64 panics. ToFloat64 returns
+// the value of the collected Metric.
+//
+// The Collector provided is typically a simple instance of Gauge or Counter, or
+// – less commonly – a GaugeVec or CounterVec with exactly one element. But any
+// Collector fulfilling the prerequisites described above will do.
+//
+// Use this function with caution. It is computationally very expensive and thus
+// not suited at all to read values from Metrics in regular code. This is really
+// only for testing purposes, and even for testing, other approaches are often
+// more appropriate (see this package's documentation).
+//
+// A clear anti-pattern would be to use a metric type from the prometheus
+// package to track values that are also needed for something else than the
+// exposition of Prometheus metrics. For example, you would like to track the
+// number of items in a queue because your code should reject queuing further
+// items if a certain limit is reached. It is tempting to track the number of
+// items in a prometheus.Gauge, as it is then easily available as a metric for
+// exposition, too. However, then you would need to call ToFloat64 in your
+// regular code, potentially quite often. The recommended way is to track the
+// number of items conventionally (in the way you would have done it without
+// considering Prometheus metrics) and then expose the number with a
+// prometheus.GaugeFunc.
+func ToFloat64(c prometheus.Collector) float64 {
+	var (
+		m      prometheus.Metric
+		mCount int
+		mChan  = make(chan prometheus.Metric)
+		done   = make(chan struct{})
+	)
+
+	go func() {
+		for m = range mChan {
+			mCount++
+		}
+		close(done)
+	}()
+
+	c.Collect(mChan)
+	close(mChan)
+	<-done
+
+	if mCount != 1 {
+		panic(fmt.Errorf("collected %d metrics instead of exactly 1", mCount))
+	}
+
+	pb := &dto.Metric{}
+	if err := m.Write(pb); err != nil {
+		panic(fmt.Errorf("error happened while collecting metrics: %w", err))
+	}
+	if pb.Gauge != nil {
+		return pb.Gauge.GetValue()
+	}
+	if pb.Counter != nil {
+		return pb.Counter.GetValue()
+	}
+	if pb.Untyped != nil {
+		return pb.Untyped.GetValue()
+	}
+	panic(fmt.Errorf("collected a non-gauge/counter/untyped metric: %s", pb))
+}
+
+// CollectAndCount registers the provided Collector with a newly created
+// pedantic Registry. It then calls GatherAndCount with that Registry and with
+// the provided metricNames. In the unlikely case that the registration or the
+// gathering fails, this function panics. (This is inconsistent with the other
+// CollectAnd… functions in this package and has historical reasons. Changing
+// the function signature would be a breaking change and will therefore only
+// happen with the next major version bump.)
+func CollectAndCount(c prometheus.Collector, metricNames ...string) int {
+	reg := prometheus.NewPedanticRegistry()
+	if err := reg.Register(c); err != nil {
+		panic(fmt.Errorf("registering collector failed: %w", err))
+	}
+	result, err := GatherAndCount(reg, metricNames...)
+	if err != nil {
+		panic(err)
+	}
+	return result
+}
+
+// GatherAndCount gathers all metrics from the provided Gatherer and counts
+// them. It returns the number of metric children in all gathered metric
+// families together. If any metricNames are provided, only metrics with those
+// names are counted.
+func GatherAndCount(g prometheus.Gatherer, metricNames ...string) (int, error) {
+	got, err := g.Gather()
+	if err != nil {
+		return 0, fmt.Errorf("gathering metrics failed: %w", err)
+	}
+	if metricNames != nil {
+		got = filterMetrics(got, metricNames)
+	}
+
+	result := 0
+	for _, mf := range got {
+		result += len(mf.GetMetric())
+	}
+	return result, nil
+}
+
+// ScrapeAndCompare calls a remote exporter's endpoint which is expected to return some metrics in
+// plain text format. Then it compares it with the results that the `expected` would return.
+// If the `metricNames` is not empty it would filter the comparison only to the given metric names.
+//
+// NOTE: Be mindful of accidental discrepancies between expected and metricNames; metricNames filter
+// both expected and scraped metrics. See https://github.com/prometheus/client_golang/issues/1351.
+func ScrapeAndCompare(url string, expected io.Reader, metricNames ...string) error {
+	resp, err := http.Get(url)
+	if err != nil {
+		return fmt.Errorf("scraping metrics failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("the scraping target returned a status code other than 200: %d",
+			resp.StatusCode)
+	}
+
+	scraped, err := convertReaderToMetricFamily(resp.Body)
+	if err != nil {
+		return err
+	}
+
+	wanted, err := convertReaderToMetricFamily(expected)
+	if err != nil {
+		return err
+	}
+
+	return compareMetricFamilies(scraped, wanted, metricNames...)
+}
+
+// CollectAndCompare collects the metrics identified by `metricNames` and compares them in the Prometheus text
+// exposition format to the data read from expected.
+//
+// NOTE: Be mindful of accidental discrepancies between expected and metricNames; metricNames filter
+// both expected and collected metrics. See https://github.com/prometheus/client_golang/issues/1351.
+func CollectAndCompare(c prometheus.Collector, expected io.Reader, metricNames ...string) error {
+	reg := prometheus.NewPedanticRegistry()
+	if err := reg.Register(c); err != nil {
+		return fmt.Errorf("registering collector failed: %w", err)
+	}
+	return GatherAndCompare(reg, expected, metricNames...)
+}
+
+// GatherAndCompare gathers all metrics from the provided Gatherer and compares
+// it to an expected output read from the provided Reader in the Prometheus text
+// exposition format. If any metricNames are provided, only metrics with those
+// names are compared.
+//
+// NOTE: Be mindful of accidental discrepancies between expected and metricNames; metricNames filter
+// both expected and gathered metrics. See https://github.com/prometheus/client_golang/issues/1351.
+func GatherAndCompare(g prometheus.Gatherer, expected io.Reader, metricNames ...string) error {
+	return TransactionalGatherAndCompare(prometheus.ToTransactionalGatherer(g), expected, metricNames...)
+}
+
+// TransactionalGatherAndCompare gathers all metrics from the provided Gatherer and compares
+// it to an expected output read from the provided Reader in the Prometheus text
+// exposition format. If any metricNames are provided, only metrics with those
+// names are compared.
+//
+// NOTE: Be mindful of accidental discrepancies between expected and metricNames; metricNames filter
+// both expected and gathered metrics. See https://github.com/prometheus/client_golang/issues/1351.
+func TransactionalGatherAndCompare(g prometheus.TransactionalGatherer, expected io.Reader, metricNames ...string) error {
+	got, done, err := g.Gather()
+	defer done()
+	if err != nil {
+		return fmt.Errorf("gathering metrics failed: %w", err)
+	}
+
+	wanted, err := convertReaderToMetricFamily(expected)
+	if err != nil {
+		return err
+	}
+
+	return compareMetricFamilies(got, wanted, metricNames...)
+}
+
+// CollectAndFormat collects the metrics identified by `metricNames` and returns them in the given format.
+func CollectAndFormat(c prometheus.Collector, format expfmt.FormatType, metricNames ...string) ([]byte, error) {
+	reg := prometheus.NewPedanticRegistry()
+	if err := reg.Register(c); err != nil {
+		return nil, fmt.Errorf("registering collector failed: %w", err)
+	}
+
+	gotFiltered, err := reg.Gather()
+	if err != nil {
+		return nil, fmt.Errorf("gathering metrics failed: %w", err)
+	}
+
+	gotFiltered = filterMetrics(gotFiltered, metricNames)
+
+	var gotFormatted bytes.Buffer
+	enc := expfmt.NewEncoder(&gotFormatted, expfmt.NewFormat(format))
+	for _, mf := range gotFiltered {
+		if err := enc.Encode(mf); err != nil {
+			return nil, fmt.Errorf("encoding gathered metrics failed: %w", err)
+		}
+	}
+
+	return gotFormatted.Bytes(), nil
+}
+
+// convertReaderToMetricFamily would read from a io.Reader object and convert it to a slice of
+// dto.MetricFamily.
+func convertReaderToMetricFamily(reader io.Reader) ([]*dto.MetricFamily, error) {
+	tp := expfmt.NewTextParser(model.UTF8Validation)
+	notNormalized, err := tp.TextToMetricFamilies(reader)
+	if err != nil {
+		return nil, fmt.Errorf("converting reader to metric families failed: %w", err)
+	}
+
+	// The text protocol handles empty help fields inconsistently. When
+	// encoding, any non-nil value, include the empty string, produces a
+	// "# HELP" line. But when decoding, the help field is only set to a
+	// non-nil value if the "# HELP" line contains a non-empty value.
+	//
+	// Because metrics in a registry always have non-nil help fields, populate
+	// any nil help fields in the parsed metrics with the empty string so that
+	// when we compare text encodings, the results are consistent.
+	for _, metric := range notNormalized {
+		if metric.Help == nil {
+			metric.Help = proto.String("")
+		}
+	}
+
+	return internal.NormalizeMetricFamilies(notNormalized), nil
+}
+
+// compareMetricFamilies would compare 2 slices of metric families, and optionally filters both of
+// them to the `metricNames` provided.
+func compareMetricFamilies(got, expected []*dto.MetricFamily, metricNames ...string) error {
+	if metricNames != nil {
+		got = filterMetrics(got, metricNames)
+		expected = filterMetrics(expected, metricNames)
+	}
+
+	return compare(got, expected)
+}
+
+// compare encodes both provided slices of metric families into the text format,
+// compares their string message, and returns an error if they do not match.
+// The error contains the encoded text of both the desired and the actual
+// result.
+func compare(got, want []*dto.MetricFamily) error {
+	var gotBuf, wantBuf bytes.Buffer
+	enc := expfmt.NewEncoder(&gotBuf, expfmt.NewFormat(expfmt.TypeTextPlain).WithEscapingScheme(model.NoEscaping))
+	for _, mf := range got {
+		if err := enc.Encode(mf); err != nil {
+			return fmt.Errorf("encoding gathered metrics failed: %w", err)
+		}
+	}
+	enc = expfmt.NewEncoder(&wantBuf, expfmt.NewFormat(expfmt.TypeTextPlain).WithEscapingScheme(model.NoEscaping))
+	for _, mf := range want {
+		if err := enc.Encode(mf); err != nil {
+			return fmt.Errorf("encoding expected metrics failed: %w", err)
+		}
+	}
+	if diffErr := diff.Diff(gotBuf.String(), wantBuf.String()); diffErr != "" {
+		return errors.New(diffErr)
+	}
+	return nil
+}
+
+func filterMetrics(metrics []*dto.MetricFamily, names []string) []*dto.MetricFamily {
+	var filtered []*dto.MetricFamily
+	for _, m := range metrics {
+		for _, name := range names {
+			if m.GetName() == name {
+				filtered = append(filtered, m)
+				break
+			}
+		}
+	}
+	return filtered
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -183,6 +183,9 @@ github.com/kubernetes-csi/external-snapshotter/client/v8/clientset/versioned/typ
 github.com/kubernetes-csi/external-snapshotter/client/v8/clientset/versioned/typed/volumegroupsnapshot/v1beta2/fake
 github.com/kubernetes-csi/external-snapshotter/client/v8/clientset/versioned/typed/volumesnapshot/v1
 github.com/kubernetes-csi/external-snapshotter/client/v8/clientset/versioned/typed/volumesnapshot/v1/fake
+# github.com/kylelemons/godebug v1.1.0
+## explicit; go 1.11
+github.com/kylelemons/godebug/diff
 # github.com/mailru/easyjson v0.9.0
 ## explicit; go 1.20
 github.com/mailru/easyjson/buffer
@@ -229,6 +232,9 @@ github.com/prometheus/client_golang/prometheus/collectors/version
 github.com/prometheus/client_golang/prometheus/internal
 github.com/prometheus/client_golang/prometheus/promhttp
 github.com/prometheus/client_golang/prometheus/promhttp/internal
+github.com/prometheus/client_golang/prometheus/testutil
+github.com/prometheus/client_golang/prometheus/testutil/promlint
+github.com/prometheus/client_golang/prometheus/testutil/promlint/validations
 # github.com/prometheus/client_model v0.6.2
 ## explicit; go 1.22.0
 github.com/prometheus/client_model/go


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Based on #1730.

Migrate the ECS and NAS OpenAPI v2 clients to the SDK's `*WithContext` methods so
the request context (cancellation, deadlines) propagates all the way into the
OpenAPI calls. `ECSv2Interface` and `NasInterface` now expose the `*WithContext`
signatures, `ctx` is threaded through every call site, and the gomock mocks are
regenerated.

##### Motivation

This began as a narrow change — adopt the `*WithContext` SDK methods. But once
`ctx` flows through the client interface, the request-scoped logger
(`klog.FromContext(ctx)`) becomes available *behind* the interface, so logging
can live there instead of at each call site. I prototyped a few approaches and
landed on a per-client **decorator**, rather than the transport-level
`dara.HttpClient` hook the first revision used:

- **The SDK's `HttpClient` extension point is poorly designed for this.** A custom
  `HttpClient` must cache the `*http.Transport` itself or it loses connection
  pooling (the SDK builds a fresh transport per call), and the per-request
  `dara.RuntimeOptions` (timeouts, etc.) are silently dropped at that layer — a
  trap for any future change that sets them.
- **The transport only sees the HTTP view.** The typed Alibaba error code — used
  for the `code` metric label and for call-site control flow — only exists after
  the SDK decodes the response body, so a hook would have to re-parse 4xx bodies
  itself.
- **It misses pre-HTTP failures.** Credential fetch and request signing fail
  before any request goes out, so a transport hook never logs them; the decorator
  wraps the whole call.
- **Cleaner attribution.** The hook had to read the action from a non-canonical
  `x-acs-action` header; the decorator passes the action as a literal and exists
  only on the `*WithContext` path, so it always has a request-scoped logger.

The cost is one wrapper method per interface method, but a generic `logV2` helper
keeps each to a single line with no per-call allocation.

##### What the decorator does

Each v2 client is wrapped in `wrap.ECS` / `wrap.NAS`. Per call it logs:

- `V(2)` (success) / `V(1)` (error): `action`, `elapsed`, `errorCode`, `requestID`
- `V(3)`: `OpenAPI start`
- `V(5)`: full request / response payloads

and records two Prometheus counters — `alibaba_cloud_api_requests_total` and
`alibaba_cloud_api_duration_seconds_total`, labeled `product`, `action`, `code`.
Series are created lazily on first call (not pre-registered), to avoid emitting
the full action set from every node DaemonSet pod, which only ever uses a few.

Error codes are read at call sites with `cloud.ErrorCodeV2(err)`, straight from
the `*tea.SDKError`, so matching does not depend on the decorator having run (the
disk tests pass the raw mock).
The decorator is now constructed in main.go, far from the code that checks the error code.
The dependency is very hard to reason about, so I decided to remove the `errors.Is(err, wrap.ErrorCode)` pattern.
The old curried `wrap.V2`/`V2C` helpers and the
`wrap`-level error-code type are removed; `wrap` now only produces brief, stable
error messages (without the requestID) for efficient k8s event aggregation.

STS and EFLO are out of scope here and keep no OpenAPI logging for now (they were
only ever covered by the transport hook this PR removes).

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

- `cloud.ErrorCodeV2(err)` reads the code from the `*tea.SDKError` regardless of
  wrapping, so call-site correctness (e.g. the error-code switches in `modify.go`)
  no longer depends on the client being decorated.
- Verified with `GOOS=linux go build ./...`, `go vet ./...`, and the `pkg/cloud`,
  `pkg/cloud/wrap`, `pkg/disk`, `pkg/nas/...` unit tests.

#### Does this PR introduce a user-facing change?

```release-note
Alibaba Cloud OpenAPI v2 calls (ECS, NAS) are now logged at the call boundary (action, elapsed, error code, request ID; full request/response at -v=5) and exported via the alibaba_cloud_api_requests_total and alibaba_cloud_api_duration_seconds_total metrics.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```

