### PR TITLE
Replace bmcpfs VSC workqueue/condvar with TTLCache + Throttler

### DIFF
--- a/pkg/bmcpfs/controllerserver.go
+++ b/pkg/bmcpfs/controllerserver.go
@@ -246,7 +246,7 @@ func (cs *controllerServer) ControllerPublishVolume(ctx context.Context, req *cs
 	}
 
 	// Get Primary VSC for the node (Lingjun or ECS w/ VSC enabled)
-	vscID, err := cs.vscManager.EnsurePrimaryVsc(ctx, instanceID, false)
+	vscID, err := cs.vscManager.EnsurePrimaryVsc(ctx, instanceID)
 	if err != nil {
 		return nil, status.Error(codes.Internal, err.Error())
 	}
@@ -287,7 +287,7 @@ func (cs *controllerServer) ControllerUnpublishVolume(ctx context.Context, req *
 	if !kind.supportsVSC() || cs.skipDetach {
 		return &csi.ControllerUnpublishVolumeResponse{}, nil
 	}
-	vsc, err := cs.vscManager.GetPrimaryVscOf(instanceID)
+	vsc, err := cs.vscManager.GetPrimaryVscOf(ctx, instanceID)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "get vsc error: %v", err)
 	}

--- a/pkg/bmcpfs/internal/vsc.go
+++ b/pkg/bmcpfs/internal/vsc.go
@@ -21,18 +21,24 @@ import (
 	"errors"
 	"fmt"
 	"strings"
-	"sync"
 	"time"
 
 	ecsClient "github.com/alibabacloud-go/ecs-20140526/v7/client"
 	efloClient "github.com/alibabacloud-go/eflo-controller-20221215/v3/client"
 	nasclient "github.com/alibabacloud-go/nas-20170626/v4/client"
 	"github.com/alibabacloud-go/tea/tea"
-	"golang.org/x/time/rate"
-	"k8s.io/client-go/util/workqueue"
+	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/cloud/throttle"
+	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/utils/ttlcache"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/clock"
 )
+
+// newVscThrottler builds a reactive backoff throttler for a single VSC OpenAPI
+// action. VSC clients use the new tea SDK, so we classify with V2Classifier.
+// Delays mirror pkg/disk's defaults.
+func newVscThrottler() *throttle.Throttler {
+	return throttle.NewThrottler(clock.RealClock{}, 1*time.Second, 10*time.Second, throttle.V2Classifier)
+}
 
 // vscDialect captures backend-specific values for VSC type/status enums
 // that are conceptually identical between Lingjun (eflo) and ECS backends
