### PR TITLE
feat(alinas): always overwrite alinas default configs on startup

### DIFF
--- a/pkg/mounter/proxy/server/alinas/driver.go
+++ b/pkg/mounter/proxy/server/alinas/driver.go
@@ -163,6 +163,10 @@ func setupDefaultConfigs() {
 	for _, name := range []string{"cpfs", "alinas"} {
 		srcDir := filepath.Join(defaultConfigDir, name)
 		dstDir := filepath.Join(configDir, name)
+		// The alinas config is always overwritten with the default shipped in
+		// the image so that config updates from a new image take effect on
+		// restart. cpfs keeps the copy-if-absent behavior.
+		overwrite := name == "alinas"
 		if err := filepath.WalkDir(srcDir, func(path string, d fs.DirEntry, err error) error {
 			if err != nil {
 				return err
@@ -179,11 +183,13 @@ func setupDefaultConfigs() {
 
 			dstPath := filepath.Join(dstDir, relPath)
 
-			if _, err := os.Stat(dstPath); err == nil {
-				// File already exists, skip
-				return nil
-			} else if !os.IsNotExist(err) {
-				return err
+			if !overwrite {
+				if _, err := os.Stat(dstPath); err == nil {
+					// File already exists, skip
+					return nil
+				} else if !os.IsNotExist(err) {
+					return err
+				}
 			}
 
 			klog.InfoS("Copying default config file", "path", dstPath)


### PR DESCRIPTION
  setupDefaultConfigs only copied a default config file when the target
  was absent (copy-if-absent). As a result, config files already present
  under /etc/aliyun/alinas (persisted on the host via the bind-mounted
  /etc/cnfs/alinas) were never refreshed, so config updates shipped in a
  new image never took effect after a restart.

  Always overwrite files under the alinas config dir with the defaults
  shipped in the image so image config updates apply on restart. cpfs
  keeps the existing copy-if-absent behavior.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
