### PR TITLE
disk: don't send empty DiskCategory/PerformanceLevel in ModifyDiskSpec

### DIFF
--- a/pkg/disk/modify.go
+++ b/pkg/disk/modify.go
@@ -37,9 +37,13 @@ func (p *ModifyParameters) buildModifySpecRequest(diskID string) *ecs20140526.Mo
 		return nil
 	}
 	req := &ecs20140526.ModifyDiskSpecRequest{
-		DiskId:           new(diskID),
-		DiskCategory:     new(string(p.Category)),
-		PerformanceLevel: new(string(p.PerformanceLevel)),
+		DiskId: &diskID,
+	}
+	if p.Category != "" {
+		req.DiskCategory = new(string(p.Category))
+	}
+	if p.PerformanceLevel != "" {
+		req.PerformanceLevel = new(string(p.PerformanceLevel))
 	}
 	if p.ProvisionedIops != nil {
 		req.ProvisionedIops = new(int64(*p.ProvisionedIops))
@@ -85,7 +89,7 @@ func (m *ModifyServer) waitForTask(ctx context.Context, logger logr.Logger, task
 func (m *ModifyServer) retrieveTask(logger logr.Logger, diskID string) (*ecs20140526.DescribeTasksResponseBodyTaskSetTask, error) {
 	req := &ecs20140526.DescribeTasksRequest{
 		PageSize:    new(int32(1)),
-		ResourceIds: []*string{new(diskID)},
+		ResourceIds: []*string{&diskID},
 		TaskAction:  new("ModifyDiskSpec"),
 	}
 
@@ -224,8 +228,8 @@ func (m *ModifyServer) modifyDiskAttribute(ctx context.Context, logger logr.Logg
 	var err error
 	for range 3 {
 		req := &ecs20140526.ModifyDiskAttributeRequest{
-			DiskId:          new(diskID),
-			BurstingEnabled: new(burstingEnabled),
+			DiskId:          &diskID,
+			BurstingEnabled: &burstingEnabled,
 		}
 
 		_, err = wrap.V2(logger, m.ecsClient.ModifyDiskAttribute)(req)
@@ -279,7 +283,7 @@ func (m *ModifyServer) Modify(ctx context.Context, diskID string, params ModifyP
 	if len(params.RemoveTags) > 0 {
 		req := &ecs20140526.UntagResourcesRequest{
 			ResourceType: new("disk"),
-			ResourceId:   []*string{new(diskID)},
+			ResourceId:   []*string{&diskID},
 			TagKey:       params.RemoveTags,
 		}
 
@@ -293,7 +297,7 @@ func (m *ModifyServer) Modify(ctx context.Context, diskID string, params ModifyP
 	if len(params.Tags) > 0 {
 		req := &ecs20140526.TagResourcesRequest{
 			ResourceType: new("disk"),
-			ResourceId:   []*string{new(diskID)},
+			ResourceId:   []*string{&diskID},
 			Tag:          params.Tags,
 		}
 

--- a/pkg/disk/modify_test.go
+++ b/pkg/disk/modify_test.go
@@ -57,8 +57,15 @@ func sdkError(code string) error {
 func TestModify_HappyPath(t *testing.T) {
 	c, m := newTestModifyServer(t)
 
-	// 1. verifyModifyDiskSpec: dry-run returns DryRunOperation → dirty=true
-	c.EXPECT().ModifyDiskSpec(gomock.Any()).Return(nil, sdkError("DryRunOperation"))
+	// 1. verifyModifyDiskSpec: dry-run returns DryRunOperation → dirty=true.
+	// Assert the exact request: the empty PerformanceLevel must be omitted,
+	// otherwise ECS rejects it with InvalidDiskCategory.NotSupported.
+	c.EXPECT().ModifyDiskSpec(&ecs20140526.ModifyDiskSpecRequest{
+		DiskId:          new("d-test"),
+		DiskCategory:    new("cloud_auto"),
+		ProvisionedIops: new(int64(1000)),
+		DryRun:          new(true),
+	}).Return(nil, sdkError("DryRunOperation"))
 
 	// 2. UntagResources
 	c.EXPECT().UntagResources(gomock.Any()).Return(&ecs20140526.UntagResourcesResponse{}, nil)
@@ -290,4 +297,60 @@ func TestModify_TagsOnly(t *testing.T) {
 		RemoveTags: []*string{new("tag1")},
 	})
 	require.NoError(t, err)
+}
+
+func TestBuildModifySpecRequest(t *testing.T) {
+	// Empty Category/PerformanceLevel must NOT be sent: the v2 SDK serializes
+	// pointers to empty strings, and passing e.g. an empty PerformanceLevel
+	// alongside DiskCategory=cloud_auto makes ECS reject the request with
+	// InvalidDiskCategory.NotSupported.
+	cases := []struct {
+		name     string
+		params   ModifyParameters
+		wantNil  bool
+		category *string
+		level    *string
+		iops     *int64
+	}{
+		{
+			name:    "all empty",
+			params:  ModifyParameters{},
+			wantNil: true,
+		},
+		{
+			name:   "iops only",
+			params: ModifyParameters{ProvisionedIops: new(10)},
+			iops:   new(int64(10)),
+		},
+		{
+			name:     "category only",
+			params:   ModifyParameters{Category: DiskESSDAuto},
+			category: new("cloud_auto"),
+		},
+		{
+			name:   "performance level only",
+			params: ModifyParameters{PerformanceLevel: PERFORMANCE_LEVEL1},
+			level:  new("PL1"),
+		},
+		{
+			name:     "category and level",
+			params:   ModifyParameters{Category: DiskESSD, PerformanceLevel: PERFORMANCE_LEVEL2},
+			category: new("cloud_essd"),
+			level:    new("PL2"),
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			req := c.params.buildModifySpecRequest("d-test")
+			if c.wantNil {
+				assert.Nil(t, req)
+				return
+			}
+			require.NotNil(t, req)
+			assert.Equal(t, new("d-test"), req.DiskId)
+			assert.Equal(t, c.category, req.DiskCategory)
+			assert.Equal(t, c.level, req.PerformanceLevel)
+			assert.Equal(t, c.iops, req.ProvisionedIops)
+		})
+	}
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind regression

#### What this PR does / why we need it:

`buildModifySpecRequest` unconditionally set `DiskCategory` and `PerformanceLevel` on the `ModifyDiskSpec` request, even when the corresponding `ModifyParameters` fields were empty.

This was fine with the legacy v1 SDK (`alibaba-cloud-sdk-go`), which stored these as plain string values and omitted empty-string query parameters. After the migration to the v2 SDK (`ecs-20140526/v7`) in a112567, the fields became pointers and `new(string(""))` is a non-nil pointer to an empty string, which the v2 SDK *does* serialize.

As a result, modifying a `cloud_auto` disk (which does not support performance levels) with only `provisionedIops` still sent `PerformanceLevel=`, and ECS rejected the request:

```
OpenAPI returned error: The specified disk category is not supported. (InvalidDiskCategory.NotSupported)
```

This broke the csi-sanity `ModifyVolume` tests:
- `should modify a volume created without a volume attribute class`
- `should modify a volume created with a volume attribute class`

The fix only sets `DiskCategory`/`PerformanceLevel` when non-empty, restoring the v1 behavior.

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

Tests added/strengthened, both verified to fail against the buggy version and pass with the fix:
- `TestBuildModifySpecRequest`: directly covers the empty `DiskCategory`/`PerformanceLevel` cases.
- `TestModify_HappyPath`: tightened the previously `gomock.Any()` `ModifyDiskSpec` expectation to assert the exact request, so an empty `PerformanceLevel` leaking through is caught at the `Modify()` level.

#### Does this PR introduce a user-facing change?

No release note, this feature is not released yet.
```release-note
NONE
```
