### PR TITLE
disk: declare ONLINE volume expansion capability

### DIFF
--- a/pkg/disk/identityserver.go
+++ b/pkg/disk/identityserver.go
@@ -62,7 +62,7 @@ func (iden *identityServer) GetPluginCapabilities(ctx context.Context, req *csi.
 			{
 				Type: &csi.PluginCapability_VolumeExpansion_{
 					VolumeExpansion: &csi.PluginCapability_VolumeExpansion{
-						Type: csi.PluginCapability_VolumeExpansion_OFFLINE,
+						Type: csi.PluginCapability_VolumeExpansion_ONLINE,
 					},
 				},
 			},

--- a/pkg/disk/identityserver_test.go
+++ b/pkg/disk/identityserver_test.go
@@ -22,7 +22,7 @@ func TestGetPluginCapabilities(t *testing.T) {
 		{
 			name:                       "volume group snapshots disabled",
 			enableVolumeGroupSnapshots: false,
-			expectedCapCount:           3, // CONTROLLER_SERVICE, VOLUME_ACCESSIBILITY_CONSTRAINTS, OFFLINE expansion
+			expectedCapCount:           3, // CONTROLLER_SERVICE, VOLUME_ACCESSIBILITY_CONSTRAINTS, ONLINE expansion
 			expectGroupControllerCap:   false,
 		},
 		{
@@ -48,7 +48,7 @@ func TestGetPluginCapabilities(t *testing.T) {
 			// Verify expected capabilities
 			hasControllerService := false
 			hasVolumeAccessibility := false
-			hasOfflineExpansion := false
+			hasOnlineExpansion := false
 			hasGroupController := false
 
 			for _, cap := range resp.Capabilities {
@@ -63,15 +63,15 @@ func TestGetPluginCapabilities(t *testing.T) {
 					}
 				}
 				if exp := cap.GetVolumeExpansion(); exp != nil {
-					if exp.Type == csi.PluginCapability_VolumeExpansion_OFFLINE {
-						hasOfflineExpansion = true
+					if exp.Type == csi.PluginCapability_VolumeExpansion_ONLINE {
+						hasOnlineExpansion = true
 					}
 				}
 			}
 
 			assert.True(t, hasControllerService, "should have CONTROLLER_SERVICE capability")
 			assert.True(t, hasVolumeAccessibility, "should have VOLUME_ACCESSIBILITY_CONSTRAINTS capability")
-			assert.True(t, hasOfflineExpansion, "should have OFFLINE volume expansion capability")
+			assert.True(t, hasOnlineExpansion, "should have ONLINE volume expansion capability")
 			assert.Equal(t, tt.expectGroupControllerCap, hasGroupController, "GROUP_CONTROLLER_SERVICE capability mismatch")
 		})
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind cleanup

#### What this PR does / why we need it:

The disk driver advertised `OFFLINE` volume expansion in `GetPluginCapabilities`, but it has actually supported **online** expansion end-to-end since 2019:

- `ControllerExpandVolume` issues an `"online"` ECS `ResizeDisk` when the disk status is `In_use` (`pkg/disk/controllerserver.go`), and never rejects an attached disk.
- The node side grows the partition on a mounted disk with `sfdisk --no-reread --no-tell-kernel` + `partx` (`pkg/disk/sfdisk/expand.go`) and then resizes the filesystem in place.

This PR flips the advertised capability from `OFFLINE` to `ONLINE` so the declaration matches the implementation, per the CSI spec's block-storage ONLINE example (a plugin with both controller and node `EXPAND_VOLUME` that supports expanding published volumes).

#### Why this was safe before, and remains safe:

Nothing actually consumed the `OFFLINE` declaration, which is why online resize already worked in practice:

- `external-resizer` only reads the `CONTROLLER_SERVICE` plugin capability; it does **not** inspect `ONLINE`/`OFFLINE` at all.
- Its "cannot expand in-use volume" gating is driven solely by an *in-use error returned by the driver* — which this driver never returns.
- We additionally run the resizer with `--handle-volume-inuse-error=false`, disabling that machinery entirely.
- Kubernetes core (kubelet CSI plugin, controllers) does not consume this capability either.

So this is purely a truth-in-advertising fix. The only behavioral effect is positive: any CO that *did* honor `OFFLINE` would have forced a detach before resize; declaring `ONLINE` removes that unnecessary restriction. There is no path where `ONLINE` causes an expansion that `OFFLINE` permitted to now be rejected.

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:

Only the identity server capability and its unit test change; the expand implementation is unchanged.

#### Does this PR introduce a user-facing change?
```release-note
disk: advertise ONLINE volume expansion capability, matching the driver's long-standing support for online (in-use) disk resize.
```