### PR TITLE
Alinas always overwrite default config

### DIFF
--- a/pkg/mounter/proxy/server/alinas/driver.go
+++ b/pkg/mounter/proxy/server/alinas/driver.go
@@ -67,9 +67,9 @@ func (h *Driver) Mount(ctx context.Context, req *proxy.MountRequest) error {
 }
 
 func (h *Driver) Init() {
+	setupDefaultConfigs()
 	go runCommandForever("aliyun-alinas-mount-watchdog")
 	go runCommandForever("aliyun-cpfs-mount-watchdog")
-	setupDefaultConfigs()
 }
 
 // defaultResetFlagPath is the path to the reset flag file written by envd.
@@ -163,6 +163,10 @@ func setupDefaultConfigs() {
 	for _, name := range []string{"cpfs", "alinas"} {
 		srcDir := filepath.Join(defaultConfigDir, name)
 		dstDir := filepath.Join(configDir, name)
+		// The alinas config is always overwritten with the default shipped in
+		// the image so that config updates from a new image take effect on
+		// restart. cpfs keeps the copy-if-absent behavior.
+		overwrite := name == "alinas"
 		if err := filepath.WalkDir(srcDir, func(path string, d fs.DirEntry, err error) error {
 			if err != nil {
 				return err
@@ -179,11 +183,13 @@ func setupDefaultConfigs() {
 
 			dstPath := filepath.Join(dstDir, relPath)
 
-			if _, err := os.Stat(dstPath); err == nil {
-				// File already exists, skip
-				return nil
-			} else if !os.IsNotExist(err) {
-				return err
+			if !overwrite {
+				if _, err := os.Stat(dstPath); err == nil {
+					// File already exists, skip
+					return nil
+				} else if !os.IsNotExist(err) {
+					return err
+				}
 			}
 
 			klog.InfoS("Copying default config file", "path", dstPath)


### PR DESCRIPTION
setupDefaultConfigs only copied a default config file when the target
was absent (copy-if-absent). As a result, config files already present
under /etc/aliyun/alinas (persisted on the host via the bind-mounted
/etc/cnfs/alinas) were never refreshed, so config updates shipped in a
new image never took effect after a restart.

Always overwrite files under the alinas config dir with the defaults
shipped in the image so image config updates apply on restart. cpfs
keeps the existing copy-if-absent behavior.

#### What type of PR is this?

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
