### PR TITLE
disk: sync PV disktype label/annotation on ModifyVolume

### DIFF
--- a/deploy/charts/alibaba-cloud-csi-driver/templates/controller.yaml
+++ b/deploy/charts/alibaba-cloud-csi-driver/templates/controller.yaml
@@ -279,6 +279,9 @@ spec:
             - --http-endpoint=:8082
             - --leader-election
             - --handle-volume-inuse-error=false
+            # Pass pv/pvc name to ControllerModifyVolume so the driver can keep the
+            # disktype label / volume-topology annotation on the PV in sync.
+            - --extra-modify-metadata
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true

--- a/pkg/disk/controllerserver.go
+++ b/pkg/disk/controllerserver.go
@@ -20,6 +20,7 @@ package disk
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"slices"
@@ -43,9 +44,12 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/timestamppb"
+	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/clock"
@@ -58,6 +62,7 @@ type controllerServer struct {
 	cd             DiskCreateDelete
 	meta           metadata.MetadataProvider
 	ecs            cloud.ECSInterface
+	clientSet      kubernetes.Interface
 	snapshotWaiter waitstatus.StatusWaiter[ecs.Snapshot]
 	modify         ModifyServer
 	common.GenericControllerServer
@@ -106,9 +111,10 @@ func newSnapshotStatusWaiter() waitstatus.StatusWaiter[ecs.Snapshot] {
 func NewControllerServer(csiCfg utils.Config, ecs cloud.ECSInterface, ecsV2 cloud.ECSv2Interface, m metadata.MetadataProvider) csi.ControllerServer {
 	waiter, batcher := newBatcher(false)
 	c := &controllerServer{
-		recorder: utils.NewEventRecorder(),
-		meta:     m,
-		ecs:      ecs,
+		recorder:  utils.NewEventRecorder(),
+		meta:      m,
+		ecs:       ecs,
+		clientSet: GlobalConfigVar.ClientSet,
 		ad: DiskAttachDetach{
 			ecs:     ecs,
 			waiter:  waiter,
@@ -748,5 +754,64 @@ func (cs *controllerServer) ControllerModifyVolume(ctx context.Context, req *csi
 	if err != nil {
 		return nil, err
 	}
+
+	if pvName := req.MutableParameters[common.PVNameKey]; pvName != "" {
+		if err := cs.updatePVDiskType(ctx, req.VolumeId, pvName, params); err != nil {
+			// The disk is already modified, so this must be a non-final error:
+			// external-resizer keeps re-driving this same target instead of
+			// switching to a different VAC.
+			return nil, status.Errorf(codes.Aborted, "update disktype metadata: %v", err)
+		}
+	}
+
 	return &csi.ControllerModifyVolumeResponse{}, nil
+}
+
+// updatePVDiskType keeps the disktype label and volume-topology annotation on the
+// PV consistent with the disk type after a successful ControllerModifyVolume.
+//
+// Callers must only invoke it when the PV name was supplied by the sidecar
+// (external-resizer --extra-modify-metadata); we never guess it from the disk ID.
+func (cs *controllerServer) updatePVDiskType(ctx context.Context, diskID, pvName string, params ModifyParameters) error {
+	logger := klog.FromContext(ctx).WithValues("pv", pvName)
+
+	// Only category / performance-level changes affect the label & annotation;
+	// skip the DescribeDisks and PV write entirely for the rest.
+	if params.Category == "" && params.PerformanceLevel == "" {
+		return nil
+	}
+
+	// Read the disk's actual category / performance level. params may be incomplete.
+	disk, err := cs.cd.batcher.Describe(ctx, diskID)
+	if err != nil {
+		return fmt.Errorf("describe disk %s: %w", diskID, err)
+	}
+	if disk == nil || disk.Category == "" {
+		// Disk is gone; there is nothing to keep in sync and a retry won't help.
+		logger.V(2).Info("disk gone or has no category, skip updating disktype metadata")
+		return nil
+	}
+
+	label, topo := diskTypeMetadata(Category(disk.Category), PerformanceLevel(disk.PerformanceLevel))
+
+	patch, err := json.Marshal(v1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels:      map[string]string{labelVolumeType: label},
+			Annotations: map[string]string{annVolumeTopoKey: topo},
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("build patch: %w", err)
+	}
+	_, err = cs.clientSet.CoreV1().PersistentVolumes().Patch(ctx, pvName, types.StrategicMergePatchType, patch, metav1.PatchOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			// PV is gone; retrying won't help. The PVC is likely being deleted too.
+			logger.V(2).Info("PV gone, skip updating disktype metadata")
+			return nil
+		}
+		return fmt.Errorf("patch PV %s: %w", pvName, err)
+	}
+	logger.V(2).Info("updated PV disktype metadata", "disktype", label)
+	return nil
 }

--- a/pkg/disk/controllerserver_test.go
+++ b/pkg/disk/controllerserver_test.go
@@ -1,0 +1,160 @@
+//go:build !windows
+
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package disk
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	ecs "github.com/aliyun/alibaba-cloud-sdk-go/services/ecs"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
+	"k8s.io/klog/v2/ktesting"
+)
+
+// fakeBatcher implements batcher.Batcher[ecs.Disk] for tests.
+type fakeBatcher struct {
+	disk   *ecs.Disk
+	err    error
+	called bool
+}
+
+func (f *fakeBatcher) Describe(ctx context.Context, id string) (*ecs.Disk, error) {
+	f.called = true
+	return f.disk, f.err
+}
+
+func TestUpdatePVDiskType(t *testing.T) {
+	const pvName = "test-pv"
+	essdPL1Label, essdPL1Topo := diskTypeMetadata(DiskESSD, "PL1")
+
+	newPV := func() *corev1.PersistentVolume {
+		return &corev1.PersistentVolume{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        pvName,
+				Labels:      map[string]string{labelVolumeType: essdPL1Label, "keep": "me"},
+				Annotations: map[string]string{annVolumeTopoKey: essdPL1Topo},
+			},
+		}
+	}
+	getPV := func(t *testing.T, ctx context.Context, client *fake.Clientset) *corev1.PersistentVolume {
+		t.Helper()
+		got, err := client.CoreV1().PersistentVolumes().Get(ctx, pvName, metav1.GetOptions{})
+		require.NoError(t, err)
+		return got
+	}
+	// assertUnchanged verifies the PV still carries its original disktype metadata.
+	assertUnchanged := func(t *testing.T, ctx context.Context, client *fake.Clientset) {
+		t.Helper()
+		got := getPV(t, ctx, client)
+		assert.Equal(t, essdPL1Label, got.Labels[labelVolumeType])
+		assert.Equal(t, essdPL1Topo, got.Annotations[annVolumeTopoKey])
+	}
+
+	t.Run("category change updates both label and annotation", func(t *testing.T) {
+		_, ctx := ktesting.NewTestContext(t)
+		fb := &fakeBatcher{disk: &ecs.Disk{Category: "cloud_auto"}}
+		client := fake.NewSimpleClientset(newPV())
+		cs := &controllerServer{clientSet: client, cd: DiskCreateDelete{batcher: fb}}
+
+		require.NoError(t, cs.updatePVDiskType(ctx, "d-x", pvName, ModifyParameters{Category: "cloud_auto"}))
+
+		wantLabel, wantTopo := diskTypeMetadata("cloud_auto", "")
+		got := getPV(t, ctx, client)
+		assert.Equal(t, wantLabel, got.Labels[labelVolumeType])
+		assert.Equal(t, wantTopo, got.Annotations[annVolumeTopoKey])
+		assert.Equal(t, "me", got.Labels["keep"], "unrelated labels must be preserved")
+	})
+
+	t.Run("PL change updates label, annotation unchanged", func(t *testing.T) {
+		_, ctx := ktesting.NewTestContext(t)
+		// ECS reports the resulting disk is still cloud_essd, now PL2.
+		fb := &fakeBatcher{disk: &ecs.Disk{Category: "cloud_essd", PerformanceLevel: "PL2"}}
+		client := fake.NewSimpleClientset(newPV())
+		cs := &controllerServer{clientSet: client, cd: DiskCreateDelete{batcher: fb}}
+
+		require.NoError(t, cs.updatePVDiskType(ctx, "d-x", pvName, ModifyParameters{PerformanceLevel: "PL2"}))
+
+		got := getPV(t, ctx, client)
+		assert.Equal(t, "cloud_essd.PL2", got.Labels[labelVolumeType])
+		assert.Equal(t, essdPL1Topo, got.Annotations[annVolumeTopoKey], "same category -> topology annotation unchanged")
+	})
+
+	t.Run("no category/PL change: batcher not called, PV untouched", func(t *testing.T) {
+		_, ctx := ktesting.NewTestContext(t)
+		fb := &fakeBatcher{disk: &ecs.Disk{Category: "cloud_auto"}}
+		client := fake.NewSimpleClientset(newPV())
+		cs := &controllerServer{clientSet: client, cd: DiskCreateDelete{batcher: fb}}
+
+		require.NoError(t, cs.updatePVDiskType(ctx, "d-x", pvName, ModifyParameters{ProvisionedIops: new(int)}))
+
+		assert.False(t, fb.called, "DescribeDisks must be skipped when category/PL unchanged")
+		assertUnchanged(t, ctx, client)
+	})
+
+	t.Run("describe error: returns error, PV untouched", func(t *testing.T) {
+		_, ctx := ktesting.NewTestContext(t)
+		fb := &fakeBatcher{err: errors.New("ecs boom")}
+		client := fake.NewSimpleClientset(newPV())
+		cs := &controllerServer{clientSet: client, cd: DiskCreateDelete{batcher: fb}}
+
+		err := cs.updatePVDiskType(ctx, "d-x", pvName, ModifyParameters{Category: "cloud_auto"})
+		require.Error(t, err)
+		assertUnchanged(t, ctx, client)
+	})
+
+	t.Run("patch error (non-NotFound): returns error", func(t *testing.T) {
+		_, ctx := ktesting.NewTestContext(t)
+		fb := &fakeBatcher{disk: &ecs.Disk{Category: "cloud_auto"}}
+		client := fake.NewSimpleClientset(newPV())
+		client.PrependReactor("patch", "persistentvolumes", func(k8stesting.Action) (bool, runtime.Object, error) {
+			return true, nil, apierrors.NewInternalError(errors.New("boom"))
+		})
+		cs := &controllerServer{clientSet: client, cd: DiskCreateDelete{batcher: fb}}
+
+		err := cs.updatePVDiskType(ctx, "d-x", pvName, ModifyParameters{Category: "cloud_auto"})
+		require.Error(t, err)
+	})
+
+	t.Run("disk gone: swallowed, PV untouched", func(t *testing.T) {
+		_, ctx := ktesting.NewTestContext(t)
+		fb := &fakeBatcher{disk: nil} // batcher reports the disk no longer exists
+		client := fake.NewSimpleClientset(newPV())
+		cs := &controllerServer{clientSet: client, cd: DiskCreateDelete{batcher: fb}}
+
+		require.NoError(t, cs.updatePVDiskType(ctx, "d-x", pvName, ModifyParameters{Category: "cloud_auto"}))
+		assertUnchanged(t, ctx, client)
+	})
+
+	t.Run("PV gone: swallowed, no error", func(t *testing.T) {
+		_, ctx := ktesting.NewTestContext(t)
+		fb := &fakeBatcher{disk: &ecs.Disk{Category: "cloud_auto"}}
+		client := fake.NewSimpleClientset() // no PV
+		cs := &controllerServer{clientSet: client, cd: DiskCreateDelete{batcher: fb}}
+
+		require.NoError(t, cs.updatePVDiskType(ctx, "d-x", pvName, ModifyParameters{Category: "cloud_auto"}))
+	})
+}

--- a/pkg/disk/utils.go
+++ b/pkg/disk/utils.go
@@ -689,6 +689,8 @@ func parseMutableParameters(mutableParameters map[string]string) (ModifyParamete
 			case strings.HasPrefix(k, REMOVE_DISK_TAG_PREFIX):
 				tagKey := k[len(REMOVE_DISK_TAG_PREFIX):]
 				params.RemoveTags = append(params.RemoveTags, &tagKey)
+			case strings.HasPrefix(k, "csi.storage.k8s.io/"):
+				// pv/pvc metadata injected by external-resizer --extra-modify-metadata.
 			default:
 				return params, fmt.Errorf("unknown parameter %s", k)
 			}
@@ -934,31 +936,12 @@ func volumeCreate(attempt createAttempt, diskID string, volSizeBytes int64, volu
 
 	accessibleTopology := []*csi.Topology{{Segments: segments}}
 	if attempt.Category != "" {
-		// Add PV Label
-		if attempt.Category == DiskESSD && attempt.PerformanceLevel == "" {
-			attempt.PerformanceLevel = "PL1"
-		}
-		// TODO delete performanceLevel key
+		// TODO delete performanceLevel/type keys
 		// delete(volumeContext, "performanceLevel")
-		volumeContext[labelAppendPrefix+labelVolumeType] = attempt.String()
-		// TODO delete type key
 		// delete(volumeContext, "type")
-
-		// Add PV NodeAffinity
-		labelKey := NodeDiskTypeLabelPrefix + string(attempt.Category)
-		expressions := []v1.NodeSelectorRequirement{{
-			Key:      labelKey,
-			Operator: v1.NodeSelectorOpIn,
-			Values:   []string{"available"},
-		}}
-		terms := []v1.NodeSelectorTerm{{
-			MatchExpressions: expressions,
-		}}
-		diskTypeTopo := &v1.NodeSelector{
-			NodeSelectorTerms: terms,
-		}
-		diskTypeTopoBytes, _ := json.Marshal(diskTypeTopo)
-		volumeContext[annAppendPrefix+annVolumeTopoKey] = string(diskTypeTopoBytes)
+		label, topo := diskTypeMetadata(attempt.Category, attempt.PerformanceLevel)
+		volumeContext[labelAppendPrefix+labelVolumeType] = label // Add PV Label
+		volumeContext[annAppendPrefix+annVolumeTopoKey] = topo   // Add PV NodeAffinity
 	}
 
 	klog.Infof("volumeCreate: volumeContext: %+v", volumeContext)
@@ -971,6 +954,25 @@ func volumeCreate(attempt createAttempt, diskID string, volSizeBytes int64, volu
 	}
 
 	return tmpVol
+}
+
+func diskTypeMetadata(category Category, performanceLevel PerformanceLevel) (label, topologyAnnotation string) {
+	if category == DiskESSD && performanceLevel == "" {
+		performanceLevel = "PL1"
+	}
+	label = createAttempt{Category: category, PerformanceLevel: performanceLevel}.String()
+
+	diskTypeTopo := &v1.NodeSelector{
+		NodeSelectorTerms: []v1.NodeSelectorTerm{{
+			MatchExpressions: []v1.NodeSelectorRequirement{{
+				Key:      NodeDiskTypeLabelPrefix + string(category),
+				Operator: v1.NodeSelectorOpIn,
+				Values:   []string{"available"},
+			}},
+		}},
+	}
+	diskTypeTopoBytes, _ := json.Marshal(diskTypeTopo)
+	return label, string(diskTypeTopoBytes)
 }
 
 func parseSnapshotID(req *csi.CreateVolumeRequest) (string, error) {

--- a/pkg/disk/utils_test.go
+++ b/pkg/disk/utils_test.go
@@ -21,6 +21,7 @@ import (
 	"cmp"
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"path"
 	"path/filepath"
@@ -957,6 +958,30 @@ func TestPrepareMountInfos(t *testing.T) {
 			options, fsType := prepareMountInfos(tt.req)
 			assert.Equal(t, tt.expectedOptions, options)
 			assert.Equal(t, tt.expectedFsType, fsType)
+		})
+	}
+}
+
+func TestDiskTypeMetadata(t *testing.T) {
+	cases := []struct {
+		name      string
+		category  Category
+		pl        PerformanceLevel
+		wantLabel string
+		// wantTopoCategory is the category expected in the node-affinity key.
+		wantTopoCategory string
+	}{
+		{"essd with PL", DiskESSD, "PL2", "cloud_essd.PL2", "cloud_essd"},
+		{"essd defaults to PL1", DiskESSD, "", "cloud_essd.PL1", "cloud_essd"},
+		{"category without PL", Category("cloud_auto"), "", "cloud_auto", "cloud_auto"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			label, topo := diskTypeMetadata(c.category, c.pl)
+			assert.Equal(t, c.wantLabel, label)
+
+			wantTopo := fmt.Sprintf(`{"nodeSelectorTerms":[{"matchExpressions":[{"key":"node.csi.alibabacloud.com/disktype.%s","operator":"In","values":["available"]}]}]}`, c.wantTopoCategory)
+			assert.JSONEq(t, wantTopo, topo)
 		})
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

When a disk's category or performance level is changed through `ModifyVolume`
(a `VolumeAttributesClass`), the PV keeps the `csi.alibabacloud.com/disktype`
label and `csi.alibabacloud.com/volume-topology` annotation that were set at
provision time, so they no longer match the disk. The topology annotation drives
scheduling, so a stale value can steer pods to nodes that cannot attach the new
disk type.

`ControllerModifyVolume` now updates both fields on the PV after a successful
modify:

- The PV name comes from the metadata external-resizer injects with
  `--extra-modify-metadata`; we never guess it from the disk ID (the PV may be
  user-created). `parseMutableParameters` ignores the injected
  `csi.storage.k8s.io/*` keys.
- The resulting category / performance level is read back from ECS via the
  shared batcher (`DescribeDisks`) rather than trusting the request, so any
  ECS-side normalisation is reflected.
- The update is a metadata-only strategic merge patch, so it never conflicts
  with external-resizer's own PV write.
- Since the disk is already modified when we patch, any failure returns a
  non-final error so external-resizer keeps re-driving the same target; only
  not-found cases are swallowed.

The Helm chart enables `--extra-modify-metadata` on the disk resizer.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

Verified end-to-end on an ACK cluster: a `cloud_essd.PL1` → `cloud_auto` modify
flipped both the disktype label and the volume-topology annotation on the PV.
Unit tests cover the metadata derivation and the PV-patch paths (category
change, PL-only change, no-op, describe/patch failures, and not-found cases).

#### Does this PR introduce a user-facing change?

```release-note
disk: the PV `csi.alibabacloud.com/disktype` label and `csi.alibabacloud.com/volume-topology` annotation are now kept in sync with the disk type after a ModifyVolume. Requires `--extra-modify-metadata` on the external-resizer sidecar (enabled in the chart).
```
