### PR TITLE
disk: report HighDensityDisk mode limit as NodeGetInfo max volumes

### DIFF
--- a/.agents/skills/init-dev-env/scripts/create-image-pull-secret.sh
+++ b/.agents/skills/init-dev-env/scripts/create-image-pull-secret.sh
@@ -5,6 +5,7 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && git rev-parse --show-toplevel)"
 VALUES_FILE="$ROOT/.local/test-values.yaml"
 
 REGISTRY=$(yq '.images.registry' "$VALUES_FILE")
+REGISTRY_VPC=$(yq '.images.registryVPC' "$VALUES_FILE")
 SECRET_NAME=$(yq '.imagePullSecrets[0]' "$VALUES_FILE")
 
 AUTH=$(jq -r --arg server "$REGISTRY" '.auths[$server].auth // empty' ~/.docker/config.json)
@@ -14,8 +15,17 @@ if [ -z "$AUTH" ]; then
     exit 1
 fi
 
-jq -n --arg server "$REGISTRY" --arg auth "$AUTH" \
-    '{"auths": {($server): {"auth": $auth}}}' | \
+# In-cluster pulls use the VPC endpoint (images.registryVPC). You usually cannot
+# `docker login` to a VPC-only endpoint from outside the VPC, but the same ACR
+# credential works for both endpoints, so authorize registryVPC with the same auth.
+AUTHS=$(jq -n --arg server "$REGISTRY" --arg auth "$AUTH" \
+    '{($server): {"auth": $auth}}')
+if [ -n "$REGISTRY_VPC" ] && [ "$REGISTRY_VPC" != "null" ] && [ "$REGISTRY_VPC" != "$REGISTRY" ]; then
+    AUTHS=$(jq --arg server "$REGISTRY_VPC" --arg auth "$AUTH" \
+        '. + {($server): {"auth": $auth}}' <<<"$AUTHS")
+fi
+
+jq -n --argjson auths "$AUTHS" '{"auths": $auths}' | \
 kubectl create secret generic "$SECRET_NAME" \
     --from-file=.dockerconfigjson=/dev/stdin \
     --type=kubernetes.io/dockerconfigjson \

