### PR TITLE
fix: restore short driver type in metric labels

### DIFF
--- a/main.go
+++ b/main.go
@@ -275,7 +275,9 @@ func main() {
 				klog.Fatalf("CSI start failed, not support driver: %s", driverName)
 			}
 
-			server := common.NewCSIServer(driverName, driver)
+			// The metric "type" label uses the short driver type (e.g. "disk", "bmcpfs").
+			driverType := strings.TrimSuffix(driverName, TypePluginSuffix)
+			server := common.NewCSIServer(driverType, driver)
 			wg.Go(func() {
 				common.Serve(server, endpoint)
 			})


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind regression

#### What this PR does / why we need it:

Refactor 78f57c6ff centralized CSI server startup into
`common.NewCSIServer(driverName, ...)`, passing the **full** driver name
(e.g. `bmcpfsplugin.csi.alibabacloud.com`). Previously each driver called
`common.RunCSIServer(driverType, ...)` with its **short** type (e.g.
`bmcpfs`, `disk`, `nas`, `oss`, `pov`, `ens`).

That value is used as the `type` label of several metrics, so the label
regressed for every driver:
- `csi_grpc_execution_time_total`
- `csi_grpc_execution_count`
- the node volume-stats metric (`WrapNodeServerWithMetricRecorder`)

e.g. the `type` label changed from `bmcpfs` to
`bmcpfsplugin.csi.alibabacloud.com`.

This trims the common `TypePluginSuffix` at the call site to restore the
short `type` label for all drivers.

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
Fix a regression where the `type` label of the `csi_grpc_execution_time_total`, `csi_grpc_execution_count` and volume-stats metrics changed from the short driver type (e.g. `bmcpfs`) to the full driver name (e.g. `bmcpfsplugin.csi.alibabacloud.com`).
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
