### PR TITLE
cloud: reject broken lingjun_config

### DIFF
--- a/pkg/cloud/metadata/lingjun.go
+++ b/pkg/cloud/metadata/lingjun.go
@@ -15,7 +15,7 @@ type LingjunMetaData struct {
 	InstanceType string `json:"InstanceType"`
 }
 
-func NewLingJunMetadata(lingjunConfigFile string) (*LingjunMetaData, error) {
+func NewLingJunMetadata(lingjunConfigFile string) *LingjunMetaData {
 	data, err := os.ReadFile(lingjunConfigFile)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
@@ -23,15 +23,19 @@ func NewLingJunMetadata(lingjunConfigFile string) (*LingjunMetaData, error) {
 		} else {
 			klog.ErrorS(err, "Failed to read lingjun metadata file", "file", lingjunConfigFile)
 		}
-		return nil, err
+		return nil
 	}
 	var lm LingjunMetaData
 	err = json.Unmarshal(data, &lm)
 	if err != nil {
 		klog.ErrorS(err, "Failed to parse lingjun metadata file", "file", lingjunConfigFile)
-		return nil, err
+		return nil
 	}
-	return &lm, nil
+	if lm.RegionId == "" || lm.ZoneId == "" || lm.NodeId == "" || lm.InstanceType == "" {
+		klog.ErrorS(err, "Invalid lingjun metadata file", "file", lingjunConfigFile)
+		return nil
+	}
+	return &lm
 }
 
 func (m *LingjunMetaData) GetAny(_ *mcontext, key MetadataKey) (any, error) {

--- a/pkg/cloud/metadata/lingjun_test.go
+++ b/pkg/cloud/metadata/lingjun_test.go
@@ -32,8 +32,7 @@ func TestNewLingJunMetadata(t *testing.T) {
 		require.NoError(t, os.WriteFile(lingjunConfigFile, []byte(LingjunConfigJson), 0644))
 
 		// Test the function
-		result, err := NewLingJunMetadata(lingjunConfigFile)
-		require.NoError(t, err)
+		result := NewLingJunMetadata(lingjunConfigFile)
 		require.NotNil(t, result)
 
 		m := testMetadata(t, result)
@@ -54,9 +53,7 @@ func TestNewLingJunMetadata(t *testing.T) {
 		tempDir := t.TempDir()
 		lingjunConfigFile := filepath.Join(tempDir, "non_existent_file")
 
-		result, err := NewLingJunMetadata(lingjunConfigFile)
-		assert.Error(t, err)
-		assert.True(t, os.IsNotExist(err))
+		result := NewLingJunMetadata(lingjunConfigFile)
 		assert.Nil(t, result)
 	})
 
@@ -64,9 +61,7 @@ func TestNewLingJunMetadata(t *testing.T) {
 		// Test with a directory path instead of a file
 		tempDir := t.TempDir()
 
-		result, err := NewLingJunMetadata(tempDir) // Pass directory instead of file
-		assert.Error(t, err)
-		assert.False(t, os.IsNotExist(err)) // Not a "not exist" error
+		result := NewLingJunMetadata(tempDir) // Pass directory instead of file
 		assert.Nil(t, result)
 	})
 
@@ -75,11 +70,19 @@ func TestNewLingJunMetadata(t *testing.T) {
 		tempDir := t.TempDir()
 		lingjunConfigFile := filepath.Join(tempDir, "lingjun_config_invalid")
 
-		err := os.WriteFile(lingjunConfigFile, []byte("{ invalid json }"), 0644)
-		require.NoError(t, err)
+		require.NoError(t, os.WriteFile(lingjunConfigFile, []byte("{ invalid json }"), 0644))
 
-		result, err := NewLingJunMetadata(lingjunConfigFile)
-		assert.Error(t, err)
+		result := NewLingJunMetadata(lingjunConfigFile)
+		assert.Nil(t, result)
+	})
+
+	t.Run("missing fields", func(t *testing.T) {
+		tempDir := t.TempDir()
+		lingjunConfigFile := filepath.Join(tempDir, "lingjun_config")
+
+		require.NoError(t, os.WriteFile(lingjunConfigFile, []byte("{}"), 0644))
+
+		result := NewLingJunMetadata(lingjunConfigFile)
 		assert.Nil(t, result)
 	})
 }

--- a/pkg/cloud/metadata/metadata.go
+++ b/pkg/cloud/metadata/metadata.go
@@ -286,7 +286,7 @@ func NewMetadata() *Metadata {
 	providers := multi{
 		newImmutable(strProvider{ENVMetadata{}}, "env"),
 	}
-	lm, _ := NewLingJunMetadata(LingjunConfigFile)
+	lm := NewLingJunMetadata(LingjunConfigFile)
 	if lm != nil { // error is already logged
 		providers = append(providers, newImmutable(lm, "lingjun"))
 	}


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Some strange host also have this file

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Validate required fields are present in lingjun_config
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
