### PR TITLE
bmcpfs: make VSC caching backend-agnostic via Backend/Instance

### DIFF
--- a/pkg/bmcpfs/controllerserver.go
+++ b/pkg/bmcpfs/controllerserver.go
@@ -52,11 +52,25 @@ import (
 type controllerServer struct {
 	common.GenericControllerServer
 	vscManager     *internal.PrimaryVscManagerWithCache
+	ecsBackend     internal.Backend
+	lingjunBackend internal.Backend
 	attachDetacher internal.CPFSAttachDetacher
 	filesetManager internal.CPFSFileSetManager
 	locks          *utils.VolumeLocks
 	nasClient      *nasclient.Client
 	skipDetach     bool
+}
+
+// vscInstance pairs an instance ID with its VSC backend, selected from the node
+// kind the CSI layer already parsed. This is the single site that pairs the two;
+// it is only called for VSC-capable kinds (see nodeKind.supportsVSC), so any
+// non-Lingjun kind is nodeKindVSC and maps to ECS.
+func (cs *controllerServer) vscInstance(instanceID string, kind nodeKind) internal.Instance {
+	backend := cs.ecsBackend
+	if kind == nodeKindLingjun {
+		backend = cs.lingjunBackend
+	}
+	return internal.Instance{ID: instanceID, Backend: backend}
 }
 
 func newControllerServer(meta *metadata.Metadata) (*controllerServer, error) {
@@ -83,7 +97,9 @@ func newControllerServer(meta *metadata.Metadata) (*controllerServer, error) {
 	}
 
 	return &controllerServer{
-		vscManager:     internal.NewPrimaryVscManagerWithCache(efloClient, ecsClient),
+		vscManager:     internal.NewPrimaryVscManagerWithCache(),
+		ecsBackend:     internal.NewEcsBackend(ecsClient),
+		lingjunBackend: internal.NewEfloBackend(efloClient),
 		attachDetacher: internal.NewCPFSAttachDetacher(nasClient),
 		filesetManager: internal.NewCPFSFileSetManager(nasClient),
 		locks:          utils.NewVolumeLocks(),
@@ -246,7 +262,7 @@ func (cs *controllerServer) ControllerPublishVolume(ctx context.Context, req *cs
 	}
 
 	// Get Primary VSC for the node (Lingjun or ECS w/ VSC enabled)
-	vscID, err := cs.vscManager.EnsurePrimaryVsc(ctx, instanceID)
+	vscID, err := cs.vscManager.EnsurePrimaryVsc(ctx, cs.vscInstance(instanceID, kind))
 	if err != nil {
 		return nil, status.Error(codes.Internal, err.Error())
 	}
@@ -287,7 +303,7 @@ func (cs *controllerServer) ControllerUnpublishVolume(ctx context.Context, req *
 	if !kind.supportsVSC() || cs.skipDetach {
 		return &csi.ControllerUnpublishVolumeResponse{}, nil
 	}
-	vsc, err := cs.vscManager.GetPrimaryVscOf(ctx, instanceID)
+	vsc, err := cs.vscManager.GetPrimaryVscOf(ctx, cs.vscInstance(instanceID, kind))
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "get vsc error: %v", err)
 	}

--- a/pkg/bmcpfs/internal/vsc.go
+++ b/pkg/bmcpfs/internal/vsc.go
@@ -40,30 +40,16 @@ func newVscThrottler() *throttle.Throttler {
 	return throttle.NewThrottler(clock.RealClock{}, 1*time.Second, 10*time.Second, throttle.V2Classifier)
 }
 
-// vscDialect captures backend-specific values for VSC type/status enums
-// that are conceptually identical between Lingjun (eflo) and ECS backends
-// but use different string literals.
-type vscDialect struct {
-	PrimaryType  string // VSC type for "primary"
-	StatusNormal string // status meaning the VSC is healthy/usable
-}
+// Backend-specific wire values for the VSC "primary" type and the healthy/usable
+// status. The concepts are identical across Lingjun (eflo) and ECS; only the string
+// literals differ. Each backend uses its own pair directly.
+const (
+	efloPrimaryVscType  = "primary" // VSC type for "primary"
+	efloVscStatusNormal = "Normal"  // status meaning the VSC is healthy/usable
 
-var (
-	efloVscDialect = vscDialect{
-		PrimaryType:  "primary",
-		StatusNormal: "Normal",
-	}
-	ecsVscDialect = vscDialect{
-		PrimaryType:  "Primary",
-		StatusNormal: "In_use",
-	}
+	ecsPrimaryVscType  = "Primary"
+	ecsVscStatusNormal = "In_use"
 )
-
-// isECSInstance reports whether the instanceId belongs to an ECS instance.
-// ECS instance IDs are prefixed with "i-"; Lingjun node IDs are not.
-func isECSInstance(instanceId string) bool {
-	return strings.HasPrefix(instanceId, "i-")
-}
 
 type Vsc struct {
 	NodeID string
@@ -72,54 +58,36 @@ type Vsc struct {
 	Status string
 }
 
-// VscBackend is the interface each cloud backend implements independently.
-type VscBackend interface {
+// Backend is the interface each cloud backend (Lingjun/eflo or ECS) implements.
+// It holds all per-backend shared state (client, throttlers) and owns its own
+// status/type dialect via Ready. A Backend is constructed once and shared across
+// every instance it serves.
+type Backend interface {
 	CreatePrimaryVsc(ctx context.Context, instanceId string) (string, error)
-	GetPrimaryVscOf(ctx context.Context, instanceId string) (*Vsc, error)
+	GetPrimaryVsc(ctx context.Context, instanceId string) (*Vsc, error)
 	GetVsc(ctx context.Context, vscId string) (*Vsc, error)
+	// Ready reports whether a VSC has reached this backend's usable status.
+	Ready(*Vsc) bool
 }
 
-type VscManager interface {
-	CreatePrimaryVscFor(ctx context.Context, instanceId string) (string, error)
-	GetPrimaryVscOf(ctx context.Context, instanceId string) (*Vsc, error)
-	// GetVsc retrieves a single VSC by ID. The instanceId is used only for
-	// routing to the correct backend; individual backends do not need it.
-	GetVsc(ctx context.Context, vscId, instanceId string) (*Vsc, error)
+// Instance binds an instance/node ID to the Backend that serves it. It is a cheap
+// value: Backend carries the shared state, so callers build an Instance per request
+// for free. The caller picks the Backend (the CSI layer does so from the node kind
+// it parsed); this package does not inspect the ID to choose a Backend.
+type Instance struct {
+	ID      string
+	Backend Backend
 }
 
-func NewVscManager(eflo *efloClient.Client, ecs *ecsClient.Client) VscManager {
-	return &dispatchingVscManager{
-		eflo: newEfloVscBackend(eflo),
-		ecs:  newEcsVscBackend(ecs),
-	}
+func (i Instance) createPrimary(ctx context.Context) (string, error) {
+	return i.Backend.CreatePrimaryVsc(ctx, i.ID)
 }
 
-// dispatchingVscManager routes calls to the correct backend based on instanceId.
-type dispatchingVscManager struct {
-	eflo VscBackend
-	ecs  VscBackend
+func (i Instance) getPrimary(ctx context.Context) (*Vsc, error) {
+	return i.Backend.GetPrimaryVsc(ctx, i.ID)
 }
 
-func (m *dispatchingVscManager) backendFor(instanceId string) VscBackend {
-	if isECSInstance(instanceId) {
-		return m.ecs
-	}
-	return m.eflo
-}
-
-func (m *dispatchingVscManager) CreatePrimaryVscFor(ctx context.Context, instanceId string) (string, error) {
-	return m.backendFor(instanceId).CreatePrimaryVsc(ctx, instanceId)
-}
-
-func (m *dispatchingVscManager) GetPrimaryVscOf(ctx context.Context, instanceId string) (*Vsc, error) {
-	return m.backendFor(instanceId).GetPrimaryVscOf(ctx, instanceId)
-}
-
-func (m *dispatchingVscManager) GetVsc(ctx context.Context, vscId, instanceId string) (*Vsc, error) {
-	return m.backendFor(instanceId).GetVsc(ctx, vscId)
-}
-
-// efloVscBackend implements VscBackend for Lingjun (eflo) nodes.
+// efloVscBackend implements Backend for Lingjun (eflo) nodes.
 type efloVscBackend struct {
 	client            *efloClient.Client
 	createThrottler   *throttle.Throttler
@@ -127,7 +95,9 @@ type efloVscBackend struct {
 	describeThrottler *throttle.Throttler
 }
 
-func newEfloVscBackend(client *efloClient.Client) *efloVscBackend {
+// NewEfloBackend builds the Backend for Lingjun (eflo) nodes. Construct it once and
+// share it: the throttlers are per-action and must be shared across all instances.
+func NewEfloBackend(client *efloClient.Client) Backend {
 	return &efloVscBackend{
 		client:            client,
 		createThrottler:   newVscThrottler(),
@@ -136,10 +106,14 @@ func newEfloVscBackend(client *efloClient.Client) *efloVscBackend {
 	}
 }
 
+func (b *efloVscBackend) Ready(v *Vsc) bool {
+	return v.Status == efloVscStatusNormal
+}
+
 func (b *efloVscBackend) CreatePrimaryVsc(ctx context.Context, instanceId string) (string, error) {
 	req := &efloClient.CreateVscRequest{
 		NodeId:  &instanceId,
-		VscType: new(efloVscDialect.PrimaryType),
+		VscType: new(efloPrimaryVscType),
 	}
 	resp, err := throttle.Throttled(b.createThrottler, b.client.CreateVsc)(ctx, req)
 	if err != nil {
@@ -152,7 +126,7 @@ func (b *efloVscBackend) CreatePrimaryVsc(ctx context.Context, instanceId string
 	return tea.StringValue(resp.Body.VscId), nil
 }
 
-func (b *efloVscBackend) GetPrimaryVscOf(ctx context.Context, instanceId string) (*Vsc, error) {
+func (b *efloVscBackend) GetPrimaryVsc(ctx context.Context, instanceId string) (*Vsc, error) {
 	req := &efloClient.ListVscsRequest{
 		NodeIds:    []*string{&instanceId},
 		MaxResults: tea.Int32(100),
@@ -163,7 +137,7 @@ func (b *efloVscBackend) GetPrimaryVscOf(ctx context.Context, instanceId string)
 	}
 	klog.V(4).InfoS("eflo:ListVscs succeeded", "instanceId", instanceId, "response", resp.Body)
 	for _, vsc := range resp.Body.Vscs {
-		if tea.StringValue(vsc.VscType) == efloVscDialect.PrimaryType {
+		if tea.StringValue(vsc.VscType) == efloPrimaryVscType {
 			return &Vsc{
 				NodeID: tea.StringValue(vsc.NodeId),
 				VscID:  tea.StringValue(vsc.VscId),
@@ -192,14 +166,16 @@ func (b *efloVscBackend) GetVsc(ctx context.Context, vscId string) (*Vsc, error)
 	}, nil
 }
 
-// ecsVscBackend implements VscBackend for ECS nodes with VSC enabled.
+// ecsVscBackend implements Backend for ECS nodes with VSC enabled.
 type ecsVscBackend struct {
 	client            *ecsClient.Client
 	createThrottler   *throttle.Throttler
 	describeThrottler *throttle.Throttler
 }
 
-func newEcsVscBackend(client *ecsClient.Client) *ecsVscBackend {
+// NewEcsBackend builds the Backend for ECS nodes with VSC enabled. Construct it once
+// and share it: the throttlers are per-action and must be shared across all instances.
+func NewEcsBackend(client *ecsClient.Client) Backend {
 	return &ecsVscBackend{
 		client:            client,
 		createThrottler:   newVscThrottler(),
@@ -207,10 +183,14 @@ func newEcsVscBackend(client *ecsClient.Client) *ecsVscBackend {
 	}
 }
 
+func (b *ecsVscBackend) Ready(v *Vsc) bool {
+	return v.Status == ecsVscStatusNormal
+}
+
 func (b *ecsVscBackend) CreatePrimaryVsc(ctx context.Context, instanceId string) (string, error) {
 	req := &ecsClient.CreateVscRequest{
 		InstanceId: &instanceId,
-		VscType:    new(ecsVscDialect.PrimaryType),
+		VscType:    new(ecsPrimaryVscType),
 	}
 	resp, err := throttle.Throttled(b.createThrottler, b.client.CreateVsc)(ctx, req)
 	if err != nil {
@@ -223,7 +203,7 @@ func (b *ecsVscBackend) CreatePrimaryVsc(ctx context.Context, instanceId string)
 	return tea.StringValue(resp.Body.VscId), nil
 }
 
-func (b *ecsVscBackend) GetPrimaryVscOf(ctx context.Context, instanceId string) (*Vsc, error) {
+func (b *ecsVscBackend) GetPrimaryVsc(ctx context.Context, instanceId string) (*Vsc, error) {
 	req := &ecsClient.DescribeVscsRequest{
 		InstanceId: &instanceId,
 		MaxResults: tea.Int32(100),
@@ -234,7 +214,7 @@ func (b *ecsVscBackend) GetPrimaryVscOf(ctx context.Context, instanceId string) 
 	}
 	klog.V(4).InfoS("ecs:DescribeVscs succeeded", "instanceId", instanceId, "response", resp.Body)
 	for _, vsc := range resp.Body.Vscs {
-		if tea.StringValue(vsc.VscType) == ecsVscDialect.PrimaryType {
+		if tea.StringValue(vsc.VscType) == ecsPrimaryVscType {
 			return &Vsc{
 				NodeID: tea.StringValue(vsc.InstanceId),
 				VscID:  tea.StringValue(vsc.VscId),
@@ -272,16 +252,17 @@ func (b *ecsVscBackend) GetVsc(ctx context.Context, vscId string) (*Vsc, error) 
 // absence might be transient) while still deduplicating concurrent lookups.
 var errVscNotFound = errors.New("primary vsc not found")
 
-// PrimaryVscManagerWithCache adds single-flight TTL caching on top of a
-// VscManager. Concurrency is reactive: requests are sent freely and each
-// backend action backs off only when the cloud actually throttles it (see
+// PrimaryVscManagerWithCache adds single-flight TTL caching on top of the VSC
+// Backends. It is backend-agnostic: callers pass a resolved Instance (an ID paired
+// with its Backend) and this layer only caches, single-flights and polls — it does
+// no backend selection itself. Concurrency is reactive: requests are sent freely and
+// each backend action backs off only when the cloud actually throttles it (see
 // newVscThrottler), rather than being capped by a fixed worker pool.
 type PrimaryVscManagerWithCache struct {
-	VscManager
-
 	// vscCache is the single VSC cache, shared by GetPrimaryVscOf (read-through)
 	// and EnsurePrimaryVsc (write-through on a confirmed VSC), so a publish warms
-	// the cache that a later unpublish reads.
+	// the cache that a later unpublish reads. Keyed by instance ID; ECS ("i-…") and
+	// Lingjun IDs never collide, so one cache safely spans both backends.
 	vscCache *ttlcache.TTLCache[string, *Vsc]
 	// createVsc single-flights EnsurePrimaryVsc per instance so concurrent
 	// publishes for a new node create only one VSC. Its TTL is 0: it never caches
@@ -291,7 +272,7 @@ type PrimaryVscManagerWithCache struct {
 	clk          clock.Clock
 	pollInterval time.Duration
 	// pollAttempts is how many times getOrCreatePrimaryFor polls GetVsc for the
-	// expected status. Must be >= 1, so a freshly created VSC (not fetched before
+	// ready status. Must be >= 1, so a freshly created VSC (not fetched before
 	// the loop) is always fetched at least once.
 	pollAttempts int
 }
@@ -304,9 +285,8 @@ const (
 	defaultVscPollAttempts = 5
 )
 
-func NewPrimaryVscManagerWithCache(efloClient *efloClient.Client, ecsClient *ecsClient.Client) *PrimaryVscManagerWithCache {
+func NewPrimaryVscManagerWithCache() *PrimaryVscManagerWithCache {
 	return &PrimaryVscManagerWithCache{
-		VscManager:   NewVscManager(efloClient, ecsClient),
 		vscCache:     ttlcache.NewTTLCache[string, *Vsc](defaultVscCacheTTL),
 		createVsc:    ttlcache.NewTTLCache[string, *Vsc](0),
 		clk:          clock.RealClock{},
@@ -315,11 +295,11 @@ func NewPrimaryVscManagerWithCache(efloClient *efloClient.Client, ecsClient *ecs
 	}
 }
 
-func (m *PrimaryVscManagerWithCache) EnsurePrimaryVsc(ctx context.Context, instanceId string) (string, error) {
-	vsc, err := m.createVsc.Get(ctx, instanceId, func() (*Vsc, error) {
+func (m *PrimaryVscManagerWithCache) EnsurePrimaryVsc(ctx context.Context, inst Instance) (string, error) {
+	vsc, err := m.createVsc.Get(ctx, inst.ID, func() (*Vsc, error) {
 		// Decouple the shared computation from any single caller's cancellation;
 		// concurrent waiters still cancel their own wait via the ctx passed to Get.
-		return m.getOrCreatePrimaryFor(context.WithoutCancel(ctx), instanceId)
+		return m.getOrCreatePrimaryFor(context.WithoutCancel(ctx), inst)
 	})
 	if err != nil {
 		return "", err
@@ -327,9 +307,9 @@ func (m *PrimaryVscManagerWithCache) EnsurePrimaryVsc(ctx context.Context, insta
 	return vsc.VscID, nil
 }
 
-func (m *PrimaryVscManagerWithCache) GetPrimaryVscOf(ctx context.Context, instanceId string) (*Vsc, error) {
-	vsc, err := m.vscCache.Get(ctx, instanceId, func() (*Vsc, error) {
-		vsc, err := m.VscManager.GetPrimaryVscOf(ctx, instanceId)
+func (m *PrimaryVscManagerWithCache) GetPrimaryVscOf(ctx context.Context, inst Instance) (*Vsc, error) {
+	vsc, err := m.vscCache.Get(ctx, inst.ID, func() (*Vsc, error) {
+		vsc, err := inst.getPrimary(ctx)
 		if err != nil {
 			return nil, err
 		}
@@ -344,48 +324,43 @@ func (m *PrimaryVscManagerWithCache) GetPrimaryVscOf(ctx context.Context, instan
 	return vsc, err
 }
 
-func (m *PrimaryVscManagerWithCache) getOrCreatePrimaryFor(ctx context.Context, instanceId string) (*Vsc, error) {
-	expected := efloVscDialect.StatusNormal
-	if isECSInstance(instanceId) {
-		expected = ecsVscDialect.StatusNormal
-	}
-
+func (m *PrimaryVscManagerWithCache) getOrCreatePrimaryFor(ctx context.Context, inst Instance) (*Vsc, error) {
 	// try to get existing vsc (through the read cache)
-	vsc, err := m.GetPrimaryVscOf(ctx, instanceId)
+	vsc, err := m.GetPrimaryVscOf(ctx, inst)
 	if err != nil {
 		return nil, err
 	}
 
 	var vscID string
 	if vsc != nil {
-		if vsc.Status == expected {
+		if inst.Backend.Ready(vsc) {
 			return vsc, nil // already usable; GetPrimaryVscOf cached it
 		}
 		vscID = vsc.VscID
 	} else {
 		// primary vsc of the instance not found, create it
-		vscID, err = m.CreatePrimaryVscFor(ctx, instanceId)
+		vscID, err = inst.createPrimary(ctx)
 		if err != nil {
 			return nil, err
 		}
 	}
 
 	// A freshly created (or not-yet-ready) VSC may take a moment to become
-	// usable; poll GetVsc a bounded number of times until it reaches expected.
+	// usable; poll GetVsc a bounded number of times until it becomes ready.
 	for range m.pollAttempts {
 		select {
 		case <-ctx.Done():
 			return vsc, ctx.Err()
 		case <-m.clk.After(m.pollInterval):
 		}
-		if vsc, err = m.GetVsc(ctx, vscID, instanceId); err != nil {
+		if vsc, err = inst.Backend.GetVsc(ctx, vscID); err != nil {
 			return nil, err
 		}
 		if vsc == nil {
 			return nil, fmt.Errorf("vsc %s not found after creation", vscID)
 		}
-		if vsc.Status == expected {
-			m.vscCache.Store(instanceId, vsc)
+		if inst.Backend.Ready(vsc) {
+			m.vscCache.Store(inst.ID, vsc)
 			return vsc, nil
 		}
 	}

--- a/pkg/bmcpfs/internal/vsc.go
+++ b/pkg/bmcpfs/internal/vsc.go
@@ -139,7 +139,7 @@ func newEfloVscBackend(client *efloClient.Client) *efloVscBackend {
 func (b *efloVscBackend) CreatePrimaryVsc(ctx context.Context, instanceId string) (string, error) {
 	req := &efloClient.CreateVscRequest{
 		NodeId:  &instanceId,
-		VscType: tea.String(efloVscDialect.PrimaryType),
+		VscType: new(efloVscDialect.PrimaryType),
 	}
 	resp, err := throttle.Throttled(b.createThrottler, b.client.CreateVsc)(ctx, req)
 	if err != nil {
@@ -210,7 +210,7 @@ func newEcsVscBackend(client *ecsClient.Client) *ecsVscBackend {
 func (b *ecsVscBackend) CreatePrimaryVsc(ctx context.Context, instanceId string) (string, error) {
 	req := &ecsClient.CreateVscRequest{
 		InstanceId: &instanceId,
-		VscType:    tea.String(ecsVscDialect.PrimaryType),
+		VscType:    new(ecsVscDialect.PrimaryType),
 	}
 	resp, err := throttle.Throttled(b.createThrottler, b.client.CreateVsc)(ctx, req)
 	if err != nil {
@@ -435,12 +435,11 @@ func IsAttachNotSupportedError(err error) bool {
 	if err == nil {
 		return false
 	}
-	var attachErr *AttachNotSupportedError
-	if errors.As(err, &attachErr) {
+	if _, ok := errors.AsType[*AttachNotSupportedError](err); ok {
 		return true
 	}
-	sdkErr := &tea.SDKError{}
-	return errors.As(err, &sdkErr) && tea.StringValue(sdkErr.Code) == VscAttachNotSupported
+	sdkErr, ok := errors.AsType[*tea.SDKError](err)
+	return ok && tea.StringValue(sdkErr.Code) == VscAttachNotSupported
 }
 
 type CPFSVscAttachInfo = nasclient.DescribeFilesystemsVscAttachInfoResponseBodyVscAttachInfoVscAttachInfo
@@ -507,8 +506,7 @@ func (ad *cpfsAttachDetacher) Attach(ctx context.Context, fsId, vscId string) er
 
 func (ad *cpfsAttachDetacher) Detach(ctx context.Context, fsId, vscId string) error {
 	if err := ad.detach(fsId, vscId); err != nil {
-		sdkErr := new(tea.SDKError)
-		if errors.As(err, &sdkErr) {
+		if sdkErr, ok := errors.AsType[*tea.SDKError](err); ok {
 			errCode := tea.StringValue(sdkErr.Code)
 			// attached by legacy inner api, ignore it
 			if errCode == "Resource.Check.Fail" || errCode == "InvalidFileSystem.NotFound" {

--- a/pkg/bmcpfs/internal/vsc_test.go
+++ b/pkg/bmcpfs/internal/vsc_test.go
@@ -81,43 +81,22 @@ func TestIsAttachNotSupportedError_SDKErrorWithAttachNotSupportedInMessage(t *te
 	assert.False(t, IsAttachNotSupportedError(sdkErr))
 }
 
-func TestIsECSInstance(t *testing.T) {
-	tests := []struct {
-		name       string
-		instanceId string
-		want       bool
-	}{
-		{name: "ecs instance id", instanceId: "i-0jl17ucar0mf5kn0yzxg", want: true},
-		{name: "lingjun node id", instanceId: "e01-cn-xyz", want: false},
-		{name: "empty", instanceId: "", want: false},
-		{name: "prefix in middle", instanceId: "foo-i-bar", want: false},
-		{name: "only prefix", instanceId: "i-", want: true},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, isECSInstance(tt.instanceId))
-		})
-	}
-}
-
-func TestVscDialectValues(t *testing.T) {
-	assert.Equal(t, "primary", efloVscDialect.PrimaryType)
-	assert.Equal(t, "Normal", efloVscDialect.StatusNormal)
-	assert.Equal(t, "Primary", ecsVscDialect.PrimaryType)
-	assert.Equal(t, "In_use", ecsVscDialect.StatusNormal)
-}
-
 func TestDefaultVscCacheTTL(t *testing.T) {
 	// Ensure the documented 5-minute default isn't accidentally lowered.
 	assert.GreaterOrEqual(t, defaultVscCacheTTL, 3*time.Minute)
 }
 
-// fakeVscManager is a minimal in-memory VscManager used to validate the cache
-// semantics of PrimaryVscManagerWithCache without hitting any cloud API.
-type fakeVscManager struct {
+// fakeReadyStatus is the status the fake stamps on VSCs it creates and treats as
+// ready. Its exact value is irrelevant — the fake is self-consistent, not tied to
+// any real backend dialect — as long as it differs from an injected notReadyStatus.
+const fakeReadyStatus = "ready"
+
+// fakeBackend is a minimal in-memory Backend used to validate the cache semantics
+// of PrimaryVscManagerWithCache without hitting any cloud API.
+type fakeBackend struct {
 	mu sync.Mutex
 
-	// existing maps instanceId -> *Vsc to be returned by GetPrimaryVscOf.
+	// existing maps instanceId -> *Vsc to be returned by GetPrimaryVsc.
 	// A nil value means "not found".
 	existing map[string]*Vsc
 	// vscs maps vscId -> *Vsc returned by GetVsc.
@@ -140,14 +119,18 @@ type fakeVscManager struct {
 	GetOneCalls int
 }
 
-func newFakeVscManager() *fakeVscManager {
-	return &fakeVscManager{
+func newFakeBackend() *fakeBackend {
+	return &fakeBackend{
 		existing: map[string]*Vsc{},
 		vscs:     map[string]*Vsc{},
 	}
 }
 
-func (f *fakeVscManager) CreatePrimaryVscFor(ctx context.Context, instanceId string) (string, error) {
+func (f *fakeBackend) Ready(v *Vsc) bool {
+	return v.Status == fakeReadyStatus
+}
+
+func (f *fakeBackend) CreatePrimaryVsc(ctx context.Context, instanceId string) (string, error) {
 	// Yield before recording the VSC so that, if single-flight ever regresses,
 	// concurrent callers overlap here instead of running check+create atomically
 	// (TestPrimaryVscCache_EnsurePrimaryVsc_ConcurrentCreatesOnce relies on this).
@@ -160,22 +143,18 @@ func (f *fakeVscManager) CreatePrimaryVscFor(ctx context.Context, instanceId str
 		return "", f.createErr
 	}
 	vscId := "vsc-" + instanceId
-	dialect := efloVscDialect
-	if isECSInstance(instanceId) {
-		dialect = ecsVscDialect
-	}
 	vsc := &Vsc{
 		NodeID: instanceId,
 		VscID:  vscId,
-		Type:   dialect.PrimaryType,
-		Status: dialect.StatusNormal,
+		Type:   "primary",
+		Status: fakeReadyStatus,
 	}
 	f.existing[instanceId] = vsc
 	f.vscs[vscId] = vsc
 	return vscId, nil
 }
 
-func (f *fakeVscManager) GetPrimaryVscOf(ctx context.Context, instanceId string) (*Vsc, error) {
+func (f *fakeBackend) GetPrimaryVsc(ctx context.Context, instanceId string) (*Vsc, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.GetCalls++
@@ -190,7 +169,7 @@ func (f *fakeVscManager) GetPrimaryVscOf(ctx context.Context, instanceId string)
 	return &cp, nil
 }
 
-func (f *fakeVscManager) GetVsc(ctx context.Context, vscId, instanceId string) (*Vsc, error) {
+func (f *fakeBackend) GetVsc(ctx context.Context, vscId string) (*Vsc, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.GetOneCalls++
@@ -208,12 +187,11 @@ func (f *fakeVscManager) GetVsc(ctx context.Context, vscId, instanceId string) (
 	return &cp, nil
 }
 
-// newTestPrimaryVscManagerWithCache builds a PrimaryVscManagerWithCache that
-// uses the supplied fake backend, with a tiny poll interval for fast tests.
-func newTestPrimaryVscManagerWithCache(t *testing.T, backend VscManager, ttl time.Duration) *PrimaryVscManagerWithCache {
+// newTestPrimaryVscManagerWithCache builds a PrimaryVscManagerWithCache with a tiny
+// poll interval for fast tests. Callers pass a resolved Instance per operation.
+func newTestPrimaryVscManagerWithCache(t *testing.T, ttl time.Duration) *PrimaryVscManagerWithCache {
 	t.Helper()
 	return &PrimaryVscManagerWithCache{
-		VscManager:   backend,
 		vscCache:     ttlcache.NewTTLCache[string, *Vsc](ttl),
 		createVsc:    ttlcache.NewTTLCache[string, *Vsc](0),
 		clk:          clock.RealClock{},
@@ -223,43 +201,46 @@ func newTestPrimaryVscManagerWithCache(t *testing.T, backend VscManager, ttl tim
 }
 
 func TestPrimaryVscCache_EnsurePrimaryVsc_CreatesAndCaches(t *testing.T) {
-	fake := newFakeVscManager()
-	m := newTestPrimaryVscManagerWithCache(t, fake, time.Minute)
+	fake := newFakeBackend()
+	m := newTestPrimaryVscManagerWithCache(t, time.Minute)
+	inst := Instance{ID: "i-ecs-1", Backend: fake}
 
-	vscId, err := m.EnsurePrimaryVsc(t.Context(), "i-ecs-1")
+	vscId, err := m.EnsurePrimaryVsc(t.Context(), inst)
 	require.NoError(t, err)
 	assert.Equal(t, "vsc-i-ecs-1", vscId)
 	assert.Equal(t, 1, fake.CreateCalls)
 
 	// Second call within TTL should be served from cache: no extra backend hits.
-	vscId2, err := m.EnsurePrimaryVsc(t.Context(), "i-ecs-1")
+	vscId2, err := m.EnsurePrimaryVsc(t.Context(), inst)
 	require.NoError(t, err)
 	assert.Equal(t, "vsc-i-ecs-1", vscId2)
 	assert.Equal(t, 1, fake.CreateCalls, "cached EnsurePrimaryVsc must not call backend")
 }
 
 func TestPrimaryVscCache_EnsurePrimaryVsc_ExpiryRefreshes(t *testing.T) {
-	fake := newFakeVscManager()
-	m := newTestPrimaryVscManagerWithCache(t, fake, 10*time.Millisecond)
+	fake := newFakeBackend()
+	m := newTestPrimaryVscManagerWithCache(t, 10*time.Millisecond)
+	inst := Instance{ID: "i-ecs-1", Backend: fake}
 
-	_, err := m.EnsurePrimaryVsc(t.Context(), "i-ecs-1")
+	_, err := m.EnsurePrimaryVsc(t.Context(), inst)
 	require.NoError(t, err)
 	prevGet := fake.GetCalls
 
 	// Wait for the entry to expire.
 	time.Sleep(50 * time.Millisecond)
 
-	_, err = m.EnsurePrimaryVsc(t.Context(), "i-ecs-1")
+	_, err = m.EnsurePrimaryVsc(t.Context(), inst)
 	require.NoError(t, err)
 	assert.Greater(t, fake.GetCalls, prevGet, "expired entry must trigger backend lookup")
 }
 
 func TestPrimaryVscCache_EnsurePrimaryVsc_BackendErrorPropagated(t *testing.T) {
-	fake := newFakeVscManager()
+	fake := newFakeBackend()
 	fake.getErr = errors.New("backend down")
-	m := newTestPrimaryVscManagerWithCache(t, fake, time.Minute)
+	m := newTestPrimaryVscManagerWithCache(t, time.Minute)
+	inst := Instance{ID: "i-ecs-1", Backend: fake}
 
-	_, err := m.EnsurePrimaryVsc(t.Context(), "i-ecs-1")
+	_, err := m.EnsurePrimaryVsc(t.Context(), inst)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "backend down")
 }
@@ -267,13 +248,14 @@ func TestPrimaryVscCache_EnsurePrimaryVsc_BackendErrorPropagated(t *testing.T) {
 // TestPrimaryVscCache_EnsurePrimaryVsc_PollsUntilReady verifies that a freshly
 // created VSC reporting a transient status is polled until it settles.
 func TestPrimaryVscCache_EnsurePrimaryVsc_PollsUntilReady(t *testing.T) {
-	fake := newFakeVscManager()
+	fake := newFakeBackend()
 	// First two GetVsc calls report a not-yet-usable status, then it settles.
 	fake.notReadyGetVscCalls = 2
 	fake.notReadyStatus = "Attaching"
-	m := newTestPrimaryVscManagerWithCache(t, fake, time.Minute)
+	m := newTestPrimaryVscManagerWithCache(t, time.Minute)
+	inst := Instance{ID: "i-ecs-1", Backend: fake}
 
-	vscId, err := m.EnsurePrimaryVsc(t.Context(), "i-ecs-1")
+	vscId, err := m.EnsurePrimaryVsc(t.Context(), inst)
 	require.NoError(t, err)
 	assert.Equal(t, "vsc-i-ecs-1", vscId)
 	// 3 polls: the first two report the transient status, the third returns Normal.
@@ -283,13 +265,14 @@ func TestPrimaryVscCache_EnsurePrimaryVsc_PollsUntilReady(t *testing.T) {
 // TestPrimaryVscCache_EnsurePrimaryVsc_PollExhaustedReturnsError verifies that a
 // VSC whose status never settles fails after pollAttempts.
 func TestPrimaryVscCache_EnsurePrimaryVsc_PollExhaustedReturnsError(t *testing.T) {
-	fake := newFakeVscManager()
+	fake := newFakeBackend()
 	// Never settles.
 	fake.notReadyGetVscCalls = 1000
 	fake.notReadyStatus = "Attaching"
-	m := newTestPrimaryVscManagerWithCache(t, fake, time.Minute)
+	m := newTestPrimaryVscManagerWithCache(t, time.Minute)
+	inst := Instance{ID: "i-ecs-1", Backend: fake}
 
-	_, err := m.EnsurePrimaryVsc(t.Context(), "i-ecs-1")
+	_, err := m.EnsurePrimaryVsc(t.Context(), inst)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unexpected vsc status: Attaching")
 	// pollAttempts polls, all reporting the transient status, before giving up.
@@ -302,9 +285,10 @@ func TestPrimaryVscCache_EnsurePrimaryVsc_PollExhaustedReturnsError(t *testing.T
 // makes the followers reuse the leader's VSC instead of creating their own.
 func TestPrimaryVscCache_EnsurePrimaryVsc_ConcurrentCreatesOnce(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
-		fake := newFakeVscManager()
-		m := newTestPrimaryVscManagerWithCache(t, fake, time.Minute)
-		// The fake's create sleeps before recording the VSC (see CreatePrimaryVscFor),
+		fake := newFakeBackend()
+		m := newTestPrimaryVscManagerWithCache(t, time.Minute)
+		inst := Instance{ID: "i-ecs-1", Backend: fake}
+		// The fake's create sleeps before recording the VSC (see CreatePrimaryVsc),
 		// so all callers reach the create window; single-flight must still collapse
 		// them to one. Under synctest the clock advances only once all are parked.
 
@@ -314,7 +298,7 @@ func TestPrimaryVscCache_EnsurePrimaryVsc_ConcurrentCreatesOnce(t *testing.T) {
 		errs := make([]error, n)
 		for i := range n {
 			wg.Go(func() {
-				ids[i], errs[i] = m.EnsurePrimaryVsc(t.Context(), "i-ecs-1")
+				ids[i], errs[i] = m.EnsurePrimaryVsc(t.Context(), inst)
 			})
 		}
 		wg.Wait()
@@ -328,63 +312,66 @@ func TestPrimaryVscCache_EnsurePrimaryVsc_ConcurrentCreatesOnce(t *testing.T) {
 }
 
 func TestPrimaryVscCache_GetPrimaryVscOf_ReadThroughCaches(t *testing.T) {
-	fake := newFakeVscManager()
+	fake := newFakeBackend()
 	// Pre-seed so GetPrimaryVscOf finds an existing one without creating.
 	fake.existing["e01-cn-xyz"] = &Vsc{
 		NodeID: "e01-cn-xyz",
 		VscID:  "vsc-existing",
-		Type:   efloVscDialect.PrimaryType,
-		Status: efloVscDialect.StatusNormal,
+		Type:   "primary",
+		Status: fakeReadyStatus,
 	}
-	m := newTestPrimaryVscManagerWithCache(t, fake, time.Minute)
+	m := newTestPrimaryVscManagerWithCache(t, time.Minute)
+	inst := Instance{ID: "e01-cn-xyz", Backend: fake}
 
-	vsc, err := m.GetPrimaryVscOf(t.Context(), "e01-cn-xyz")
+	vsc, err := m.GetPrimaryVscOf(t.Context(), inst)
 	require.NoError(t, err)
 	require.NotNil(t, vsc)
 	assert.Equal(t, "vsc-existing", vsc.VscID)
 
 	prev := fake.GetCalls
 	// Second call should be served from the cache.
-	vsc, err = m.GetPrimaryVscOf(t.Context(), "e01-cn-xyz")
+	vsc, err = m.GetPrimaryVscOf(t.Context(), inst)
 	require.NoError(t, err)
 	require.NotNil(t, vsc)
 	assert.Equal(t, prev, fake.GetCalls, "cached GetPrimaryVscOf must not call backend")
 }
 
 func TestPrimaryVscCache_GetPrimaryVscOf_NotFoundNotCached(t *testing.T) {
-	fake := newFakeVscManager()
-	m := newTestPrimaryVscManagerWithCache(t, fake, time.Minute)
+	fake := newFakeBackend()
+	m := newTestPrimaryVscManagerWithCache(t, time.Minute)
+	inst := Instance{ID: "e01-missing", Backend: fake}
 
-	vsc, err := m.GetPrimaryVscOf(t.Context(), "e01-missing")
+	vsc, err := m.GetPrimaryVscOf(t.Context(), inst)
 	require.NoError(t, err)
 	assert.Nil(t, vsc)
 	assert.Equal(t, 1, fake.GetCalls)
 
 	// A subsequent call must hit the backend again because nil results are not
 	// cached (the absence might be transient).
-	vsc, err = m.GetPrimaryVscOf(t.Context(), "e01-missing")
+	vsc, err = m.GetPrimaryVscOf(t.Context(), inst)
 	require.NoError(t, err)
 	assert.Nil(t, vsc)
 	assert.Equal(t, 2, fake.GetCalls)
 }
 
 func TestPrimaryVscCache_GetPrimaryVscOf_ExpiryRefetches(t *testing.T) {
-	fake := newFakeVscManager()
+	fake := newFakeBackend()
 	fake.existing["e01-cn-xyz"] = &Vsc{
 		NodeID: "e01-cn-xyz",
 		VscID:  "vsc-existing",
-		Type:   efloVscDialect.PrimaryType,
-		Status: efloVscDialect.StatusNormal,
+		Type:   "primary",
+		Status: fakeReadyStatus,
 	}
-	m := newTestPrimaryVscManagerWithCache(t, fake, 10*time.Millisecond)
+	m := newTestPrimaryVscManagerWithCache(t, 10*time.Millisecond)
+	inst := Instance{ID: "e01-cn-xyz", Backend: fake}
 
-	_, err := m.GetPrimaryVscOf(t.Context(), "e01-cn-xyz")
+	_, err := m.GetPrimaryVscOf(t.Context(), inst)
 	require.NoError(t, err)
 	prev := fake.GetCalls
 
 	time.Sleep(50 * time.Millisecond)
 
-	_, err = m.GetPrimaryVscOf(t.Context(), "e01-cn-xyz")
+	_, err = m.GetPrimaryVscOf(t.Context(), inst)
 	require.NoError(t, err)
 	assert.Greater(t, fake.GetCalls, prev, "expired entry must refetch")
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Refactors the bmcpfs VSC layer to be backend-agnostic.

Previously `VscManager` dispatched every call to the ECS or eflo backend by
re-sniffing the instance ID (`isECSInstance`), which duplicated the node-kind
classification the CSI layer already computes from the node ID prefix — two
sources of truth for the same ECS-vs-Lingjun fact.

This PR introduces:
- a `Backend` interface, where each cloud owns its own type/status dialect via
  `Ready`, and
- an `Instance` value pairing an instance ID with its `Backend`.

The CSI layer now resolves the backend once from the parsed node kind and passes
a resolved `Instance` down, so `PrimaryVscManagerWithCache` becomes a pure
caching decorator with no backend selection of its own. `isECSInstance`,
`dispatchingVscManager`, the `VscManager` interface, and the now-redundant
`vscDialect` struct are removed in favor of plain per-backend constants.

No behavior change; the existing cache / single-flight / poll tests are preserved
and updated to the new seam.

#### Which issue(s) this PR fixes:

N/A

#### Special notes for your reviewer:

Two commits, reviewable independently:
1. Style cleanup in `vsc.go` (`tea.String` → `new`, `errors.As` → `errors.AsType`).
2. The `Backend`/`Instance` refactor.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