--- a/pkg/cloud/metadata/ecs_instance_type.go
+++ b/pkg/cloud/metadata/ecs_instance_type.go
@@ -2,9 +2,11 @@ package metadata
 
 import (
 	"fmt"
+	"strconv"
 
 	ecs20140526 "github.com/alibabacloud-go/ecs-20140526/v7/client"
 	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/cloud"
+	"k8s.io/utils/ptr"
 )
 
 type ECSInstanceTypeMetadata struct {
@@ -14,6 +16,10 @@ type ECSInstanceTypeMetadata struct {
 func NewEcsInstanceTypeMetadata(c cloud.ECSv2Interface, instanceType string) (*ECSInstanceTypeMetadata, error) {
 	req := ecs20140526.DescribeInstanceTypesRequest{
 		InstanceTypes: []*string{&instanceType},
+		// MaxResults is required for the response to include the Attributes array
+		// (which carries DensityDiskQuantity). A single-type query returns one
+		// result with an empty NextToken, so no pagination is needed.
+		MaxResults: new(int64(100)),
 	}
 	resp, err := c.DescribeInstanceTypes(&req)
 	if err != nil {
@@ -36,6 +42,8 @@ func (m *ECSInstanceTypeMetadata) GetAny(_ *mcontext, key MetadataKey) (any, err
 		if m.t.DiskQuantity != nil {
 			return *m.t.DiskQuantity, nil
 		}
+	case diskQuantityHighDensity:
+		return m.DiskQuantityHighDensity(), nil
 	}
 	return nil, ErrUnknownMetadataKey
 }
@@ -48,6 +56,22 @@ func (m *ECSInstanceTypeMetadata) DiskQuantity() int32 {
 	return *m.t.DiskQuantity
 }
 
+// DiskQuantityHighDensity returns the DensityDiskQuantity attribute value (the disk
+// count attachable in HighDensityDisk mode), or 0 if the type does not advertise it.
+func (m *ECSInstanceTypeMetadata) DiskQuantityHighDensity() int32 {
+	if m.t.Attributes == nil {
+		return 0
+	}
+	for _, a := range m.t.Attributes.Attribute {
+		if a != nil && ptr.Deref(a.Name, "") == "DensityDiskQuantity" {
+			if v, err := strconv.Atoi(ptr.Deref(a.Value, "")); err == nil {
+				return int32(v)
+			}
+		}
+	}
+	return 0
+}
+
 type ECSInstanceTypeFetcher struct {
 	ecsClient cloud.ECSv2Interface
 	mPre      middleware
@@ -57,7 +81,7 @@ func (f *ECSInstanceTypeFetcher) ID() fetcherID { return ecsInstanceTypeFetcherI
 
 func (f *ECSInstanceTypeFetcher) FetchFor(ctx *mcontext, key MetadataKey) (middleware, error) {
 	switch key {
-	case diskQuantity:
+	case diskQuantity, diskQuantityHighDensity:
 	default:
 		return nil, ErrUnknownMetadataKey
 	}

--- a/pkg/cloud/metadata/ecs_instance_type_test.go
+++ b/pkg/cloud/metadata/ecs_instance_type_test.go
@@ -156,6 +156,59 @@ func TestGetEcsInstanceTypeError(t *testing.T) {
 	}
 }
 
+func TestGetEcsInstanceTypeDensity(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	client := cloud.NewMockECSv2Interface(ctrl)
+	resp := &ecs20140526.DescribeInstanceTypesResponse{
+		Body: &ecs20140526.DescribeInstanceTypesResponseBody{
+			InstanceTypes: &ecs20140526.DescribeInstanceTypesResponseBodyInstanceTypes{
+				InstanceType: []*ecs20140526.DescribeInstanceTypesResponseBodyInstanceTypesInstanceType{
+					{
+						InstanceTypeId: new("ecs.c7a.4xlarge"),
+						DiskQuantity:   new(int32(9)),
+						Attributes: &ecs20140526.DescribeInstanceTypesResponseBodyInstanceTypesInstanceTypeAttributes{
+							Attribute: []*ecs20140526.DescribeInstanceTypesResponseBodyInstanceTypesInstanceTypeAttributesAttribute{
+								{Name: new("SomethingElse"), Value: new("x")},
+								{Name: new("DensityDiskQuantity"), Value: new("33")},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	client.EXPECT().DescribeInstanceTypes(gomock.Any()).DoAndReturn(
+		func(req *ecs20140526.DescribeInstanceTypesRequest) (*ecs20140526.DescribeInstanceTypesResponse, error) {
+			// MaxResults must be set or the API omits the Attributes array.
+			assert.NotNil(t, req.MaxResults, "MaxResults must be set")
+			return resp, nil
+		})
+
+	p, err := NewEcsInstanceTypeMetadata(client, "ecs.c7a.4xlarge")
+	require.NoError(t, err)
+	assert.Equal(t, int32(9), p.DiskQuantity())
+	assert.Equal(t, int32(33), p.DiskQuantityHighDensity())
+
+	v, err := p.GetAny(testMContext(t), diskQuantityHighDensity)
+	assert.NoError(t, err)
+	assert.Equal(t, int32(33), v)
+}
+
+func TestGetEcsInstanceTypeNoDensity(t *testing.T) {
+	m := ECSInstanceTypeMetadata{
+		t: &ecs20140526.DescribeInstanceTypesResponseBodyInstanceTypesInstanceType{
+			InstanceTypeId: new("ecs.g6.xlarge"),
+			DiskQuantity:   new(int32(17)),
+			// No Attributes -> no high-density support
+		},
+	}
+	assert.Equal(t, int32(0), m.DiskQuantityHighDensity())
+	// 0 is a valid answer for an ECS type without high-density support, not an error.
+	v, err := m.GetAny(testMContext(t), diskQuantityHighDensity)
+	assert.NoError(t, err)
+	assert.Equal(t, int32(0), v)
+}
+
 func TestGetEcsInstanceTypeNoDiskQuantity(t *testing.T) {
 	m := ECSInstanceTypeMetadata{
 		t: &ecs20140526.DescribeInstanceTypesResponseBodyInstanceTypesInstanceType{

--- a/pkg/cloud/metadata/metadata.go
+++ b/pkg/cloud/metadata/metadata.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 
 	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/cloud"
+	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/features"
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
@@ -35,7 +36,9 @@ const (
 
 	// non-string metadata, not public, can only access with corresponding methods
 	machineKind
-	diskQuantity // int32
+	diskQuantity            // int32
+	diskQuantityHighDensity // int32
+	isHighDensityMode       // bool
 )
 
 const LingjunConfigFile = "/host/etc/eflo_config/lingjun_config"
@@ -70,6 +73,10 @@ func (k MetadataKey) String() string {
 		return "MachineKind"
 	case diskQuantity:
 		return "DiskQuantity"
+	case diskQuantityHighDensity:
+		return "DiskQuantityHighDensity"
+	case isHighDensityMode:
+		return "IsHighDensityMode"
 	default:
 		return fmt.Sprintf("MetadataKey(%d)", k)
 	}
@@ -118,6 +125,16 @@ type MetadataProvider interface {
 	strMetadataProvider
 	MachineKind() (MachineKind, error)
 	DiskQuantity() (int32, error)
+	// DiskQuantityHighDensity returns the per-instance-type DensityDiskQuantity, the
+	// number of disks attachable when the instance runs in HighDensityDisk mode, or
+	// 0 if the type does not support high density or the feature is off. Returns
+	// ErrUnknownMetadataKey only when it cannot be determined (e.g. non-ECS nodes).
+	DiskQuantityHighDensity() (int32, error)
+	// IsHighDensityMode reports whether this instance currently runs in
+	// HighDensityDisk mode. It performs a per-instance DescribeInstances call, so
+	// callers should only consult it for high-density-capable types (see
+	// EffectiveDiskQuantity).
+	IsHighDensityMode() (bool, error)
 	WithSession(ctx context.Context) MetadataProvider
 }
 
@@ -185,6 +202,53 @@ func getT[T any](m *Metadata, key MetadataKey) (T, error) {
 func (m *Metadata) Get(key MetadataKey) (string, error) { return getT[string](m, key) }
 func (m *Metadata) MachineKind() (MachineKind, error)   { return getT[MachineKind](m, machineKind) }
 func (m *Metadata) DiskQuantity() (int32, error)        { return getT[int32](m, diskQuantity) }
+func (m *Metadata) DiskQuantityHighDensity() (int32, error) {
+	if !diskHighDensityModeEnabled() {
+		return 0, nil // feature off -> no high density, same as an unsupported type
+	}
+	return getT[int32](m, diskQuantityHighDensity)
+}
+func (m *Metadata) IsHighDensityMode() (bool, error) {
+	if !diskHighDensityModeEnabled() {
+		return false, nil
+	}
+	return getT[bool](m, isHighDensityMode)
+}
+
+func diskHighDensityModeEnabled() bool {
+	return features.FunctionalMutableFeatureGate.Enabled(features.DiskHighDensityMode)
+}
+
+// EffectiveDiskQuantity returns the number of data disks attachable to this
+// instance, accounting for ECS HighDensityDisk mode: DensityDiskQuantity when the
+// instance runs in high-density mode and its type supports it, else the normal
+// DiskQuantity.
+func EffectiveDiskQuantity(m MetadataProvider) (int32, error) {
+	normal, err := m.DiskQuantity()
+	if err != nil {
+		return 0, err
+	}
+	density, err := m.DiskQuantityHighDensity()
+	if err != nil {
+		if errors.Is(err, ErrUnknownMetadataKey) {
+			return normal, nil // type has no high-density support -> no DescribeInstances call
+		}
+		return 0, err
+	}
+	if density <= 0 || density == normal {
+		// No usable high-density value (unsupported / feature off), or identical to
+		// normal: high density cannot change the answer, so skip the DescribeInstances call.
+		return normal, nil
+	}
+	hd, err := m.IsHighDensityMode() // the per-instance OpenAPI call
+	if err != nil {
+		return 0, err
+	}
+	if hd {
+		return density, nil
+	}
+	return normal, nil
+}
 
 type fetcher interface {
 	// FetchFor should return [ErrUnknownMetadataKey] if the key is not supported
@@ -435,8 +499,10 @@ func GetFallbackZoneID(m MetadataProvider) (string, error) {
 type FakeProvider struct {
 	Values map[MetadataKey]string
 	V      struct {
-		MachineKind  MachineKind
-		DiskQuantity int32
+		MachineKind             MachineKind
+		DiskQuantity            int32
+		DiskQuantityHighDensity int32
+		IsHighDensityMode       bool
 	}
 }
 
@@ -453,6 +519,14 @@ func (p *FakeProvider) MachineKind() (MachineKind, error) {
 
 func (p *FakeProvider) DiskQuantity() (int32, error) {
 	return p.V.DiskQuantity, nil
+}
+
+func (p *FakeProvider) DiskQuantityHighDensity() (int32, error) {
+	return p.V.DiskQuantityHighDensity, nil
+}
+
+func (p *FakeProvider) IsHighDensityMode() (bool, error) {
+	return p.V.IsHighDensityMode, nil
 }
 
 func (p *FakeProvider) WithSession(ctx context.Context) MetadataProvider {

--- a/pkg/cloud/metadata/metadata_test.go
+++ b/pkg/cloud/metadata/metadata_test.go
@@ -14,9 +14,11 @@ import (
 	"github.com/jarcoal/httpmock"
 	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/cloud"
 	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/cloud/metadata/imds"
+	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/features"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	fake "k8s.io/client-go/kubernetes/fake"
+	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	"k8s.io/klog/v2/ktesting"
 )
 
@@ -313,6 +315,134 @@ func TestGetUnknownKey(t *testing.T) {
 
 	_, err := m.Get(99999)
 	assert.Equal(t, ErrUnknownMetadataKey, err)
+}
+
+// effProvider is a controllable MetadataProvider for EffectiveDiskQuantity tests.
+// It counts IsHighDensityMode calls so tests can assert the per-instance
+// DescribeInstances is skipped for types without high-density support.
+type effProvider struct {
+	normal, density int32
+	normalErr       error
+	densityErr      error
+	hd              bool
+	hdErr           error
+	hdCalls         int
+}
+
+func (p *effProvider) Get(MetadataKey) (string, error)   { return "", ErrUnknownMetadataKey }
+func (p *effProvider) MachineKind() (MachineKind, error) { return MachineKindECS, nil }
+func (p *effProvider) DiskQuantity() (int32, error)      { return p.normal, p.normalErr }
+func (p *effProvider) DiskQuantityHighDensity() (int32, error) {
+	return p.density, p.densityErr
+}
+func (p *effProvider) IsHighDensityMode() (bool, error) {
+	p.hdCalls++
+	return p.hd, p.hdErr
+}
+func (p *effProvider) WithSession(context.Context) MetadataProvider { return p }
+
+// When the DiskHighDensityMode feature is off, the high-density accessors must
+// short-circuit without making any OpenAPI call.
+func TestHighDensityAccessorsGateOff(t *testing.T) {
+	featuregatetesting.SetFeatureGateDuringTest(t, features.FunctionalMutableFeatureGate, features.DiskHighDensityMode, false)
+	ctrl := gomock.NewController(t)
+	client := cloud.NewMockECSv2Interface(ctrl) // no EXPECT: any OpenAPI call fails the test
+
+	m := testMetadata(t, fakeMiddleware{InstanceType: "ecs.c7a.4xlarge", InstanceID: "i-x"})
+	m.EnableOpenAPI(client)
+
+	density, err := m.DiskQuantityHighDensity()
+	assert.NoError(t, err)
+	assert.Equal(t, int32(0), density)
+
+	hd, err := m.IsHighDensityMode()
+	assert.NoError(t, err)
+	assert.False(t, hd)
+}
+
+func TestEffectiveDiskQuantity(t *testing.T) {
+	errBoom := errors.New("boom")
+	cases := []struct {
+		name        string
+		p           effProvider
+		want        int32
+		wantErr     bool
+		wantHDCalls int
+	}{
+		{
+			name:        "no high-density support",
+			p:           effProvider{normal: 9, density: 0}, // 0 = unsupported type / feature off
+			want:        9,
+			wantHDCalls: 0, // must not call the per-instance DescribeInstances
+		},
+		{
+			name:        "high density unavailable",
+			p:           effProvider{normal: 9, density: 0, densityErr: ErrUnknownMetadataKey},
+			want:        9,
+			wantHDCalls: 0, // e.g. non-ECS node -> normal, no DescribeInstances
+		},
+		{
+			name:        "density equal to normal",
+			p:           effProvider{normal: 33, density: 33},
+			want:        33,
+			wantHDCalls: 0,
+		},
+		{
+			name:        "capable but mode off",
+			p:           effProvider{normal: 9, density: 33, hd: false},
+			want:        9,
+			wantHDCalls: 1,
+		},
+		{
+			name:        "capable and mode on",
+			p:           effProvider{normal: 9, density: 33, hd: true},
+			want:        33,
+			wantHDCalls: 1,
+		},
+		{
+			// Defensive: the two modes are mutually exclusive, so if the instance
+			// really runs in high-density mode we honor DensityDiskQuantity even when
+			// it is (unexpectedly) lower than the normal DiskQuantity.
+			name:        "density lower, mode on",
+			p:           effProvider{normal: 9, density: 5, hd: true},
+			want:        5,
+			wantHDCalls: 1,
+		},
+		{
+			name:        "density lower, mode off",
+			p:           effProvider{normal: 9, density: 5, hd: false},
+			want:        9,
+			wantHDCalls: 1,
+		},
+		{
+			name:    "density lookup error propagates",
+			p:       effProvider{normal: 9, density: 0, densityErr: errBoom},
+			wantErr: true,
+		},
+		{
+			name:    "normal error propagates",
+			p:       effProvider{normalErr: errBoom},
+			wantErr: true,
+		},
+		{
+			name:    "high-density flag error propagates",
+			p:       effProvider{normal: 9, density: 33, hdErr: errBoom},
+			wantErr: true,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			p := c.p
+			got, err := EffectiveDiskQuantity(&p)
+			if c.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, c.want, got)
+			assert.Equal(t, c.wantHDCalls, p.hdCalls)
+		})
+	}
 }
 
 type fakeMiddleware map[MetadataKey]any

--- a/pkg/cloud/metadata/openapi.go
+++ b/pkg/cloud/metadata/openapi.go
@@ -8,6 +8,7 @@ import (
 
 	ecs20140526 "github.com/alibabacloud-go/ecs-20140526/v7/client"
 	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/cloud"
+	"k8s.io/utils/ptr"
 )
 
 type OpenAPIMetadata struct {
@@ -21,6 +22,11 @@ func NewOpenAPIMetadata(c cloud.ECSv2Interface, instanceId string) (*OpenAPIMeta
 	}
 	instanceRequest := ecs20140526.DescribeInstancesRequest{
 		InstanceIds: new(string(ids)),
+	}
+	if diskHighDensityModeEnabled() {
+		// Request the high-density flag from AdditionalInfo. Only when the feature is
+		// on, so a server that rejects the non-standard attribute never receives it.
+		instanceRequest.AdditionalAttributes = []*string{new("DISK_HIGH_DENSITY_MODE")}
 	}
 
 	instanceResponse, err := c.DescribeInstances(&instanceRequest)
@@ -48,12 +54,15 @@ func (m *OpenAPIMetadata) get(key MetadataKey) *string {
 	return nil
 }
 
-func (m *OpenAPIMetadata) Get(key MetadataKey) (string, error) {
-	v := m.get(key)
-	if v == nil {
-		return "", ErrUnknownMetadataKey
+func (m *OpenAPIMetadata) GetAny(_ *mcontext, key MetadataKey) (any, error) {
+	if key == isHighDensityMode {
+		ai := m.instance.AdditionalInfo
+		return ai != nil && ptr.Deref(ai.EnableHighDensityMode, false), nil
 	}
-	return *v, nil
+	if v := m.get(key); v != nil {
+		return *v, nil
+	}
+	return nil, ErrUnknownMetadataKey
 }
 
 type OpenAPIFetcher struct {
@@ -65,7 +74,7 @@ func (f *OpenAPIFetcher) ID() fetcherID { return openAPIFetcherID }
 
 func (f *OpenAPIFetcher) FetchFor(ctx *mcontext, key MetadataKey) (middleware, error) {
 	switch key {
-	case ZoneID, InstanceType:
+	case ZoneID, InstanceType, isHighDensityMode:
 	default:
 		return nil, ErrUnknownMetadataKey
 	}
@@ -93,5 +102,5 @@ func (f *OpenAPIFetcher) FetchFor(ctx *mcontext, key MetadataKey) (middleware, e
 	if err != nil {
 		return nil, err
 	}
-	return newImmutable(strProvider{p}, "OpenAPI"), nil
+	return newImmutable(p, "OpenAPI"), nil
 }

--- a/pkg/cloud/metadata/openapi_test.go
+++ b/pkg/cloud/metadata/openapi_test.go
@@ -8,8 +8,11 @@ import (
 	ecs20140526 "github.com/alibabacloud-go/ecs-20140526/v7/client"
 	"github.com/golang/mock/gomock"
 	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/cloud"
+	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/features"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	featuregatetesting "k8s.io/component-base/featuregate/testing"
+	"k8s.io/utils/ptr"
 )
 
 // It is too long, only show some fields
@@ -61,10 +64,80 @@ func TestGetOpenAPI(t *testing.T) {
 	ecsClient := testEcsClient(t)
 
 	m, err := NewOpenAPIMetadata(ecsClient, "i-2zec1slzwdzrwmvlr4w2")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
-	assert.Equal(t, "cn-beijing-k", MustGet(m, ZoneID))
-	assert.Equal(t, "ecs.g7.xlarge", MustGet(m, InstanceType))
+	ctx := testMContext(t)
+	zone, err := m.GetAny(ctx, ZoneID)
+	assert.NoError(t, err)
+	assert.Equal(t, "cn-beijing-k", zone)
+
+	it, err := m.GetAny(ctx, InstanceType)
+	assert.NoError(t, err)
+	assert.Equal(t, "ecs.g7.xlarge", it)
+}
+
+func TestGetOpenAPIHighDensity(t *testing.T) {
+	featuregatetesting.SetFeatureGateDuringTest(t, features.FunctionalMutableFeatureGate, features.DiskHighDensityMode, true)
+	cases := []struct {
+		name string
+		ai   *ecs20140526.DescribeInstancesResponseBodyInstancesInstanceAdditionalInfo
+		want bool
+	}{
+		{"enabled", &ecs20140526.DescribeInstancesResponseBodyInstancesInstanceAdditionalInfo{EnableHighDensityMode: new(true)}, true},
+		{"disabled", &ecs20140526.DescribeInstancesResponseBodyInstancesInstanceAdditionalInfo{EnableHighDensityMode: new(false)}, false},
+		{"nil flag", &ecs20140526.DescribeInstancesResponseBodyInstancesInstanceAdditionalInfo{}, false},
+		{"nil additional info", nil, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			client := cloud.NewMockECSv2Interface(ctrl)
+			resp := &ecs20140526.DescribeInstancesResponse{
+				Body: &ecs20140526.DescribeInstancesResponseBody{
+					Instances: &ecs20140526.DescribeInstancesResponseBodyInstances{
+						Instance: []*ecs20140526.DescribeInstancesResponseBodyInstancesInstance{
+							{InstanceId: new("i-hd"), AdditionalInfo: c.ai},
+						},
+					},
+				},
+			}
+			client.EXPECT().DescribeInstances(gomock.Any()).DoAndReturn(
+				func(req *ecs20140526.DescribeInstancesRequest) (*ecs20140526.DescribeInstancesResponse, error) {
+					require.Len(t, req.AdditionalAttributes, 1)
+					assert.Equal(t, "DISK_HIGH_DENSITY_MODE", ptr.Deref(req.AdditionalAttributes[0], ""))
+					return resp, nil
+				})
+
+			m, err := NewOpenAPIMetadata(client, "i-hd")
+			require.NoError(t, err)
+			v, err := m.GetAny(testMContext(t), isHighDensityMode)
+			assert.NoError(t, err)
+			assert.Equal(t, c.want, v)
+		})
+	}
+}
+
+func TestGetOpenAPINoAttrWhenGateOff(t *testing.T) {
+	featuregatetesting.SetFeatureGateDuringTest(t, features.FunctionalMutableFeatureGate, features.DiskHighDensityMode, false)
+	ctrl := gomock.NewController(t)
+	client := cloud.NewMockECSv2Interface(ctrl)
+	resp := &ecs20140526.DescribeInstancesResponse{
+		Body: &ecs20140526.DescribeInstancesResponseBody{
+			Instances: &ecs20140526.DescribeInstancesResponseBodyInstances{
+				Instance: []*ecs20140526.DescribeInstancesResponseBodyInstancesInstance{
+					{InstanceId: new("i-hd")},
+				},
+			},
+		},
+	}
+	client.EXPECT().DescribeInstances(gomock.Any()).DoAndReturn(
+		func(req *ecs20140526.DescribeInstancesRequest) (*ecs20140526.DescribeInstancesResponse, error) {
+			assert.Empty(t, req.AdditionalAttributes, "must not send the non-standard attribute when the feature is off")
+			return resp, nil
+		})
+
+	_, err := NewOpenAPIMetadata(client, "i-hd")
+	require.NoError(t, err)
 }
 
 func TestGetOpenAPIError(t *testing.T) {

--- a/pkg/disk/nodeserver.go
+++ b/pkg/disk/nodeserver.go
@@ -872,7 +872,7 @@ func (ns *nodeServer) NodeGetInfo(ctx context.Context, req *csi.NodeGetInfoReque
 		}
 		logger.V(2).Info("using labeler annotation for maxVolumes, skipping all OpenAPI calls", "maxVolumes", maxVolumesNum)
 	} else if maxVolumesNum == 0 {
-		quantity, err := m.DiskQuantity()
+		quantity, err := metadata.EffectiveDiskQuantity(m)
 		if err != nil {
 			if errors.Is(err, metadata.ErrUnknownMetadataKey) {
 				// Some LingJun node don't have this data

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -62,6 +62,16 @@ const (
 	// for fuse pod delete operations. When not explicitly set via --feature-gates,
 	// the behavior is determined by the Kubernetes server version.
 	ConstrainFusePodDeleteRV featuregate.Feature = "ConstrainFusePodDeleteRV"
+
+	// Populate NodeGetInfo MaxVolumesPerNode from the ECS HighDensityDisk mode
+	// (云盘高密模式) limit instead of the default DiskQuantity.
+	//
+	// Relies on non-public ECS OpenAPI fields (AdditionalInfo.EnableHighDensityMode and
+	// the DensityDiskQuantity instance-type attribute). When enabled, the node/labeler
+	// makes one extra DescribeInstances call per high-density-capable node; nodes whose
+	// instance type does not support high density incur no extra call. When disabled,
+	// the behavior is byte-identical to before (no extra API call).
+	DiskHighDensityMode featuregate.Feature = "DiskHighDensityMode"
 )
 
 var (
@@ -73,6 +83,7 @@ var (
 		DisableExpandAutoSnapshots: {Default: true, PreRelease: featuregate.GA, LockToDefault: true},
 		EnableVolumeGroupSnapshots: {Default: false, PreRelease: featuregate.Alpha},
 		EnableDeleteAutoSnapshots:  {Default: false, PreRelease: featuregate.Alpha},
+		DiskHighDensityMode:        {Default: false, PreRelease: featuregate.Alpha},
 	}
 
 	defaultOSSFeatureGate = map[featuregate.Feature]featuregate.FeatureSpec{

--- a/pkg/labeler/labeler.go
+++ b/pkg/labeler/labeler.go
@@ -172,7 +172,7 @@ func runOnce(ctx context.Context, client kubernetes.Interface, ecsClient cloud.E
 		RegionID:          regionID,
 		NodeLister:        nodeInformer.Lister(),
 		Queue:             queue,
-		instanceTypeCache: ttlcache.NewTTLCache[string, int32](defaultInstanceTypeTTL),
+		instanceTypeCache: ttlcache.NewTTLCache[string, diskQuantities](defaultInstanceTypeTTL),
 		nodeTypeCache:     ttlcache.NewTTLCache[string, int32](defaultInstanceTypeTTL),
 		diskTypesCache:    ttlcache.NewTTLCache[diskTypeCacheKey, []string](defaultInstanceTypeTTL),
 	}

--- a/pkg/labeler/reconcile.go
+++ b/pkg/labeler/reconcile.go
@@ -39,7 +39,7 @@ type Reconciler struct {
 	NodeLister corev1listers.NodeLister
 	Queue      workqueue.TypedRateLimitingInterface[string]
 
-	instanceTypeCache *ttlcache.TTLCache[string, int32]
+	instanceTypeCache *ttlcache.TTLCache[string, diskQuantities]
 	nodeTypeCache     *ttlcache.TTLCache[string, int32]
 	diskTypesCache    *ttlcache.TTLCache[diskTypeCacheKey, []string]
 }
@@ -47,6 +47,14 @@ type Reconciler struct {
 type diskTypeCacheKey struct {
 	instanceType string
 	zoneID       string
+}
+
+// diskQuantities holds the per-instance-type disk attach limits. Both values are
+// per-type and safe to cache. highDensity is 0 when the type does not support
+// HighDensityDisk mode or the feature gate is off.
+type diskQuantities struct {
+	normal      int32
+	highDensity int32
 }
 
 func (r *Reconciler) enqueue(obj any) {
@@ -178,9 +186,21 @@ func (r *Reconciler) resolveECS(ctx context.Context, mp metadata.MetadataProvide
 		return 0, nil, err
 	}
 
-	diskQuantity, err := r.resolveDiskQuantity(ctx, mp, instanceType)
+	quantities, err := r.resolveDiskQuantities(ctx, mp, instanceType)
 	if err != nil {
 		return 0, nil, fmt.Errorf("get disk quantity for %s: %w", instanceType, err)
+	}
+	diskQuantity := quantities.normal
+	if quantities.highDensity > quantities.normal {
+		// The type supports HighDensityDisk mode. Whether it is actually enabled is
+		// per-instance, so query the flag per node (uncached).
+		hd, err := mp.IsHighDensityMode()
+		if err != nil {
+			return 0, nil, fmt.Errorf("check high density mode for %s: %w", instanceType, err)
+		}
+		if hd {
+			diskQuantity = quantities.highDensity
+		}
 	}
 
 	zoneID, err := mp.Get(metadata.ZoneID)
@@ -210,11 +230,19 @@ func (r *Reconciler) resolveLingjun(ctx context.Context, mp metadata.MetadataPro
 	return diskQuantity, diskTypes, nil
 }
 
-// resolveDiskQuantity returns the cached disk quantity for instanceType,
-// computing it via nm.DiskQuantity() if not cached.
-func (r *Reconciler) resolveDiskQuantity(ctx context.Context, nm metadata.MetadataProvider, instanceType string) (int32, error) {
-	return r.instanceTypeCache.Get(ctx, instanceType, func() (int32, error) {
-		return nm.DiskQuantity()
+// resolveDiskQuantities returns the cached per-type disk quantities for instanceType,
+// computing them via nm on a cache miss.
+func (r *Reconciler) resolveDiskQuantities(ctx context.Context, nm metadata.MetadataProvider, instanceType string) (diskQuantities, error) {
+	return r.instanceTypeCache.Get(ctx, instanceType, func() (diskQuantities, error) {
+		normal, err := nm.DiskQuantity()
+		if err != nil {
+			return diskQuantities{}, err
+		}
+		highDensity, err := nm.DiskQuantityHighDensity()
+		if err != nil && !errors.Is(err, metadata.ErrUnknownMetadataKey) {
+			return diskQuantities{}, err
+		}
+		return diskQuantities{normal: normal, highDensity: highDensity}, nil
 	})
 }
 

--- a/pkg/labeler/reconcile_test.go
+++ b/pkg/labeler/reconcile_test.go
@@ -2,6 +2,7 @@ package labeler
 
 import (
 	"errors"
+	"strconv"
 	"testing"
 
 	ecsv2 "github.com/alibabacloud-go/ecs-20140526/v7/client"
@@ -9,6 +10,7 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/cloud"
 	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/disk"
+	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/features"
 	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/utils/ttlcache"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -19,6 +21,7 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 	clienttesting "k8s.io/client-go/testing"
 	"k8s.io/client-go/util/workqueue"
+	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	"k8s.io/klog/v2/ktesting"
 	"k8s.io/utils/ptr"
 )
@@ -29,6 +32,35 @@ func describeInstanceTypesV2Resp(instanceType string, diskQty int32) *ecsv2.Desc
 			InstanceTypes: &ecsv2.DescribeInstanceTypesResponseBodyInstanceTypes{
 				InstanceType: []*ecsv2.DescribeInstanceTypesResponseBodyInstanceTypesInstanceType{
 					{InstanceTypeId: &instanceType, DiskQuantity: &diskQty},
+				},
+			},
+		},
+	}
+}
+
+// describeInstanceTypesV2RespDensity builds a response advertising both the normal
+// DiskQuantity and the DensityDiskQuantity attribute (HighDensityDisk mode).
+func describeInstanceTypesV2RespDensity(instanceType string, diskQty, density int32) *ecsv2.DescribeInstanceTypesResponse {
+	resp := describeInstanceTypesV2Resp(instanceType, diskQty)
+	resp.Body.InstanceTypes.InstanceType[0].Attributes = &ecsv2.DescribeInstanceTypesResponseBodyInstanceTypesInstanceTypeAttributes{
+		Attribute: []*ecsv2.DescribeInstanceTypesResponseBodyInstanceTypesInstanceTypeAttributesAttribute{
+			{Name: new("DensityDiskQuantity"), Value: new(strconv.Itoa(int(density)))},
+		},
+	}
+	return resp
+}
+
+// describeInstancesV2RespHighDensity builds a DescribeInstances response carrying
+// the per-instance EnableHighDensityMode flag.
+func describeInstancesV2RespHighDensity(instanceID string, enabled bool) *ecsv2.DescribeInstancesResponse {
+	return &ecsv2.DescribeInstancesResponse{
+		Body: &ecsv2.DescribeInstancesResponseBody{
+			Instances: &ecsv2.DescribeInstancesResponseBodyInstances{
+				Instance: []*ecsv2.DescribeInstancesResponseBodyInstancesInstance{
+					{
+						InstanceId:     &instanceID,
+						AdditionalInfo: &ecsv2.DescribeInstancesResponseBodyInstancesInstanceAdditionalInfo{EnableHighDensityMode: &enabled},
+					},
 				},
 			},
 		},
@@ -163,7 +195,7 @@ func newTestFixture(t *testing.T, nodes ...*v1.Node) *testFixture {
 			RegionID:          "cn-test",
 			NodeLister:        nodeInformer.Lister(),
 			Queue:             q,
-			instanceTypeCache: ttlcache.NewTTLCache[string, int32](defaultInstanceTypeTTL),
+			instanceTypeCache: ttlcache.NewTTLCache[string, diskQuantities](defaultInstanceTypeTTL),
 			nodeTypeCache:     ttlcache.NewTTLCache[string, int32](defaultInstanceTypeTTL),
 			diskTypesCache:    ttlcache.NewTTLCache[diskTypeCacheKey, []string](defaultInstanceTypeTTL),
 		},
@@ -318,6 +350,113 @@ func TestReconcile_FullPatch(t *testing.T) {
 			"labels": {"node.csi.alibabacloud.com/disktype.cloud_essd": "available", "node.csi.alibabacloud.com/disktype.cloud_regional_disk_auto": "available"}
 		}
 	}`, string(patchBody))
+}
+
+func hdNode(name string) *v1.Node {
+	return &v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+			Labels: map[string]string{
+				"node.kubernetes.io/instance-type": "ecs.c7a.4xlarge",
+				"topology.kubernetes.io/zone":      "cn-test-a",
+			},
+		},
+		Spec: v1.NodeSpec{ProviderID: "cn-test.i-bp1hd"},
+	}
+}
+
+// expectDiskTypesAndDisks sets up the disk-type and attached-disk calls shared by
+// the high-density reconcile subtests (one system disk => nonManaged=1).
+func expectDiskTypesAndDisks(f *testFixture) {
+	f.ecs.EXPECT().DescribeAvailableResource(gomock.Any()).
+		Return(makeAvailResp("cn-test-a", "cloud_essd"), nil)
+	f.ecs.EXPECT().DescribeAvailableResource(gomock.Any()).
+		Return(makeAvailResp("", "cloud_essd"), nil)
+	f.ecs.EXPECT().DescribeDisks(gomock.Any()).
+		Return(&ecsv2.DescribeDisksResponse{
+			Body: &ecsv2.DescribeDisksResponseBody{
+				Disks: &ecsv2.DescribeDisksResponseBodyDisks{
+					Disk: []*ecsv2.DescribeDisksResponseBodyDisksDisk{
+						{DiskId: new("d-system"), Category: new("cloud_essd"), Status: new("In_use")},
+					},
+				},
+			},
+		}, nil)
+}
+
+func patchedMaxDisk(t *testing.T, f *testFixture) []byte {
+	t.Helper()
+	var patchBody []byte
+	for _, a := range f.client.Actions() {
+		if pa, ok := a.(clienttesting.PatchAction); ok {
+			patchBody = pa.GetPatch()
+		}
+	}
+	return patchBody
+}
+
+func TestReconcile_HighDensity(t *testing.T) {
+	t.Run("gate on, mode enabled -> density quantity", func(t *testing.T) {
+		node := hdNode("node-hd-on")
+		f := newTestFixture(t, node)
+		featuregatetesting.SetFeatureGateDuringTest(t, features.FunctionalMutableFeatureGate, features.DiskHighDensityMode, true)
+
+		f.ecs.EXPECT().DescribeInstanceTypes(gomock.Any()).
+			Return(describeInstanceTypesV2RespDensity("ecs.c7a.4xlarge", 9, 33), nil)
+		f.ecs.EXPECT().DescribeInstances(gomock.Any()).DoAndReturn(
+			func(req *ecsv2.DescribeInstancesRequest) (*ecsv2.DescribeInstancesResponse, error) {
+				require.Len(t, req.AdditionalAttributes, 1)
+				assert.Equal(t, "DISK_HIGH_DENSITY_MODE", ptr.Deref(req.AdditionalAttributes[0], ""))
+				return describeInstancesV2RespHighDensity("i-bp1hd", true), nil
+			})
+		expectDiskTypesAndDisks(f)
+
+		logger, ctx := ktesting.NewTestContext(t)
+		require.NoError(t, f.r.reconcile(ctx, logger, node.Name))
+
+		body := patchedMaxDisk(t, f)
+		require.NotNil(t, body)
+		assert.Contains(t, string(body), `"node.csi.alibabacloud.com/max-disk":"32"`) // 33 - 1 system disk
+	})
+
+	t.Run("gate on, mode disabled -> normal quantity", func(t *testing.T) {
+		node := hdNode("node-hd-off")
+		f := newTestFixture(t, node)
+		featuregatetesting.SetFeatureGateDuringTest(t, features.FunctionalMutableFeatureGate, features.DiskHighDensityMode, true)
+
+		f.ecs.EXPECT().DescribeInstanceTypes(gomock.Any()).
+			Return(describeInstanceTypesV2RespDensity("ecs.c7a.4xlarge", 9, 33), nil)
+		f.ecs.EXPECT().DescribeInstances(gomock.Any()).
+			Return(describeInstancesV2RespHighDensity("i-bp1hd", false), nil)
+		expectDiskTypesAndDisks(f)
+
+		logger, ctx := ktesting.NewTestContext(t)
+		require.NoError(t, f.r.reconcile(ctx, logger, node.Name))
+
+		body := patchedMaxDisk(t, f)
+		require.NotNil(t, body)
+		assert.Contains(t, string(body), `"node.csi.alibabacloud.com/max-disk":"8"`) // 9 - 1 system disk
+	})
+
+	t.Run("gate off -> no DescribeInstances, normal quantity", func(t *testing.T) {
+		node := hdNode("node-hd-gateoff")
+		f := newTestFixture(t, node)
+		// Gate defaults to off; be explicit for clarity.
+		featuregatetesting.SetFeatureGateDuringTest(t, features.FunctionalMutableFeatureGate, features.DiskHighDensityMode, false)
+
+		f.ecs.EXPECT().DescribeInstanceTypes(gomock.Any()).
+			Return(describeInstanceTypesV2RespDensity("ecs.c7a.4xlarge", 9, 33), nil)
+		// Must not consult the per-instance high-density flag when the gate is off.
+		f.ecs.EXPECT().DescribeInstances(gomock.Any()).Times(0)
+		expectDiskTypesAndDisks(f)
+
+		logger, ctx := ktesting.NewTestContext(t)
+		require.NoError(t, f.r.reconcile(ctx, logger, node.Name))
+
+		body := patchedMaxDisk(t, f)
+		require.NotNil(t, body)
+		assert.Contains(t, string(body), `"node.csi.alibabacloud.com/max-disk":"8"`) // 9 - 1 system disk
+	})
 }
 
 func TestReconcile_APIErrors(t *testing.T) {


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

When an ECS instance runs in **HighDensityDisk mode (云盘高密模式)**, it can attach far more
cloud disks than its default `DiskQuantity`. This PR makes the disk driver report that raised
limit in `NodeGetInfo.MaxVolumesPerNode` (and the centralized labeler's
`node.csi.alibabacloud.com/max-disk` annotation) so the scheduler packs disks correctly.

The feature relies on non-public ECS OpenAPI fields, so it is behind an **alpha feature gate
`DiskHighDensityMode` (off by default)** with **zero overhead when off** — no extra OpenAPI
calls and no non-standard request fields are sent.

Details:
- High-density state is **per-instance** — `DescribeInstances`
  `AdditionalInfo.EnableHighDensityMode` (needs `AdditionalAttributes=DISK_HIGH_DENSITY_MODE`).
- The raised limit is **per-instance-type** — the `DensityDiskQuantity` attribute of
  `DescribeInstanceTypes` (needs `MaxResults` set, otherwise `Attributes` is omitted).
- `metadata.EffectiveDiskQuantity` composes them: it only makes the per-instance
  `DescribeInstances` call for types that actually advertise a higher `DensityDiskQuantity`,
  so non-capable types take the normal path with no extra API call.
- The gate is consulted at a single point in the metadata layer; the node plugin and the
  labeler need no gate check of their own, and when the gate is off `DescribeInstances`
  carries no `AdditionalAttributes`.

Validated end-to-end on a test node (`ecs.c7a.4xlarge`, high-density on): the
`allocatable-disk` annotation and the CSINode allocatable count flip from 8 to 32.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

- Also included: a small dev-env tooling fix (`init-dev-env` skill) so the generated image
  pull secret also authorizes the VPC ACR endpoint, for clusters without public internet.
- `DensityDiskQuantity` / `EnableHighDensityMode` are non-public ECS OpenAPI surface, hence
  the gate.

#### Does this PR introduce a user-facing change?

```release-note
Add an alpha `DiskHighDensityMode` feature gate (off by default). When enabled, the disk driver reports the raised disk attach limit of ECS instances running in HighDensityDisk mode (云盘高密模式) as NodeGetInfo MaxVolumesPerNode.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
