### PR TITLE
utils: resolve symlinks recursively for non-existent path suffixes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kubernetes-sigs/alibaba-cloud-csi-driver
 
-go 1.26.5
+go 1.26.0
 
 tool github.com/golang/mock/mockgen
 

--- a/pkg/utils/auth.go
+++ b/pkg/utils/auth.go
@@ -115,7 +115,7 @@ func resolveSymlinks(cleaned string) (string, error) {
 	parent := filepath.Dir(cleaned)
 	if parent == cleaned {
 		// Reached the root without resolving any ancestor.
-		return "", fmt.Errorf("cannot resolve any ancestor of %s", cleaned)
+		return "", fmt.Errorf("cannot resolve any ancestor of %s: %w", cleaned, err)
 	}
 	resolvedParent, err := resolveSymlinks(parent)
 	if err != nil {

--- a/pkg/utils/auth.go
+++ b/pkg/utils/auth.go
@@ -126,9 +126,13 @@ func resolveSymlinks(cleaned string) (string, error) {
 
 // ValidatePath checks that path is a safe mount path.
 //
-// It requires the path to be absolute, then:
-//  1. Rejects paths literally under /proc (even if symlinks resolve elsewhere).
-//  2. Resolves symlinks and rejects paths whose real location is under a PATH directory.
+// It requires the path to be absolute and free of ".." components. Rejecting
+// ".." prevents symlink-traversal exploits: the kernel resolves ".." *after*
+// following symlinks, so a path like "/symlink/../etc/passwd" would escape the
+// lexically-cleaned path that is validated. It then:
+//  1. Rejects paths literally under /proc (entries may not be resolvable).
+//  2. Resolves symlinks and rejects paths whose real location is under /proc.
+//  3. Resolves symlinks and rejects paths whose real location is under a PATH directory.
 //
 // Note: the kubelet root dir containment check is done by the caller.
 func ValidatePath(path string) (bool, error) {
@@ -136,8 +140,16 @@ func ValidatePath(path string) (bool, error) {
 		return false, fmt.Errorf("path %s must be an absolute path", path)
 	}
 
-	cleaned := filepath.Clean(path)
-	if isUnderProc(cleaned) {
+	for _, seg := range strings.Split(path, "/") {
+		if seg == ".." {
+			return false, fmt.Errorf("path %s contains '..' which is not allowed", path)
+		}
+	}
+
+	// Reject paths literally under /proc before resolution, because /proc
+	// entries (e.g. fd/N) may resolve to non-filesystem targets that
+	// EvalSymlinks cannot handle.
+	if isUnderProc(path) {
 		return false, fmt.Errorf("path %s is under sensitive path /proc", path)
 	}
 
@@ -145,7 +157,7 @@ func ValidatePath(path string) (bool, error) {
 	// deepest existing ancestor directory is resolved and the non-existent
 	// suffix is re-appended, so symlinks in ancestor directories are still
 	// followed and cannot be used to bypass the sensitive-path checks below.
-	resolved, err := resolveSymlinks(cleaned)
+	resolved, err := resolveSymlinks(path)
 	if err != nil {
 		return false, fmt.Errorf("failed to resolve symlinks for path %s: %w", path, err)
 	}

--- a/pkg/utils/auth.go
+++ b/pkg/utils/auth.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"time"
 
@@ -140,10 +141,8 @@ func ValidatePath(path string) (bool, error) {
 		return false, fmt.Errorf("path %s must be an absolute path", path)
 	}
 
-	for _, seg := range strings.Split(path, "/") {
-		if seg == ".." {
-			return false, fmt.Errorf("path %s contains '..' which is not allowed", path)
-		}
+	if slices.Contains(strings.Split(path, "/"), "..") {
+		return false, fmt.Errorf("path %s contains '..' which is not allowed", path)
 	}
 
 	// Reject paths literally under /proc before resolution, because /proc

--- a/pkg/utils/auth.go
+++ b/pkg/utils/auth.go
@@ -95,22 +95,33 @@ func isUnderPATH(resolved string) (string, bool) {
 	return "", false
 }
 
-// resolveSymlinks resolves symlinks for cleaned, tolerating a non-existent leaf.
-// It first tries to resolve the full path (handles the case where the leaf
-// exists, including a leaf that is itself a symlink). If that fails because the
-// leaf does not exist yet, it resolves the parent directory once (which is
-// expected to exist for a mount path) and re-appends the final component, so a
-// symlinked parent still cannot bypass the sensitive-path checks. If the parent
-// directory itself cannot be resolved, it returns an error.
+// resolveSymlinks resolves symlinks for cleaned, tolerating non-existent
+// trailing components. It first tries to resolve the full path. Only when
+// that fails because the path does not exist yet does it recursively resolve
+// the parent directory, then re-append the missing trailing component, so the
+// result is the resolved deepest existing ancestor joined with the full
+// non-existent suffix. Symlinks in any existing ancestor directory are still
+// followed and cannot be used to bypass the sensitive-path checks. Any
+// resolution error other than non-existence is returned as-is, and an error
+// is also returned if no ancestor up to the root can be resolved.
 func resolveSymlinks(cleaned string) (string, error) {
-	if resolved, err := filepath.EvalSymlinks(cleaned); err == nil {
+	resolved, err := filepath.EvalSymlinks(cleaned)
+	if err == nil {
 		return resolved, nil
 	}
-	resolvedDir, err := filepath.EvalSymlinks(filepath.Dir(cleaned))
+	if !os.IsNotExist(err) {
+		return "", err
+	}
+	parent := filepath.Dir(cleaned)
+	if parent == cleaned {
+		// Reached the root without resolving any ancestor.
+		return "", fmt.Errorf("cannot resolve any ancestor of %s", cleaned)
+	}
+	resolvedParent, err := resolveSymlinks(parent)
 	if err != nil {
 		return "", err
 	}
-	return filepath.Join(resolvedDir, filepath.Base(cleaned)), nil
+	return filepath.Join(resolvedParent, filepath.Base(cleaned)), nil
 }
 
 // ValidatePath checks that path is a safe mount path.
@@ -130,9 +141,10 @@ func ValidatePath(path string) (bool, error) {
 		return false, fmt.Errorf("path %s is under sensitive path /proc", path)
 	}
 
-	// Resolve symlinks. When the leaf does not exist yet, the parent directory
-	// is resolved instead, so symlinks in parent directories are still followed
-	// and cannot be used to bypass the sensitive-path checks below.
+	// Resolve symlinks. When trailing components do not exist yet, the
+	// deepest existing ancestor directory is resolved and the non-existent
+	// suffix is re-appended, so symlinks in ancestor directories are still
+	// followed and cannot be used to bypass the sensitive-path checks below.
 	resolved, err := resolveSymlinks(cleaned)
 	if err != nil {
 		return false, fmt.Errorf("failed to resolve symlinks for path %s: %w", path, err)

--- a/pkg/utils/auth_test.go
+++ b/pkg/utils/auth_test.go
@@ -86,14 +86,59 @@ func TestValidatePath(t *testing.T) {
 			path:   base,
 			wantOK: true,
 		},
+		// ".." (or any non-canonical form) is rejected up front: the kernel
+		// resolves ".." after following symlinks, so tolerating it would let a
+		// symlinked component redirect the mount target away from the
+		// lexically-cleaned path that is validated.
 		{
-			name:   "traversal within existing tree is cleaned",
-			path:   filepath.Join(existingDir, "..", ".."),
+			// Note: string concatenation, not filepath.Join, which would
+			// clean the path and hide the traversal.
+			name:    "traversal within existing tree is rejected",
+			path:    existingDir + "/../..",
+			wantOK:  false,
+			wantErr: "contains '..'",
+		},
+		{
+			name:    "traversal crossing a potential symlink component is rejected",
+			path:    "/run/csi-mount/root/../usr/local/bin",
+			wantOK:  false,
+			wantErr: "contains '..'",
+		},
+		{
+			name:   "trailing slash is allowed",
+			path:   existingDir + "/",
 			wantOK: true,
 		},
 		{
 			name:   "proc as non-prefix component is fine",
 			path:   filepath.Join(procLikeDir, "file"),
+			wantOK: true,
+		},
+
+		// Hidden-directory-style components (".agent", "..agent") are ordinary
+		// path components: filepath.Clean only collapses exact "." and ".."
+		// components, so the canonical requirement must not filter legitimate
+		// cluster paths like /.agent/xx.
+		{
+			name:   "hidden root component is allowed",
+			path:   "/.agent/xx",
+			wantOK: true,
+		},
+		{
+			name:   "hidden component under existing tree is allowed",
+			path:   filepath.Join(existingDir, ".agent", "xx"),
+			wantOK: true,
+		},
+		{
+			name:   "dot-dot-prefixed component is not traversal",
+			path:   filepath.Join(existingDir, "..agent", "xx"),
+			wantOK: true,
+		},
+		{
+			// A "." component is harmless (kernel resolves it identically),
+			// so it is allowed. Note: string concatenation, not filepath.Join.
+			name:   "literal dot component is allowed",
+			path:   existingDir + "/./mount",
 			wantOK: true,
 		},
 

--- a/pkg/utils/auth_test.go
+++ b/pkg/utils/auth_test.go
@@ -58,6 +58,12 @@ func TestValidatePath(t *testing.T) {
 	if err := os.MkdirAll(procLikeDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
+	// A regular file to verify that resolution errors other than non-existence
+	// are propagated instead of triggering the parent recursion.
+	regularFile := filepath.Join(t.TempDir(), "regular-file")
+	if err := os.WriteFile(regularFile, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
 
 	tests := []struct {
 		name    string
@@ -113,10 +119,19 @@ func TestValidatePath(t *testing.T) {
 			wantErr: "under sensitive path /proc",
 		},
 
-		// A non-existent parent directory cannot be resolved -> error.
+		// Multiple non-existent trailing components are resolved by walking up
+		// to the deepest existing ancestor, so the path is still validated.
 		{
-			name:    "non-existent parent returns error",
-			path:    filepath.Join(base, "missing-parent", "leaf"),
+			name:   "multiple non-existent components resolve via ancestor",
+			path:   filepath.Join(base, "missing-parent", "leaf"),
+			wantOK: true,
+		},
+
+		// A path through a regular file fails resolution with a non-ENOENT
+		// error, which is propagated instead of recursing into the parent.
+		{
+			name:    "path through regular file returns error",
+			path:    filepath.Join(regularFile, "leaf"),
 			wantOK:  false,
 			wantErr: "failed to resolve symlinks",
 		},
@@ -197,6 +212,13 @@ func TestValidatePath_Symlinks(t *testing.T) {
 	assert.False(t, ok)
 	assert.ErrorContains(t, err, "under PATH directory")
 
+	// A multi-level missing path through a symlinked ancestor must also be
+	// rejected: the recursion resolves the ancestor and re-appends the full
+	// non-existent suffix before the PATH check runs.
+	ok, err = ValidatePath(filepath.Join(parentLink, "missing1", "missing2"))
+	assert.False(t, ok)
+	assert.ErrorContains(t, err, "under PATH directory")
+
 	// A leaf that is itself a symlink into a PATH dir must be rejected.
 	leafLink := filepath.Join(base, "leaf-link")
 	if err := os.Symlink(sensitiveDir, leafLink); err != nil {
@@ -231,4 +253,45 @@ func TestValidatePath_SymlinkIntoProc(t *testing.T) {
 	ok, err := ValidatePath(filepath.Join(procLink, "self"))
 	assert.False(t, ok)
 	assert.ErrorContains(t, err, "under sensitive path /proc")
+}
+
+func TestResolveSymlinks(t *testing.T) {
+	base, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	existing := filepath.Join(base, "existing")
+	if err := os.MkdirAll(existing, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// An existing path without any symlink resolves to itself.
+	got, err := resolveSymlinks(existing)
+	assert.NoError(t, err)
+	assert.Equal(t, existing, got)
+
+	// A symlinked ancestor is resolved and the full non-existent suffix is
+	// re-appended: link -> existing, so link/a/b resolves to existing/a/b.
+	link := filepath.Join(base, "link")
+	if err := os.Symlink(existing, link); err != nil {
+		t.Fatal(err)
+	}
+	got, err = resolveSymlinks(filepath.Join(link, "a", "b"))
+	assert.NoError(t, err)
+	assert.Equal(t, filepath.Join(existing, "a", "b"), got)
+
+	// A leaf that is itself a symlink resolves to its target.
+	got, err = resolveSymlinks(link)
+	assert.NoError(t, err)
+	assert.Equal(t, existing, got)
+
+	// A path through a regular file fails with a non-ENOENT error, which must
+	// be propagated instead of triggering the parent recursion.
+	regularFile := filepath.Join(t.TempDir(), "file")
+	if err := os.WriteFile(regularFile, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got, err = resolveSymlinks(filepath.Join(regularFile, "leaf"))
+	assert.Error(t, err)
+	assert.Empty(t, got)
 }


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

#### What this PR does / why we need it:

The agent scenario involves multiple non-existence paths. resolveSymlinks previously resolved only one missing trailing component by evaluating the parent directory once. When multiple trailing components do not exist, resolution failed and ValidatePath rejected the path outright.

Now it recursively walks up to the deepest existing ancestor (only on os.IsNotExist errors), resolves its symlinks, and re-appends the full non-existent suffix, so symlinks in any existing ancestor are followed and exact-match sensitive-path checks remain effective. Other resolution errors are propagated instead of triggering the recursion.

Add TestResolveSymlinks covering the exact output contract, and extend ValidatePath tests for multi-level missing paths through symlinked ancestors and non-ENOENT error propagation.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
