### PR TITLE
chore: bump aliyun-alinas-utils to 2.4-0.20260721112941.f65c1a

### DIFF
--- a/VERSIONS
+++ b/VERSIONS
@@ -28,7 +28,7 @@ OSSFS2_IMAGE_TAG=v2.0.8.ack.1-d7bd1d4
 ALINAS_RPM_BASE_URL=https://aliyun-alinas-eac.oss-cn-beijing.aliyuncs.com/efc-release/2.4
 
 # ALINAS Utils version (used in Dockerfile for yum install)
-ALINAS_UTILS_VERSION=2.4-0.20260716211217.1eba09.generic
+ALINAS_UTILS_VERSION=2.4-0.20260721112941.f65c1a.generic
 
 # EFC version (used in Dockerfile for yum install)
 EFC_VERSION=2.4-20260715152610.afea64.3351f8b.release

--- a/build/mount-proxy/Dockerfile
+++ b/build/mount-proxy/Dockerfile
@@ -107,7 +107,7 @@ ENTRYPOINT ["csi-mount-proxy-server", "--driver=ossfs2"]
 FROM alinux-install AS alinas
 
 ARG TARGETPLATFORM
-ARG ALINAS_UTILS_VERSION=2.4-0.20260716211217.1eba09.generic
+ARG ALINAS_UTILS_VERSION=2.4-0.20260721112941.f65c1a.generic
 ARG EFC_VERSION=2.4-20260715152610.afea64.3351f8b.release
 ARG ALINAS_RPM_BASE_URL=https://aliyun-alinas-eac.oss-cn-beijing.aliyuncs.com/efc-release/2.4
 
@@ -146,7 +146,7 @@ ARG OSSFS_VERSION=v1.91.11.ack.1
 ARG OSSFS2_VERSION=v2.0.8.ack.1
 ARG OSSFS_RPM_URL
 ARG OSSFS2_RPM_URL
-ARG ALINAS_UTILS_VERSION=2.4-0.20260716211217.1eba09.generic
+ARG ALINAS_UTILS_VERSION=2.4-0.20260721112941.f65c1a.generic
 ARG EFC_VERSION=2.4-20260715152610.afea64.3351f8b.release
 ARG ALINAS_RPM_BASE_URL=https://aliyun-alinas-eac.oss-cn-beijing.aliyuncs.com/efc-release/2.4
 


### PR DESCRIPTION
## Summary
Bump `aliyun-alinas-utils` to `2.4-0.20260721112941.f65c1a.generic`.

Updated `ALINAS_UTILS_VERSION` in `VERSIONS` and regenerated the downstream references via `make update-versions`.

### RPM sources
- alinas-utils (x86_64): https://aliyun-alinas-eac.oss-cn-beijing.aliyuncs.com/efc-release/2.4/aliyun-alinas-utils-2.4-0.20260721112941.f65c1a.generic.x86_64.rpm
- alinas-utils (aarch64): https://aliyun-alinas-eac.oss-cn-beijing.aliyuncs.com/efc-release/2.4/aliyun-alinas-utils-2.4-0.20260721112941.f65c1a.generic.aarch64.rpm

### Notes
- EFC version (`2.4-20260715152610.afea64.3351f8b.release`) and the RPM base URL are unchanged.
- Changes are limited to `VERSIONS` and `build/mount-proxy/Dockerfile` (both the `alinas` and `aio` stages).
