### PR TITLE
support noopAgent for local passthrough driver in csi-agent

### DIFF
--- a/cmd/csi-agent/main.go
+++ b/cmd/csi-agent/main.go
@@ -105,6 +105,8 @@ func main() {
 		agent = disk.NewCSIAgent()
 	case "nasplugin.csi.alibabacloud.com":
 		agent = nas.NewCSIAgent(mountProxySocket)
+	case "local-passthrough.csi.alibabacloud.com":
+		agent = &noopAgent{}
 	default:
 		printError(fmt.Errorf("invalid CSI_DRIVER: %q", driver))
 		os.Exit(1)
@@ -135,4 +137,25 @@ func printError(err error) {
 
 type fakeAgent struct {
 	csi.UnimplementedNodeServer
+}
+
+// noopAgent is a no-op agent with no extra capabilities.
+// NodePublish and NodeUnpublish return success immediately without performing any action.
+type noopAgent struct {
+	csi.UnimplementedNodeServer
+}
+
+func (a *noopAgent) NodeGetCapabilities(ctx context.Context, req *csi.NodeGetCapabilitiesRequest) (*csi.NodeGetCapabilitiesResponse, error) {
+	fmt.Printf("NodeGetCapabilities is called, noopAgent returns success immediately")
+	return &csi.NodeGetCapabilitiesResponse{}, nil
+}
+
+func (a *noopAgent) NodePublishVolume(ctx context.Context, req *csi.NodePublishVolumeRequest) (*csi.NodePublishVolumeResponse, error) {
+	fmt.Printf("NodePublishVolume is called, noopAgent returns success immediately")
+	return &csi.NodePublishVolumeResponse{}, nil
+}
+
+func (a *noopAgent) NodeUnpublishVolume(ctx context.Context, req *csi.NodeUnpublishVolumeRequest) (*csi.NodeUnpublishVolumeResponse, error) {
+	fmt.Printf("NodeUnpublishVolume is called, noopAgent returns success immediately")
+	return &csi.NodeUnpublishVolumeResponse{}, nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Skip local-passthrough csidriver in csi-agent.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
