### PR TITLE
nas: enlarge default qps to 6

### DIFF
--- a/pkg/nas/cloud/nas_client_factory.go
+++ b/pkg/nas/cloud/nas_client_factory.go
@@ -9,7 +9,7 @@ import (
 	"k8s.io/klog/v2"
 )
 
-const defaultQps = 2
+const defaultQps = 6
 
 type NasClientFactory struct {
 	// ratelimiter only takes effect on v2 client


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Each NAS subpath `CreateVolume` issues 3 sequential API requests: `DescribeFileSystems`, `CreateDir`, `SetDirQuota`.

The external-nas-provisioner runs with `--timeout=150s` and the default `--worker-threads=100`. With the previous default QPS of 2, when all 100 workers are active each request waits up to ~50s in the rate limiter (100 / 2 qps), so the 3 requests of a single `CreateVolume` add up to ~150s and exceed the timeout. No request can succeed and the system stalls.

This raises the default QPS to 6, allowing ~2 volumes/second (6 qps / 3 requests). That matches the tightest server-side throttling limit — `SetDirQuota` at 120 / 60s = 2/s.

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
nas: increase the default client QPS from 2 to 6 to avoid CreateVolume timeouts/stalls when many volumes are provisioned concurrently
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
