### PR TITLE
ecs: send RegionId on RPC-style v2 SDK requests

### DIFF
--- a/pkg/utils/openapi.go
+++ b/pkg/utils/openapi.go
@@ -46,8 +46,22 @@ func getOpenAPIConfig(regionID string) *openapi.Config {
 	return config
 }
 
-func GetStsConfig(regionID string) *openapi.Config {
+// getRPCConfig builds a config for RPC-style products. The v2 SDK does not send
+// RegionId automatically (config.RegionId is only used for endpoint
+// resolution), but the v1 SDK we migrated from injected RegionId into every RPC
+// request (see signRpcRequest) and our clients rely on it, e.g. ECS
+// TagResources requires it. Inject it as a global query parameter to restore
+// that behavior; a per-request RegionId still overrides this default.
+func getRPCConfig(regionID string) *openapi.Config {
 	config := getOpenAPIConfig(regionID)
+	config.GlobalParameters = &openapi.GlobalParameters{
+		Queries: map[string]*string{"RegionId": &regionID},
+	}
+	return config
+}
+
+func GetStsConfig(regionID string) *openapi.Config {
+	config := getRPCConfig(regionID)
 	if e := os.Getenv("STS_ENDPOINT"); e != "" {
 		config.Endpoint = &e
 	}
@@ -55,7 +69,7 @@ func GetStsConfig(regionID string) *openapi.Config {
 }
 
 func GetEcsConfig(regionID string) *openapi.Config {
-	config := getOpenAPIConfig(regionID)
+	config := getRPCConfig(regionID)
 	if e := os.Getenv("ECS_ENDPOINT"); e != "" {
 		config.Endpoint = &e
 	} else {
@@ -75,7 +89,7 @@ func GetEfloControllerConfig(regionID string) *openapi.Config {
 		regionID = r
 	}
 
-	config := getOpenAPIConfig(regionID)
+	config := getRPCConfig(regionID)
 	if e := os.Getenv("EFLO_CONTROLLER_ENDPOINT"); e != "" {
 		config.Endpoint = &e
 	}

--- a/pkg/utils/openapi_test.go
+++ b/pkg/utils/openapi_test.go
@@ -79,6 +79,16 @@ func TestEcsEndpoint(t *testing.T) {
 	})
 }
 
+func TestEcsConfigRegionId(t *testing.T) {
+	// The v2 SDK does not auto-fill RegionId; it must be injected as a global
+	// query parameter, otherwise region-mandatory APIs like TagResources fail
+	// with MissingParameter.
+	cfg := GetEcsConfig("cn-hangzhou")
+	if assert.NotNil(t, cfg.GlobalParameters) {
+		assert.Equal(t, ptr.To("cn-hangzhou"), cfg.GlobalParameters.Queries["RegionId"])
+	}
+}
+
 func TestEfloControllerConfig(t *testing.T) {
 	cases := []struct {
 		network  string


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind regression

#### What this PR does / why we need it:

Follow-up to #1740. The disk `ModifyVolume` path has a second regression from the ECS SDK v1→v2 migration.

The v1 SDK injected `RegionId` into every **RPC** request (see `signRpcRequest`), and our clients relied on it. The v2 SDK only uses `config.RegionId` for endpoint resolution and does not send it as a request parameter, so region-mandatory APIs such as `TagResources` fail:

```
The input parameter "RegionId" that is mandatory for processing this request is not supplied. (MissingParameter)
```

This broke the csi-sanity `ModifyVolume` tests at the tagging step (after the `InvalidDiskCategory` issue fixed in #1740).

Fix: add a `getRPCConfig` helper that injects `RegionId` as a global query parameter, and route the RPC-style clients (ECS, STS, EFLO) through it. A per-request `RegionId` still overrides the default (SDK merge order: global queries are applied before request queries), so existing cross-region calls are unaffected.

`getOpenAPIConfig` stays unchanged for ROA-style clients — v1 never sent `RegionId` for ROA requests (`signRoaRequest` doesn't touch it), so keeping the injection in an explicit RPC-only helper preserves that distinction for any future ROA client.

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

- `TestEcsConfigRegionId` asserts the `RegionId` global query parameter is set.
- All clients built via `getRPCConfig` (ECS/STS/EFLO) and NAS are RPC-style; there are currently no ROA-style clients.

#### Does this PR introduce a user-facing change?

No release note, this feature is not released yet.
```release-note
NONE
```