@@ -68,23 +74,23 @@ type Vsc struct {
 
 // VscBackend is the interface each cloud backend implements independently.
 type VscBackend interface {
-	CreatePrimaryVsc(instanceId string) (string, error)
-	GetPrimaryVscOf(instanceId string) (*Vsc, error)
-	GetVsc(vscId string) (*Vsc, error)
+	CreatePrimaryVsc(ctx context.Context, instanceId string) (string, error)
+	GetPrimaryVscOf(ctx context.Context, instanceId string) (*Vsc, error)
+	GetVsc(ctx context.Context, vscId string) (*Vsc, error)
 }
 
 type VscManager interface {
-	CreatePrimaryVscFor(instanceId string) (string, error)
-	GetPrimaryVscOf(instanceId string) (*Vsc, error)
+	CreatePrimaryVscFor(ctx context.Context, instanceId string) (string, error)
+	GetPrimaryVscOf(ctx context.Context, instanceId string) (*Vsc, error)
 	// GetVsc retrieves a single VSC by ID. The instanceId is used only for
 	// routing to the correct backend; individual backends do not need it.
-	GetVsc(vscId, instanceId string) (*Vsc, error)
+	GetVsc(ctx context.Context, vscId, instanceId string) (*Vsc, error)
 }
 
 func NewVscManager(eflo *efloClient.Client, ecs *ecsClient.Client) VscManager {
 	return &dispatchingVscManager{
-		eflo: &efloVscBackend{client: eflo},
-		ecs:  &ecsVscBackend{client: ecs},
+		eflo: newEfloVscBackend(eflo),
+		ecs:  newEcsVscBackend(ecs),
 	}
 }
 
@@ -101,29 +107,41 @@ func (m *dispatchingVscManager) backendFor(instanceId string) VscBackend {
 	return m.eflo
 }
 
-func (m *dispatchingVscManager) CreatePrimaryVscFor(instanceId string) (string, error) {
-	return m.backendFor(instanceId).CreatePrimaryVsc(instanceId)
+func (m *dispatchingVscManager) CreatePrimaryVscFor(ctx context.Context, instanceId string) (string, error) {
+	return m.backendFor(instanceId).CreatePrimaryVsc(ctx, instanceId)
 }
 
-func (m *dispatchingVscManager) GetPrimaryVscOf(instanceId string) (*Vsc, error) {
-	return m.backendFor(instanceId).GetPrimaryVscOf(instanceId)
+func (m *dispatchingVscManager) GetPrimaryVscOf(ctx context.Context, instanceId string) (*Vsc, error) {
+	return m.backendFor(instanceId).GetPrimaryVscOf(ctx, instanceId)
 }
 
-func (m *dispatchingVscManager) GetVsc(vscId, instanceId string) (*Vsc, error) {
-	return m.backendFor(instanceId).GetVsc(vscId)
+func (m *dispatchingVscManager) GetVsc(ctx context.Context, vscId, instanceId string) (*Vsc, error) {
+	return m.backendFor(instanceId).GetVsc(ctx, vscId)
 }
 
 // efloVscBackend implements VscBackend for Lingjun (eflo) nodes.
 type efloVscBackend struct {
-	client *efloClient.Client
+	client            *efloClient.Client
+	createThrottler   *throttle.Throttler
+	listThrottler     *throttle.Throttler
+	describeThrottler *throttle.Throttler
 }
 
-func (b *efloVscBackend) CreatePrimaryVsc(instanceId string) (string, error) {
+func newEfloVscBackend(client *efloClient.Client) *efloVscBackend {
+	return &efloVscBackend{
+		client:            client,
+		createThrottler:   newVscThrottler(),
+		listThrottler:     newVscThrottler(),
+		describeThrottler: newVscThrottler(),
+	}
+}
+
+func (b *efloVscBackend) CreatePrimaryVsc(ctx context.Context, instanceId string) (string, error) {
 	req := &efloClient.CreateVscRequest{
 		NodeId:  &instanceId,
 		VscType: tea.String(efloVscDialect.PrimaryType),
 	}
-	resp, err := b.client.CreateVsc(req)
+	resp, err := throttle.Throttled(b.createThrottler, b.client.CreateVsc)(ctx, req)
 	if err != nil {
 		return "", fmt.Errorf("eflo:CreateVsc failed: %w", err)
 	}
@@ -134,12 +152,12 @@ func (b *efloVscBackend) CreatePrimaryVsc(instanceId string) (string, error) {
 	return tea.StringValue(resp.Body.VscId), nil
 }
 
-func (b *efloVscBackend) GetPrimaryVscOf(instanceId string) (*Vsc, error) {
+func (b *efloVscBackend) GetPrimaryVscOf(ctx context.Context, instanceId string) (*Vsc, error) {
 	req := &efloClient.ListVscsRequest{
 		NodeIds:    []*string{&instanceId},
 		MaxResults: tea.Int32(100),
 	}
-	resp, err := b.client.ListVscs(req)
+	resp, err := throttle.Throttled(b.listThrottler, b.client.ListVscs)(ctx, req)
 	if err != nil {
 		return nil, fmt.Errorf("eflo:ListVscs failed: %w", err)
 	}
@@ -157,11 +175,11 @@ func (b *efloVscBackend) GetPrimaryVscOf(instanceId string) (*Vsc, error) {
 	return nil, nil
 }
 
-func (b *efloVscBackend) GetVsc(vscId string) (*Vsc, error) {
+func (b *efloVscBackend) GetVsc(ctx context.Context, vscId string) (*Vsc, error) {
 	req := &efloClient.DescribeVscRequest{
 		VscId: &vscId,
 	}
-	resp, err := b.client.DescribeVsc(req)
+	resp, err := throttle.Throttled(b.describeThrottler, b.client.DescribeVsc)(ctx, req)
 	if err != nil {
 		return nil, fmt.Errorf("eflo:DescribeVsc failed: %w", err)
 	}
@@ -176,15 +194,25 @@ func (b *efloVscBackend) GetVsc(vscId string) (*Vsc, error) {
 
 // ecsVscBackend implements VscBackend for ECS nodes with VSC enabled.
 type ecsVscBackend struct {
-	client *ecsClient.Client
+	client            *ecsClient.Client
+	createThrottler   *throttle.Throttler
+	describeThrottler *throttle.Throttler
 }
 
-func (b *ecsVscBackend) CreatePrimaryVsc(instanceId string) (string, error) {
+func newEcsVscBackend(client *ecsClient.Client) *ecsVscBackend {
+	return &ecsVscBackend{
+		client:            client,
+		createThrottler:   newVscThrottler(),
+		describeThrottler: newVscThrottler(),
+	}
+}
+
+func (b *ecsVscBackend) CreatePrimaryVsc(ctx context.Context, instanceId string) (string, error) {
 	req := &ecsClient.CreateVscRequest{
 		InstanceId: &instanceId,
 		VscType:    tea.String(ecsVscDialect.PrimaryType),
 	}
-	resp, err := b.client.CreateVsc(req)
+	resp, err := throttle.Throttled(b.createThrottler, b.client.CreateVsc)(ctx, req)
 	if err != nil {
 		return "", fmt.Errorf("ecs:CreateVsc failed: %w", err)
 	}
@@ -195,12 +223,12 @@ func (b *ecsVscBackend) CreatePrimaryVsc(instanceId string) (string, error) {
 	return tea.StringValue(resp.Body.VscId), nil
 }
 
-func (b *ecsVscBackend) GetPrimaryVscOf(instanceId string) (*Vsc, error) {
+func (b *ecsVscBackend) GetPrimaryVscOf(ctx context.Context, instanceId string) (*Vsc, error) {
 	req := &ecsClient.DescribeVscsRequest{
 		InstanceId: &instanceId,
 		MaxResults: tea.Int32(100),
 	}
-	resp, err := b.client.DescribeVscs(req)
+	resp, err := throttle.Throttled(b.describeThrottler, b.client.DescribeVscs)(ctx, req)
 	if err != nil {
 		return nil, fmt.Errorf("ecs:DescribeVscs failed: %w", err)
 	}
@@ -218,11 +246,11 @@ func (b *ecsVscBackend) GetPrimaryVscOf(instanceId string) (*Vsc, error) {
 	return nil, nil
 }
 
-func (b *ecsVscBackend) GetVsc(vscId string) (*Vsc, error) {
+func (b *ecsVscBackend) GetVsc(ctx context.Context, vscId string) (*Vsc, error) {
 	req := &ecsClient.DescribeVscsRequest{
 		VscIds: []*string{&vscId},
 	}
-	resp, err := b.client.DescribeVscs(req)
+	resp, err := throttle.Throttled(b.describeThrottler, b.client.DescribeVscs)(ctx, req)
 	if err != nil {
 		return nil, fmt.Errorf("ecs:DescribeVscs failed: %w", err)
 	}
@@ -238,176 +266,131 @@ func (b *ecsVscBackend) GetVsc(vscId string) (*Vsc, error) {
 	}, nil
 }
 
-type vscWithErr struct {
-	*Vsc
-	err      error
-	cachedAt time.Time
-}
+// errVscNotFound is a sentinel returned by the readCache producer when the
+// backend reports no primary VSC for an instance. TTLCache does not cache
+// errors, so returning it keeps "not found" out of the positive cache (the
+// absence might be transient) while still deduplicating concurrent lookups.
+var errVscNotFound = errors.New("primary vsc not found")
 
-func (v *vscWithErr) isExpired(ttl time.Duration) bool {
-	return time.Since(v.cachedAt) > ttl
-}
-
+// PrimaryVscManagerWithCache adds single-flight TTL caching on top of a
+// VscManager. Concurrency is reactive: requests are sent freely and each
+// backend action backs off only when the cloud actually throttles it (see
+// newVscThrottler), rather than being capped by a fixed worker pool.
 type PrimaryVscManagerWithCache struct {
 	VscManager
-	retryTimes int
-	cacheTTL   time.Duration
 
-	cond *sync.Cond
-	// Instance ID to VSC
-	cache map[string]vscWithErr
-	// To create primary vsc for node
-	queue workqueue.TypedRateLimitingInterface[string]
+	// vscCache is the single VSC cache, shared by GetPrimaryVscOf (read-through)
+	// and EnsurePrimaryVsc (write-through on a confirmed VSC), so a publish warms
+	// the cache that a later unpublish reads.
+	vscCache *ttlcache.TTLCache[string, *Vsc]
+	// createVsc single-flights EnsurePrimaryVsc per instance so concurrent
+	// publishes for a new node create only one VSC. Its TTL is 0: it never caches
+	// (vscCache is the cache), it only serializes in-flight creates.
+	createVsc *ttlcache.TTLCache[string, *Vsc]
+
+	clk          clock.Clock
+	pollInterval time.Duration
+	// pollAttempts is how many times getOrCreatePrimaryFor polls GetVsc for the
+	// expected status. Must be >= 1, so a freshly created VSC (not fetched before
+	// the loop) is always fetched at least once.
+	pollAttempts int
 }
 
 const (
-	defaultVscManagerRetryTimes  = 3
-	defaultVscManagerWorkerCount = 3
-	defaultVscCacheTTL           = 3 * time.Minute
+	defaultVscCacheTTL     = 3 * time.Minute
+	defaultVscPollInterval = 2 * time.Second
+	// defaultVscPollAttempts bounds in-process polling of a freshly created VSC
+	// until it reaches the expected status.
+	defaultVscPollAttempts = 5
 )
 
 func NewPrimaryVscManagerWithCache(efloClient *efloClient.Client, ecsClient *ecsClient.Client) *PrimaryVscManagerWithCache {
-	m := &PrimaryVscManagerWithCache{
-		VscManager: NewVscManager(efloClient, ecsClient),
-		retryTimes: defaultVscManagerRetryTimes,
-		cacheTTL:   defaultVscCacheTTL,
-		cond:       sync.NewCond(&sync.Mutex{}),
-		cache:      make(map[string]vscWithErr),
-		queue: workqueue.NewTypedRateLimitingQueue(
-			workqueue.NewTypedMaxOfRateLimiter(
-				workqueue.NewTypedItemExponentialFailureRateLimiter[string](500*time.Millisecond, 1000*time.Second),
-				&workqueue.TypedBucketRateLimiter[string]{Limiter: rate.NewLimiter(rate.Limit(10), 100)},
-			),
-		),
+	return &PrimaryVscManagerWithCache{
+		VscManager:   NewVscManager(efloClient, ecsClient),
+		vscCache:     ttlcache.NewTTLCache[string, *Vsc](defaultVscCacheTTL),
+		createVsc:    ttlcache.NewTTLCache[string, *Vsc](0),
+		clk:          clock.RealClock{},
+		pollInterval: defaultVscPollInterval,
+		pollAttempts: defaultVscPollAttempts,
 	}
-
-	for range defaultVscManagerWorkerCount {
-		go func() {
-			for m.handleNext() {
-			}
-		}()
-	}
-	return m
 }
 
-func (m *PrimaryVscManagerWithCache) handleNext() bool {
-	instanceId, quit := m.queue.Get()
-	if quit {
-		return false
-	}
-	defer m.queue.Done(instanceId)
-
-	newVsc, err := m.getOrCreatePrimaryFor(instanceId)
-
-	m.cond.L.Lock()
-	m.cache[instanceId] = vscWithErr{Vsc: newVsc, err: err, cachedAt: time.Now()}
-	m.cond.L.Unlock()
-
-	if err == nil {
-		m.queue.Forget(instanceId)
-		m.cond.Broadcast()
-	} else {
-		sdkErr := &tea.SDKError{}
-		if errors.As(err, &sdkErr) || m.queue.NumRequeues(instanceId) > m.retryTimes {
-			klog.ErrorS(err, "Failed to ensure VSC", "instance", instanceId)
-			m.queue.Forget(instanceId)
-			m.cond.Broadcast()
-		} else {
-			klog.InfoS("Retrying to ensure VSC", "instance", instanceId, "error", err)
-			m.queue.AddRateLimited(instanceId)
-		}
-	}
-	return true
-}
-
-func (m *PrimaryVscManagerWithCache) getOrCreatePrimaryFor(instanceId string) (*Vsc, error) {
-	var err error
-	// try to get existing vsc
-	vsc, err := m.VscManager.GetPrimaryVscOf(instanceId)
+func (m *PrimaryVscManagerWithCache) EnsurePrimaryVsc(ctx context.Context, instanceId string) (string, error) {
+	vsc, err := m.createVsc.Get(ctx, instanceId, func() (*Vsc, error) {
+		// Decouple the shared computation from any single caller's cancellation;
+		// concurrent waiters still cancel their own wait via the ctx passed to Get.
+		return m.getOrCreatePrimaryFor(context.WithoutCancel(ctx), instanceId)
+	})
 	if err != nil {
-		return nil, err
+		return "", err
 	}
-	// primary vsc of the instance not found, create it
-	var vscId string
-	if vsc == nil {
-		vscId, err = m.CreatePrimaryVscFor(instanceId)
+	return vsc.VscID, nil
+}
+
+func (m *PrimaryVscManagerWithCache) GetPrimaryVscOf(ctx context.Context, instanceId string) (*Vsc, error) {
+	vsc, err := m.vscCache.Get(ctx, instanceId, func() (*Vsc, error) {
+		vsc, err := m.VscManager.GetPrimaryVscOf(ctx, instanceId)
 		if err != nil {
 			return nil, err
 		}
-		vsc, err = m.GetVsc(vscId, instanceId)
-		if err != nil {
-			return nil, err
+		if vsc == nil {
+			return nil, errVscNotFound
 		}
+		return vsc, nil
+	})
+	if errors.Is(err, errVscNotFound) {
+		return nil, nil
 	}
-	if vsc == nil {
-		return nil, fmt.Errorf("vsc %s not found after creation", vscId)
-	}
-	// check vsc status
+	return vsc, err
+}
+
+func (m *PrimaryVscManagerWithCache) getOrCreatePrimaryFor(ctx context.Context, instanceId string) (*Vsc, error) {
 	expected := efloVscDialect.StatusNormal
 	if isECSInstance(instanceId) {
 		expected = ecsVscDialect.StatusNormal
 	}
-	if vsc.Status != expected {
-		return vsc, fmt.Errorf("unexpected vsc status: %s", vsc.Status)
-	}
-	return vsc, nil
-}
 
-func (m *PrimaryVscManagerWithCache) EnsurePrimaryVsc(ctx context.Context, instanceId string, refresh bool) (string, error) {
-	m.cond.L.Lock()
-	defer m.cond.L.Unlock()
-
-	if !refresh {
-		vsc, exists := m.cache[instanceId]
-		if exists && vsc.err == nil && !vsc.isExpired(m.cacheTTL) {
-			return vsc.VscID, nil
-		}
-	}
-
-	delete(m.cache, instanceId)
-	m.queue.Add(instanceId)
-	for {
-		vsc, exists := m.cache[instanceId]
-		if exists {
-			var vscId string
-			if vsc.Vsc != nil {
-				vscId = vsc.VscID
-			}
-			return vscId, vsc.err
-		}
-		select {
-		case <-ctx.Done():
-			return "", ctx.Err()
-		default:
-			m.cond.Wait()
-		}
-	}
-}
-
-func (m *PrimaryVscManagerWithCache) GetPrimaryVscOf(instanceId string) (*Vsc, error) {
-	m.cond.L.Lock()
-	cachedVsc, exists := m.cache[instanceId]
-	if exists && cachedVsc.Vsc != nil && !cachedVsc.isExpired(m.cacheTTL) {
-		m.cond.L.Unlock()
-		return cachedVsc.Vsc, nil
-	}
-	m.cond.L.Unlock()
-
-	vsc, err := m.VscManager.GetPrimaryVscOf(instanceId)
+	// try to get existing vsc (through the read cache)
+	vsc, err := m.GetPrimaryVscOf(ctx, instanceId)
 	if err != nil {
 		return nil, err
 	}
 
-	// update the cache
+	var vscID string
 	if vsc != nil {
-		m.cond.L.Lock()
-		clonedVsc := new(Vsc)
-		*clonedVsc = *vsc
-		m.cache[instanceId] = vscWithErr{Vsc: clonedVsc, err: nil, cachedAt: time.Now()}
-		m.cond.L.Unlock()
+		if vsc.Status == expected {
+			return vsc, nil // already usable; GetPrimaryVscOf cached it
+		}
+		vscID = vsc.VscID
+	} else {
+		// primary vsc of the instance not found, create it
+		vscID, err = m.CreatePrimaryVscFor(ctx, instanceId)
+		if err != nil {
+			return nil, err
+		}
 	}
 
-	return vsc, nil
+	// A freshly created (or not-yet-ready) VSC may take a moment to become
+	// usable; poll GetVsc a bounded number of times until it reaches expected.
+	for range m.pollAttempts {
+		select {
+		case <-ctx.Done():
+			return vsc, ctx.Err()
+		case <-m.clk.After(m.pollInterval):
+		}
+		if vsc, err = m.GetVsc(ctx, vscID, instanceId); err != nil {
+			return nil, err
+		}
+		if vsc == nil {
+			return nil, fmt.Errorf("vsc %s not found after creation", vscID)
+		}
+		if vsc.Status == expected {
+			m.vscCache.Store(instanceId, vsc)
+			return vsc, nil
+		}
+	}
+	// pollAttempts >= 1, so the loop ran at least once and vsc is non-nil here.
+	return vsc, fmt.Errorf("unexpected vsc status: %s", vsc.Status)
 }
 
 const (

--- a/pkg/bmcpfs/internal/vsc_test.go
+++ b/pkg/bmcpfs/internal/vsc_test.go
@@ -22,13 +22,14 @@ import (
 	"fmt"
 	"sync"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/alibabacloud-go/tea/tea"
+	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/utils/ttlcache"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/time/rate"
-	"k8s.io/client-go/util/workqueue"
+	"k8s.io/utils/clock"
 )
 
 func TestAttachNotSupportedError_Error(t *testing.T) {
@@ -106,20 +107,6 @@ func TestVscDialectValues(t *testing.T) {
 	assert.Equal(t, "In_use", ecsVscDialect.StatusNormal)
 }
 
-func TestVscWithErr_IsExpired(t *testing.T) {
-	ttl := 100 * time.Millisecond
-
-	fresh := vscWithErr{cachedAt: time.Now()}
-	assert.False(t, fresh.isExpired(ttl), "freshly cached value should not be expired")
-
-	stale := vscWithErr{cachedAt: time.Now().Add(-2 * ttl)}
-	assert.True(t, stale.isExpired(ttl), "value older than ttl should be expired")
-
-	// Zero cachedAt means "never cached" -> always expired against any positive ttl.
-	never := vscWithErr{}
-	assert.True(t, never.isExpired(ttl))
-}
-
 func TestDefaultVscCacheTTL(t *testing.T) {
 	// Ensure the documented 5-minute default isn't accidentally lowered.
 	assert.GreaterOrEqual(t, defaultVscCacheTTL, 3*time.Minute)
@@ -141,6 +128,12 @@ type fakeVscManager struct {
 	getErr    error
 	getOneErr error
 
+	// notReadyGetVscCalls: the first N GetVsc calls report notReadyStatus instead
+	// of the stored status, to simulate a freshly created VSC settling. When 0,
+	// GetVsc always returns the stored status.
+	notReadyGetVscCalls int
+	notReadyStatus      string
+
 	// counters
 	CreateCalls int
 	GetCalls    int
@@ -154,7 +147,12 @@ func newFakeVscManager() *fakeVscManager {
 	}
 }
 
-func (f *fakeVscManager) CreatePrimaryVscFor(instanceId string) (string, error) {
+func (f *fakeVscManager) CreatePrimaryVscFor(ctx context.Context, instanceId string) (string, error) {
+	// Yield before recording the VSC so that, if single-flight ever regresses,
+	// concurrent callers overlap here instead of running check+create atomically
+	// (TestPrimaryVscCache_EnsurePrimaryVsc_ConcurrentCreatesOnce relies on this).
+	// Negligible under real time; auto-advanced under synctest.
+	time.Sleep(time.Microsecond)
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.CreateCalls++
@@ -177,7 +175,7 @@ func (f *fakeVscManager) CreatePrimaryVscFor(instanceId string) (string, error) 
 	return vscId, nil
 }
 
-func (f *fakeVscManager) GetPrimaryVscOf(instanceId string) (*Vsc, error) {
+func (f *fakeVscManager) GetPrimaryVscOf(ctx context.Context, instanceId string) (*Vsc, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.GetCalls++
@@ -192,7 +190,7 @@ func (f *fakeVscManager) GetPrimaryVscOf(instanceId string) (*Vsc, error) {
 	return &cp, nil
 }
 
-func (f *fakeVscManager) GetVsc(vscId, instanceId string) (*Vsc, error) {
+func (f *fakeVscManager) GetVsc(ctx context.Context, vscId, instanceId string) (*Vsc, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.GetOneCalls++
@@ -204,90 +202,54 @@ func (f *fakeVscManager) GetVsc(vscId, instanceId string) (*Vsc, error) {
 		return nil, nil
 	}
 	cp := *v
+	if f.notReadyGetVscCalls > 0 && f.GetOneCalls <= f.notReadyGetVscCalls {
+		cp.Status = f.notReadyStatus
+	}
 	return &cp, nil
 }
 
 // newTestPrimaryVscManagerWithCache builds a PrimaryVscManagerWithCache that
-// uses the supplied fake backend, with a small worker count for fast tests.
+// uses the supplied fake backend, with a tiny poll interval for fast tests.
 func newTestPrimaryVscManagerWithCache(t *testing.T, backend VscManager, ttl time.Duration) *PrimaryVscManagerWithCache {
 	t.Helper()
-	m := &PrimaryVscManagerWithCache{
-		VscManager: backend,
-		retryTimes: 1,
-		cacheTTL:   ttl,
-		cond:       sync.NewCond(&sync.Mutex{}),
-		cache:      make(map[string]vscWithErr),
-		queue: workqueue.NewTypedRateLimitingQueue(
-			workqueue.NewTypedMaxOfRateLimiter(
-				workqueue.NewTypedItemExponentialFailureRateLimiter[string](time.Millisecond, 100*time.Millisecond),
-				&workqueue.TypedBucketRateLimiter[string]{Limiter: rate.NewLimiter(rate.Limit(100), 100)},
-			),
-		),
+	return &PrimaryVscManagerWithCache{
+		VscManager:   backend,
+		vscCache:     ttlcache.NewTTLCache[string, *Vsc](ttl),
+		createVsc:    ttlcache.NewTTLCache[string, *Vsc](0),
+		clk:          clock.RealClock{},
+		pollInterval: time.Millisecond,
+		pollAttempts: defaultVscPollAttempts,
 	}
-	done := make(chan struct{})
-	go func() {
-		defer close(done)
-		for m.handleNext() {
-		}
-	}()
-	t.Cleanup(func() {
-		m.queue.ShutDown()
-		<-done
-	})
-	return m
 }
 
 func TestPrimaryVscCache_EnsurePrimaryVsc_CreatesAndCaches(t *testing.T) {
 	fake := newFakeVscManager()
 	m := newTestPrimaryVscManagerWithCache(t, fake, time.Minute)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-
-	vscId, err := m.EnsurePrimaryVsc(ctx, "i-ecs-1", false)
+	vscId, err := m.EnsurePrimaryVsc(t.Context(), "i-ecs-1")
 	require.NoError(t, err)
 	assert.Equal(t, "vsc-i-ecs-1", vscId)
 	assert.Equal(t, 1, fake.CreateCalls)
 
 	// Second call within TTL should be served from cache: no extra backend hits.
-	vscId2, err := m.EnsurePrimaryVsc(ctx, "i-ecs-1", false)
+	vscId2, err := m.EnsurePrimaryVsc(t.Context(), "i-ecs-1")
 	require.NoError(t, err)
 	assert.Equal(t, "vsc-i-ecs-1", vscId2)
 	assert.Equal(t, 1, fake.CreateCalls, "cached EnsurePrimaryVsc must not call backend")
-}
-
-func TestPrimaryVscCache_EnsurePrimaryVsc_RefreshBypassesCache(t *testing.T) {
-	fake := newFakeVscManager()
-	m := newTestPrimaryVscManagerWithCache(t, fake, time.Hour)
-
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-
-	_, err := m.EnsurePrimaryVsc(ctx, "i-ecs-1", false)
-	require.NoError(t, err)
-	prevGet := fake.GetCalls
-
-	// refresh=true must bypass the cache and hit the backend again.
-	_, err = m.EnsurePrimaryVsc(ctx, "i-ecs-1", true)
-	require.NoError(t, err)
-	assert.Greater(t, fake.GetCalls, prevGet, "refresh=true must trigger backend lookup")
 }
 
 func TestPrimaryVscCache_EnsurePrimaryVsc_ExpiryRefreshes(t *testing.T) {
 	fake := newFakeVscManager()
 	m := newTestPrimaryVscManagerWithCache(t, fake, 10*time.Millisecond)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-
-	_, err := m.EnsurePrimaryVsc(ctx, "i-ecs-1", false)
+	_, err := m.EnsurePrimaryVsc(t.Context(), "i-ecs-1")
 	require.NoError(t, err)
 	prevGet := fake.GetCalls
 
 	// Wait for the entry to expire.
 	time.Sleep(50 * time.Millisecond)
 
-	_, err = m.EnsurePrimaryVsc(ctx, "i-ecs-1", false)
+	_, err = m.EnsurePrimaryVsc(t.Context(), "i-ecs-1")
 	require.NoError(t, err)
 	assert.Greater(t, fake.GetCalls, prevGet, "expired entry must trigger backend lookup")
 }
@@ -297,12 +259,72 @@ func TestPrimaryVscCache_EnsurePrimaryVsc_BackendErrorPropagated(t *testing.T) {
 	fake.getErr = errors.New("backend down")
 	m := newTestPrimaryVscManagerWithCache(t, fake, time.Minute)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-
-	_, err := m.EnsurePrimaryVsc(ctx, "i-ecs-1", false)
+	_, err := m.EnsurePrimaryVsc(t.Context(), "i-ecs-1")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "backend down")
+}
+
+// TestPrimaryVscCache_EnsurePrimaryVsc_PollsUntilReady verifies that a freshly
+// created VSC reporting a transient status is polled until it settles.
+func TestPrimaryVscCache_EnsurePrimaryVsc_PollsUntilReady(t *testing.T) {
+	fake := newFakeVscManager()
+	// First two GetVsc calls report a not-yet-usable status, then it settles.
+	fake.notReadyGetVscCalls = 2
+	fake.notReadyStatus = "Attaching"
+	m := newTestPrimaryVscManagerWithCache(t, fake, time.Minute)
+
+	vscId, err := m.EnsurePrimaryVsc(t.Context(), "i-ecs-1")
+	require.NoError(t, err)
+	assert.Equal(t, "vsc-i-ecs-1", vscId)
+	// 3 polls: the first two report the transient status, the third returns Normal.
+	assert.Equal(t, 3, fake.GetOneCalls)
+}
+
+// TestPrimaryVscCache_EnsurePrimaryVsc_PollExhaustedReturnsError verifies that a
+// VSC whose status never settles fails after pollAttempts.
+func TestPrimaryVscCache_EnsurePrimaryVsc_PollExhaustedReturnsError(t *testing.T) {
+	fake := newFakeVscManager()
+	// Never settles.
+	fake.notReadyGetVscCalls = 1000
+	fake.notReadyStatus = "Attaching"
+	m := newTestPrimaryVscManagerWithCache(t, fake, time.Minute)
+
+	_, err := m.EnsurePrimaryVsc(t.Context(), "i-ecs-1")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unexpected vsc status: Attaching")
+	// pollAttempts polls, all reporting the transient status, before giving up.
+	assert.Equal(t, m.pollAttempts, fake.GetOneCalls)
+}
+
+// TestPrimaryVscCache_EnsurePrimaryVsc_ConcurrentCreatesOnce verifies the core
+// invariant: concurrent EnsurePrimaryVsc calls for a not-yet-existing instance
+// create exactly one VSC. createVsc serializes the callers and check-before-create
+// makes the followers reuse the leader's VSC instead of creating their own.
+func TestPrimaryVscCache_EnsurePrimaryVsc_ConcurrentCreatesOnce(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		fake := newFakeVscManager()
+		m := newTestPrimaryVscManagerWithCache(t, fake, time.Minute)
+		// The fake's create sleeps before recording the VSC (see CreatePrimaryVscFor),
+		// so all callers reach the create window; single-flight must still collapse
+		// them to one. Under synctest the clock advances only once all are parked.
+
+		const n = 5
+		var wg sync.WaitGroup
+		ids := make([]string, n)
+		errs := make([]error, n)
+		for i := range n {
+			wg.Go(func() {
+				ids[i], errs[i] = m.EnsurePrimaryVsc(t.Context(), "i-ecs-1")
+			})
+		}
+		wg.Wait()
+
+		for i := range n {
+			require.NoError(t, errs[i])
+			assert.Equal(t, "vsc-i-ecs-1", ids[i])
+		}
+		assert.Equal(t, 1, fake.CreateCalls, "concurrent EnsurePrimaryVsc must create exactly one VSC")
+	})
 }
 
 func TestPrimaryVscCache_GetPrimaryVscOf_ReadThroughCaches(t *testing.T) {
@@ -316,14 +338,14 @@ func TestPrimaryVscCache_GetPrimaryVscOf_ReadThroughCaches(t *testing.T) {
 	}
 	m := newTestPrimaryVscManagerWithCache(t, fake, time.Minute)
 
-	vsc, err := m.GetPrimaryVscOf("e01-cn-xyz")
+	vsc, err := m.GetPrimaryVscOf(t.Context(), "e01-cn-xyz")
 	require.NoError(t, err)
 	require.NotNil(t, vsc)
 	assert.Equal(t, "vsc-existing", vsc.VscID)
 
 	prev := fake.GetCalls
 	// Second call should be served from the cache.
-	vsc, err = m.GetPrimaryVscOf("e01-cn-xyz")
+	vsc, err = m.GetPrimaryVscOf(t.Context(), "e01-cn-xyz")
 	require.NoError(t, err)
 	require.NotNil(t, vsc)
 	assert.Equal(t, prev, fake.GetCalls, "cached GetPrimaryVscOf must not call backend")
@@ -333,14 +355,14 @@ func TestPrimaryVscCache_GetPrimaryVscOf_NotFoundNotCached(t *testing.T) {
 	fake := newFakeVscManager()
 	m := newTestPrimaryVscManagerWithCache(t, fake, time.Minute)
 
-	vsc, err := m.GetPrimaryVscOf("e01-missing")
+	vsc, err := m.GetPrimaryVscOf(t.Context(), "e01-missing")
 	require.NoError(t, err)
 	assert.Nil(t, vsc)
 	assert.Equal(t, 1, fake.GetCalls)
 
 	// A subsequent call must hit the backend again because nil results are not
 	// cached (the absence might be transient).
-	vsc, err = m.GetPrimaryVscOf("e01-missing")
+	vsc, err = m.GetPrimaryVscOf(t.Context(), "e01-missing")
 	require.NoError(t, err)
 	assert.Nil(t, vsc)
 	assert.Equal(t, 2, fake.GetCalls)
@@ -356,13 +378,13 @@ func TestPrimaryVscCache_GetPrimaryVscOf_ExpiryRefetches(t *testing.T) {
 	}
 	m := newTestPrimaryVscManagerWithCache(t, fake, 10*time.Millisecond)
 
-	_, err := m.GetPrimaryVscOf("e01-cn-xyz")
+	_, err := m.GetPrimaryVscOf(t.Context(), "e01-cn-xyz")
 	require.NoError(t, err)
 	prev := fake.GetCalls
 
 	time.Sleep(50 * time.Millisecond)
 
-	_, err = m.GetPrimaryVscOf("e01-cn-xyz")
+	_, err = m.GetPrimaryVscOf(t.Context(), "e01-cn-xyz")
 	require.NoError(t, err)
 	assert.Greater(t, fake.GetCalls, prev, "expired entry must refetch")
 }

--- a/pkg/cloud/throttle/throttle.go
+++ b/pkg/cloud/throttle/throttle.go
@@ -2,15 +2,93 @@ package throttle
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"sync/atomic"
 	"time"
 
+	"github.com/alibabacloud-go/tea/tea"
 	alierrors "github.com/aliyun/alibaba-cloud-sdk-go/sdk/errors"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/clock"
 )
+
+// Class categorizes an error returned by an OpenAPI call for throttling purposes.
+type Class int
+
+const (
+	// ClassUnknown means the error is not a recognized cloud API error, so we
+	// cannot tell whether we are being throttled. Throttle state is left untouched.
+	ClassUnknown Class = iota
+	// ClassOK means the call was a recognized outcome that is not throttling
+	// (success or a non-throttling cloud error). Any active throttling is cleared.
+	ClassOK
+	// ClassThrottling means the cloud responded with a throttling error, so we
+	// should back off and retry.
+	ClassThrottling
+)
+
+// Classifier maps an error (which may be nil) to a Class plus a best-effort
+// request ID for logging (empty when unavailable). It lets the Throttler work
+// with different Alibaba Cloud SDKs whose error types are incompatible.
+type Classifier func(error) (Class, string)
+
+// V1Classifier classifies errors from the old SDK
+// (github.com/aliyun/alibaba-cloud-sdk-go), whose errors are *alierrors.ServerError.
+func V1Classifier(err error) (Class, string) {
+	if err == nil {
+		return ClassOK, ""
+	}
+	alierr, ok := errors.AsType[*alierrors.ServerError](err)
+	if !ok {
+		return ClassUnknown, ""
+	}
+	if alierr.ErrorCode() == "Throttling" {
+		return ClassThrottling, alierr.RequestId()
+	}
+	return ClassOK, alierr.RequestId()
+}
+
+// V2Classifier classifies errors from the new tea SDK
+// (github.com/alibabacloud-go/*), whose errors are *tea.SDKError. Throttling
+// codes take several forms (Throttling, Throttling.User, Throttling.Api), so we
+// match on the "Throttling" prefix.
+func V2Classifier(err error) (Class, string) {
+	if err == nil {
+		return ClassOK, ""
+	}
+	sdkErr, ok := errors.AsType[*tea.SDKError](err)
+	if !ok {
+		return ClassUnknown, ""
+	}
+	requestID := sdkErrorRequestID(sdkErr)
+	if strings.HasPrefix(tea.StringValue(sdkErr.Code), "Throttling") {
+		return ClassThrottling, requestID
+	}
+	return ClassOK, requestID
+}
+
+// sdkErrorRequestID extracts the request ID from a tea SDKError. The tea SDK
+// stashes it inside the JSON-encoded Data field rather than a typed accessor
+// (see pkg/cloud/wrap.transformV2ErrorForLog).
+func sdkErrorRequestID(e *tea.SDKError) string {
+	if e.Data == nil {
+		return ""
+	}
+	data := *e.Data
+	if data == "" || data[0] != '{' { // only attempt to parse a JSON object
+		return ""
+	}
+	var parsed struct {
+		RequestId string
+	}
+	if json.Unmarshal([]byte(data), &parsed) != nil {
+		return ""
+	}
+	return parsed.RequestId
+}
 
 type throttlingError struct {
 	err error
@@ -35,16 +113,18 @@ type Throttler struct {
 	initDelay time.Duration
 	maxDelay  time.Duration
 
-	clk clock.Clock
+	clk      clock.Clock
+	classify Classifier
 
 	current atomic.Pointer[throttlingContext]
 }
 
-func NewThrottler(clk clock.Clock, initDelay, maxDelay time.Duration) *Throttler {
+func NewThrottler(clk clock.Clock, initDelay, maxDelay time.Duration, classify Classifier) *Throttler {
 	return &Throttler{
 		initDelay: initDelay,
 		maxDelay:  maxDelay,
 		clk:       clk,
+		classify:  classify,
 	}
 }
 
@@ -88,17 +168,16 @@ func (t *Throttler) Throttle(ctx context.Context, f func() error) error {
 
 		err := f()
 
-		var alierr *alierrors.ServerError
-		if err != nil && !errors.As(err, &alierr) {
+		class, requestID := t.classify(err)
+		switch class {
+		case ClassUnknown:
 			// We are not sure what's wrong, don't change state.
 			if tCtx != nil {
 				// Initiate the next probe immediately.
 				tCtx.probing <- struct{}{}
 			}
 			return err
-		}
-
-		if err == nil || alierr.ErrorCode() != "Throttling" {
+		case ClassOK:
 			if tCtx != nil {
 				logger.V(1).Info("OpenAPI throttling ended")
 				close(tCtx.probing)
@@ -116,9 +195,9 @@ func (t *Throttler) Throttle(ctx context.Context, f func() error) error {
 			}
 			tCtx.probing <- struct{}{}
 			if t.current.CompareAndSwap(nil, tCtx) {
-				logger.V(1).Info("OpenAPI throttling detected", "requestID", alierr.RequestId())
+				logger.V(1).Info("OpenAPI throttling detected", "requestID", requestID)
 			} else {
-				logger.V(3).Info("already throttling", "requestID", alierr.RequestId())
+				logger.V(3).Info("already throttling", "requestID", requestID)
 			}
 		} else {
 			tCtx.lastThrottling = t.clk.Now()
@@ -127,7 +206,7 @@ func (t *Throttler) Throttle(ctx context.Context, f func() error) error {
 				tCtx.retryDelay = t.maxDelay
 			}
 			tCtx.probing <- struct{}{}
-			logger.V(2).Info("still throttling", "retry", tCtx.retryDelay, "requestID", alierr.RequestId())
+			logger.V(2).Info("still throttling", "retry", tCtx.retryDelay, "requestID", requestID)
 		}
 	}
 }

--- a/pkg/cloud/throttle/throttle_test.go
+++ b/pkg/cloud/throttle/throttle_test.go
@@ -8,6 +8,7 @@ import (
 	"testing/synctest"
 	"time"
 
+	"github.com/alibabacloud-go/tea/tea"
 	alierrors "github.com/aliyun/alibaba-cloud-sdk-go/sdk/errors"
 	"github.com/stretchr/testify/assert"
 	"k8s.io/klog/v2"
@@ -17,6 +18,51 @@ import (
 )
 
 var ErrThrottling error = alierrors.NewServerError(400, `{"Code": "Throttling"}`, "")
+
+func TestV1Classifier(t *testing.T) {
+	tests := []struct {
+		name      string
+		err       error
+		want      Class
+		wantReqID string
+	}{
+		{name: "nil", err: nil, want: ClassOK},
+		{name: "throttling", err: alierrors.NewServerError(400, `{"Code": "Throttling", "RequestId": "req-123"}`, ""), want: ClassThrottling, wantReqID: "req-123"},
+		{name: "other server error", err: alierrors.NewServerError(400, `{"Code": "Test", "RequestId": "req-456"}`, ""), want: ClassOK, wantReqID: "req-456"},
+		{name: "unknown error", err: errors.New("boom"), want: ClassUnknown},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			class, reqID := V1Classifier(tt.err)
+			assert.Equal(t, tt.want, class)
+			assert.Equal(t, tt.wantReqID, reqID)
+		})
+	}
+}
+
+func TestV2Classifier(t *testing.T) {
+	tests := []struct {
+		name      string
+		err       error
+		want      Class
+		wantReqID string
+	}{
+		{name: "nil", err: nil, want: ClassOK},
+		{name: "throttling", err: &tea.SDKError{Code: tea.String("Throttling"), Data: tea.String(`{"RequestId":"req-123"}`)}, want: ClassThrottling, wantReqID: "req-123"},
+		{name: "throttling user prefix", err: &tea.SDKError{Code: tea.String("Throttling.User")}, want: ClassThrottling},
+		{name: "throttling api prefix", err: &tea.SDKError{Code: tea.String("Throttling.Api")}, want: ClassThrottling},
+		{name: "other sdk error", err: &tea.SDKError{Code: tea.String("InvalidParameter"), Data: tea.String(`{"RequestId":"req-789"}`)}, want: ClassOK, wantReqID: "req-789"},
+		{name: "non-json data", err: &tea.SDKError{Code: tea.String("Throttling"), Data: tea.String("not json")}, want: ClassThrottling},
+		{name: "unknown error", err: errors.New("boom"), want: ClassUnknown},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			class, reqID := V2Classifier(tt.err)
+			assert.Equal(t, tt.want, class)
+			assert.Equal(t, tt.wantReqID, reqID)
+		})
+	}
+}
 
 func TestThrottlingStress(t *testing.T) { synctest.Test(t, testThrottlingStressSync) }
 func testThrottlingStressSync(t *testing.T) {
@@ -35,7 +81,7 @@ func testThrottlingStressSync(t *testing.T) {
 			return nil
 		}
 	}
-	throttler := NewThrottler(clock.RealClock{}, 1*time.Second, 8*time.Second)
+	throttler := NewThrottler(clock.RealClock{}, 1*time.Second, 8*time.Second, V1Classifier)
 
 	for i := range reqCount {
 		go func() {
@@ -94,7 +140,7 @@ func testThrottlingStressSync(t *testing.T) {
 func TestThrottleErrorPassThrough(t *testing.T) {
 	_, ctx := ktesting.NewTestContext(t)
 	clk := testclock.NewFakeClock(time.Now())
-	throttler := NewThrottler(clk, time.Second*1, time.Second*10)
+	throttler := NewThrottler(clk, time.Second*1, time.Second*10, V1Classifier)
 
 	testErr := func(t *testing.T, expectedErr error) {
 		f := func() error {
@@ -114,7 +160,7 @@ func TestThrottleErrorPassThrough(t *testing.T) {
 
 func TestCancelAtDelay(t *testing.T) { synctest.Test(t, testCancelAtDelaySync) }
 func testCancelAtDelaySync(t *testing.T) {
-	throttler := NewThrottler(clock.RealClock{}, time.Second*1, time.Second*10)
+	throttler := NewThrottler(clock.RealClock{}, time.Second*1, time.Second*10, V1Classifier)
 
 	_, ctx := ktesting.NewTestContext(t)
 	ctxToCancel, cancel := context.WithCancel(ctx)
@@ -138,7 +184,7 @@ func testCancelAtDelaySync(t *testing.T) {
 func TestUnknownErrorOnProbing(t *testing.T) { synctest.Test(t, testUnknownErrorOnProbingSync) }
 func testUnknownErrorOnProbingSync(t *testing.T) {
 	_, ctx := ktesting.NewTestContext(t)
-	throttler := NewThrottler(clock.RealClock{}, time.Second*1, time.Second*10)
+	throttler := NewThrottler(clock.RealClock{}, time.Second*1, time.Second*10, V1Classifier)
 
 	errUnknown := errors.New("unknown error")
 	var errRet atomic.Pointer[error]

--- a/pkg/disk/disk.go
+++ b/pkg/disk/disk.go
@@ -240,7 +240,7 @@ func newBatcher(fromNode bool) (waitstatus.StatusWaiter[ecs.Disk], batcher.Batch
 }
 
 func defaultThrottler() *throttle.Throttler {
-	return throttle.NewThrottler(clock.RealClock{}, 1*time.Second, 10*time.Second)
+	return throttle.NewThrottler(clock.RealClock{}, 1*time.Second, 10*time.Second, throttle.V1Classifier)
 }
 
 // parseLingjunNodeDiskTypes parses allowed disk types for Lingjun nodes from a comma-separated string.

--- a/pkg/labeler/labeler.go
+++ b/pkg/labeler/labeler.go
@@ -24,6 +24,7 @@ import (
 	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/cloud"
 	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/cloud/metadata"
 	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/disk"
+	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/utils/ttlcache"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -171,9 +172,9 @@ func runOnce(ctx context.Context, client kubernetes.Interface, ecsClient cloud.E
 		RegionID:          regionID,
 		NodeLister:        nodeInformer.Lister(),
 		Queue:             queue,
-		instanceTypeCache: NewTTLCache[string, int32](defaultInstanceTypeTTL),
-		nodeTypeCache:     NewTTLCache[string, int32](defaultInstanceTypeTTL),
-		diskTypesCache:    NewTTLCache[diskTypeCacheKey, []string](defaultInstanceTypeTTL),
+		instanceTypeCache: ttlcache.NewTTLCache[string, int32](defaultInstanceTypeTTL),
+		nodeTypeCache:     ttlcache.NewTTLCache[string, int32](defaultInstanceTypeTTL),
+		diskTypesCache:    ttlcache.NewTTLCache[diskTypeCacheKey, []string](defaultInstanceTypeTTL),
 	}
 
 	_, err := nodeInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{

--- a/pkg/labeler/reconcile.go
+++ b/pkg/labeler/reconcile.go
@@ -19,6 +19,7 @@ import (
 	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/cloud"
 	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/cloud/metadata"
 	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/disk"
+	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/utils/ttlcache"
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -38,9 +39,9 @@ type Reconciler struct {
 	NodeLister corev1listers.NodeLister
 	Queue      workqueue.TypedRateLimitingInterface[string]
 
-	instanceTypeCache *TTLCache[string, int32]
-	nodeTypeCache     *TTLCache[string, int32]
-	diskTypesCache    *TTLCache[diskTypeCacheKey, []string]
+	instanceTypeCache *ttlcache.TTLCache[string, int32]
+	nodeTypeCache     *ttlcache.TTLCache[string, int32]
+	diskTypesCache    *ttlcache.TTLCache[diskTypeCacheKey, []string]
 }
 
 type diskTypeCacheKey struct {

--- a/pkg/labeler/reconcile_test.go
+++ b/pkg/labeler/reconcile_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/cloud"
 	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/disk"
+	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/utils/ttlcache"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
@@ -162,9 +163,9 @@ func newTestFixture(t *testing.T, nodes ...*v1.Node) *testFixture {
 			RegionID:          "cn-test",
 			NodeLister:        nodeInformer.Lister(),
 			Queue:             q,
-			instanceTypeCache: NewTTLCache[string, int32](defaultInstanceTypeTTL),
-			nodeTypeCache:     NewTTLCache[string, int32](defaultInstanceTypeTTL),
-			diskTypesCache:    NewTTLCache[diskTypeCacheKey, []string](defaultInstanceTypeTTL),
+			instanceTypeCache: ttlcache.NewTTLCache[string, int32](defaultInstanceTypeTTL),
+			nodeTypeCache:     ttlcache.NewTTLCache[string, int32](defaultInstanceTypeTTL),
+			diskTypesCache:    ttlcache.NewTTLCache[diskTypeCacheKey, []string](defaultInstanceTypeTTL),
 		},
 		client: client,
 		ecs:    ecsMock,

--- a/pkg/utils/ttlcache/ttl_cache.go
+++ b/pkg/utils/ttlcache/ttl_cache.go
@@ -8,7 +8,8 @@ You may obtain a copy of the License at
     http://www.apache.org/licenses/LICENSE-2.0
 */
 
-package labeler
+// Package ttlcache provides small, reusable in-memory caching primitives.
+package ttlcache
 
 import (
 	"context"
@@ -23,6 +24,10 @@ import (
 // are shared among concurrent callers but not cached (immediately
 // evicted so the next call retries). Expired entries are lazily
 // evicted on Get.
+//
+// A non-positive TTL turns the cache into a pure single-flight: nothing
+// is retained across calls (the entry is evicted right after computing),
+// but concurrent callers still share one in-flight computation.
 type TTLCache[K comparable, V any] struct {
 	m   sync.Map // map[K]*cacheEntry[V]
 	ttl time.Duration
@@ -67,16 +72,22 @@ func (c *TTLCache[K, V]) Get(ctx context.Context, key K, fn func() (V, error)) (
 		entry := existing.(*cacheEntry[V])
 		select {
 		case <-entry.done:
-			if entry.err != nil {
-				// Error shared with concurrent callers; entry already removed by compute.
+			// Entry was already resolved when we found it: honor the TTL, so an
+			// expired entry (or any entry in a non-positive-TTL cache) refreshes.
+			if now.Before(entry.expires) {
 				return entry.value, entry.err
 			}
-			if now.Before(entry.expires) {
-				return entry.value, nil
-			}
 			// Expired; fall through to CAS replacement.
-		case <-ctx.Done():
-			return zero, ctx.Err()
+		default:
+			// Computation is still in flight; wait for it and share its result
+			// regardless of TTL — we are a genuine single-flight follower, not a
+			// caller that stumbled onto a stale entry.
+			select {
+			case <-entry.done:
+				return entry.value, entry.err
+			case <-ctx.Done():
+				return zero, ctx.Err()
+			}
 		}
 
 		// Expired resolved entry: try CAS to replace with a new pending entry.
@@ -96,9 +107,23 @@ func (c *TTLCache[K, V]) compute(key K, pending *cacheEntry[V], fn func() (V, er
 		pending.expires = now.Add(c.ttl)
 	}
 	close(pending.done)
-	if err != nil {
-		// Remove failed entry so future callers can retry.
+	if err != nil || c.ttl <= 0 {
+		// Don't retain the result: errors must not be cached, and a non-positive
+		// TTL means single-flight only. Concurrent followers already have it.
 		c.m.CompareAndDelete(key, pending)
 	}
 	return value, err
+}
+
+// Store puts value into the cache directly, without running fn, replacing any
+// existing entry and (re)starting its TTL. Use it to populate the cache from a
+// value obtained elsewhere (e.g. a write-through after creating the resource).
+func (c *TTLCache[K, V]) Store(key K, value V) {
+	entry := &cacheEntry[V]{
+		value:   value,
+		expires: time.Now().Add(c.ttl),
+		done:    make(chan struct{}),
+	}
+	close(entry.done)
+	c.m.Store(key, entry)
 }

--- a/pkg/utils/ttlcache/ttl_cache_test.go
+++ b/pkg/utils/ttlcache/ttl_cache_test.go
@@ -8,7 +8,7 @@ You may obtain a copy of the License at
     http://www.apache.org/licenses/LICENSE-2.0
 */
 
-package labeler
+package ttlcache
 
 import (
 	"context"
@@ -235,9 +235,13 @@ func testTTLCacheContextCancelWhileWaitingSync(t *testing.T) {
 }
 
 func TestTTLCacheStructKey(t *testing.T) {
-	c := NewTTLCache[diskTypeCacheKey, []string](10 * time.Second)
+	type structKey struct {
+		instanceType string
+		zoneID       string
+	}
+	c := NewTTLCache[structKey, []string](10 * time.Second)
 
-	val, err := c.Get(t.Context(), diskTypeCacheKey{"ecs.g7.large", "cn-beijing-a"}, func() ([]string, error) {
+	val, err := c.Get(t.Context(), structKey{"ecs.g7.large", "cn-beijing-a"}, func() ([]string, error) {
 		return []string{"cloud_essd", "cloud_ssd"}, nil
 	})
 	require.NoError(t, err)
@@ -245,7 +249,7 @@ func TestTTLCacheStructKey(t *testing.T) {
 
 	// Same key → cached.
 	var calls atomic.Int32
-	val, err = c.Get(t.Context(), diskTypeCacheKey{"ecs.g7.large", "cn-beijing-a"}, func() ([]string, error) {
+	val, err = c.Get(t.Context(), structKey{"ecs.g7.large", "cn-beijing-a"}, func() ([]string, error) {
 		calls.Add(1)
 		return []string{"other"}, nil
 	})
@@ -254,9 +258,70 @@ func TestTTLCacheStructKey(t *testing.T) {
 	assert.Equal(t, 0, int(calls.Load()))
 
 	// Different key → new computation.
-	val, err = c.Get(t.Context(), diskTypeCacheKey{"ecs.g7.xlarge", "cn-beijing-a"}, func() ([]string, error) {
+	val, err = c.Get(t.Context(), structKey{"ecs.g7.xlarge", "cn-beijing-a"}, func() ([]string, error) {
 		return []string{"cloud_essd"}, nil
 	})
 	require.NoError(t, err)
 	assert.Equal(t, []string{"cloud_essd"}, val)
+}
+
+// TestTTLCacheZeroTTLNoCache verifies that a non-positive TTL disables caching:
+// every sequential Get recomputes (the entry is evicted right after compute).
+func TestTTLCacheZeroTTLNoCache(t *testing.T) {
+	c := NewTTLCache[string, int](0)
+
+	var calls atomic.Int32
+	get := func() (int, error) {
+		calls.Add(1)
+		return 42, nil
+	}
+	for range 3 {
+		val, err := c.Get(t.Context(), "key1", get)
+		require.NoError(t, err)
+		assert.Equal(t, 42, val)
+	}
+	assert.Equal(t, 3, int(calls.Load()), "zero TTL must not cache; each Get recomputes")
+}
+
+// TestTTLCacheZeroTTLSingleFlight verifies that even with caching disabled
+// (TTL 0), concurrent callers for the same key share a single in-flight
+// computation.
+func TestTTLCacheZeroTTLSingleFlight(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		c := NewTTLCache[string, int](0)
+
+		var calls atomic.Int32
+		var wg sync.WaitGroup
+		for range 20 {
+			wg.Go(func() {
+				val, err := c.Get(t.Context(), "key1", func() (int, error) {
+					calls.Add(1)
+					time.Sleep(time.Millisecond) // hold fn open so all callers pile up
+					return 42, nil
+				})
+				assert.NoError(t, err)
+				assert.Equal(t, 42, val)
+			})
+		}
+		wg.Wait()
+
+		assert.Equal(t, 1, int(calls.Load()), "concurrent callers must dedup even with zero TTL")
+	})
+}
+
+// TestTTLCacheStore verifies that Store populates the cache directly, so a
+// subsequent Get returns the value without invoking fn.
+func TestTTLCacheStore(t *testing.T) {
+	c := NewTTLCache[string, int](10 * time.Second)
+
+	c.Store("key1", 42)
+
+	var calls atomic.Int32
+	val, err := c.Get(t.Context(), "key1", func() (int, error) {
+		calls.Add(1)
+		return 99, nil
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 42, val)
+	assert.Equal(t, 0, int(calls.Load()), "stored value must be served without recomputing")
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

The bmcpfs primary-VSC manager hand-rolled its concurrency with a `sync.Cond` + map cache and a rate-limited `workqueue` backed by a fixed worker pool. This replaces that machinery with two reusable components:

- **`TTLCache`** (moved from `pkg/labeler` to a shared `pkg/utils/ttlcache`): single-flight + TTL caching. `GetPrimaryVscOf` reads through `vscCache` (3-min TTL). `EnsurePrimaryVsc` runs through `createVsc`, a TTL-0 cache that only single-flights concurrent creates (no caching), and write-throughs the confirmed VSC into `vscCache` — so a publish warms the cache a later unpublish reads (restoring the single shared cache the old code had).
- **`throttle.Throttler`**: reactive backoff on real OpenAPI throttling instead of a static worker/qps cap.

`Throttler` is made SDK-agnostic via an injectable `Classifier`, so it works with both the old `alibaba-cloud-sdk-go` (`V1Classifier`) and the new tea SDK (`V2Classifier`) used by the VSC clients. Previously it only recognized the old SDK and **silently ignored tea-SDK throttling errors**, so these calls never backed off. The classifier also surfaces the request ID for logging.

Other changes:
- Thread `ctx` through `VscBackend`/`VscManager`; wrap each OpenAPI action with a per-action throttler.
- Non-`Normal` VSC status is recovered via a bounded in-process poll loop instead of workqueue requeue.
- Drop the prod-unused `refresh` parameter of `EnsurePrimaryVsc`.

#### Which issue(s) this PR fixes:

N/A

#### Special notes for your reviewer:

- No behavior change for existing `TTLCache` users (labeler, `pkg/disk`): the `V1Classifier` preserves the old-SDK throttling behavior, and the new in-flight-follower / non-positive-TTL semantics are no-ops for the positive-TTL, sub-second-compute usage there.
- Correctness of "no duplicate primary VSC under concurrent publishes" rests on two local, tested properties: per-instance serialization (`createVsc` single-flight) + check-before-create. Covered by `TestPrimaryVscCache_EnsurePrimaryVsc_ConcurrentCreatesOnce` and `TestTTLCacheZeroTTLSingleFlight`.
- Pre-existing stale-cache behavior (a VSC deleted out-of-band but still cached for the TTL) is unchanged from the old design; the recreate-TODO in `controllerserver.go` remains the place to address it.
- `go test -race ./pkg/utils/ttlcache/... ./pkg/cloud/throttle/... ./pkg/bmcpfs/... ./pkg/labeler/...` and `pkg/disk` all pass.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```