### PR TITLE
feat(bmcpfs): delay detach on unstage for possible reuse

### DIFF
--- a/pkg/bmcpfs/nodeserver.go
+++ b/pkg/bmcpfs/nodeserver.go
@@ -26,6 +26,8 @@ import (
 	"os"
 	"slices"
 	"strings"
+	"sync"
+	"time"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/cloud/metadata"
@@ -42,6 +44,9 @@ type nodeServer struct {
 	common.GenericNodeServer
 	mounter mount.Interface
 	locks   *utils.VolumeLocks
+
+	detachDelay      time.Duration
+	unstageStartTime sync.Map // map[volumeID]time.Time
 }
 
 const (
@@ -49,7 +54,7 @@ const (
 	metricsPathPrefix             = "/run/cnfs/efc/"
 )
 
-func newNodeServer(meta *metadata.Metadata) (*nodeServer, error) {
+func newNodeServer(meta metadata.MetadataProvider) (*nodeServer, error) {
 	var nodeID string
 	data, err := os.ReadFile(metadata.LingjunConfigFile)
 	if err != nil {
@@ -83,11 +88,59 @@ func newNodeServer(meta *metadata.Metadata) (*nodeServer, error) {
 	}
 	klog.Infof("bmcpfsplugin nodeId: %s", nodeID)
 	mounter := mounter.NewProxyMounter(defaultAlinasMountProxySocket, mount.NewWithoutSystemd(""))
+
+	var detachDelay time.Duration
+	if delay := os.Getenv("BMCPFS_DETACH_DELAY"); delay != "" {
+		if delay, err := time.ParseDuration(delay); err == nil {
+			detachDelay = delay
+		} else {
+			return nil, fmt.Errorf("parse BMCPFS_DETACH_DELAY: %w", err)
+		}
+	}
 	return &nodeServer{
 		GenericNodeServer: common.GenericNodeServer{NodeID: nodeID},
 		locks:             utils.NewVolumeLocks(),
 		mounter:           mounter,
+		detachDelay:       detachDelay,
 	}, nil
+}
+
+func (ns *nodeServer) NodeGetCapabilities(ctx context.Context, req *csi.NodeGetCapabilitiesRequest) (*csi.NodeGetCapabilitiesResponse, error) {
+	return &csi.NodeGetCapabilitiesResponse{
+		Capabilities: []*csi.NodeServiceCapability{
+			{
+				Type: &csi.NodeServiceCapability_Rpc{
+					Rpc: &csi.NodeServiceCapability_RPC{
+						Type: csi.NodeServiceCapability_RPC_STAGE_UNSTAGE_VOLUME,
+					},
+				},
+			},
+		},
+	}, nil
+}
+
+func (ns *nodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRequest) (*csi.NodeStageVolumeResponse, error) {
+	ns.unstageStartTime.Delete(req.VolumeId)   // in case NodeUnstageVolume never finished and next Pod comes
+	return &csi.NodeStageVolumeResponse{}, nil // no-op
+}
+
+func (ns *nodeServer) NodeUnstageVolume(ctx context.Context, req *csi.NodeUnstageVolumeRequest) (*csi.NodeUnstageVolumeResponse, error) {
+	if ns.detachDelay == 0 {
+		return &csi.NodeUnstageVolumeResponse{}, nil
+	}
+	actual, _ := ns.unstageStartTime.LoadOrStore(req.VolumeId, time.Now())
+	startTime := actual.(time.Time)
+	select {
+	case <-time.After(time.Until(startTime.Add(ns.detachDelay))):
+	case <-time.After(1 * time.Second):
+		// Return fast, so the returning pod don't need to wait for the long timeout.
+		// But still wait 1s to avoid busy loop.
+		return nil, status.Error(codes.DeadlineExceeded, "delaying detach for possible reuse")
+	case <-ctx.Done():
+		return nil, status.Errorf(codes.DeadlineExceeded, "delaying detach for possible reuse: %v", ctx.Err())
+	}
+	ns.unstageStartTime.Delete(req.VolumeId)
+	return &csi.NodeUnstageVolumeResponse{}, nil
 }
 
 func (ns *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublishVolumeRequest) (

--- a/pkg/bmcpfs/nodeserver_test.go
+++ b/pkg/bmcpfs/nodeserver_test.go
@@ -21,10 +21,15 @@ package bmcpfs
 import (
 	"context"
 	"testing"
+	"testing/synctest"
+	"time"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
+	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/cloud/metadata"
 	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/utils"
 	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	k8smount "k8s.io/mount-utils"
 )
 
@@ -160,4 +165,130 @@ func TestNodePublishVolume_GLeaseEnable(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestNewNodeServer(t *testing.T) {
+	cases := []struct {
+		name           string
+		detachDelayEnv string
+		detachDelay    time.Duration
+		err            string
+	}{
+		{
+			name: "default",
+		},
+		{
+			name:           "detach_delay",
+			detachDelayEnv: "10m",
+			detachDelay:    10 * time.Minute,
+		},
+		{
+			name:           "detach_delay_invalid",
+			detachDelayEnv: "invalid",
+			err:            "invalid duration",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("BMCPFS_DETACH_DELAY", tc.detachDelayEnv)
+			ns, err := newNodeServer(&metadata.FakeProvider{})
+			if tc.err != "" {
+				assert.ErrorContains(t, err, tc.err)
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, ns)
+				assert.Equal(t, tc.detachDelay, ns.detachDelay)
+			}
+		})
+	}
+}
+
+func (ns *nodeServer) hasUnstageEntry(volumeID string) bool {
+	_, ok := ns.unstageStartTime.Load(volumeID)
+	return ok
+}
+
+// drainUnstage models kubelet retrying NodeUnstageVolume until it succeeds.
+// Each call is capped, so success only lands once detachDelay has elapsed.
+func drainUnstage(t *testing.T, ns *nodeServer, volumeID string) {
+	t.Helper()
+	req := &csi.NodeUnstageVolumeRequest{VolumeId: volumeID}
+	for {
+		_, err := ns.NodeUnstageVolume(t.Context(), req)
+		if err == nil {
+			return
+		}
+		assert.Equal(t, codes.DeadlineExceeded, status.Code(err))
+	}
+}
+
+func TestNodeGetCapabilities_StageUnstage(t *testing.T) {
+	ns := &nodeServer{}
+	resp, err := ns.NodeGetCapabilities(t.Context(), &csi.NodeGetCapabilitiesRequest{})
+	assert.NoError(t, err)
+	assert.Len(t, resp.Capabilities, 1)
+	assert.Equal(t, csi.NodeServiceCapability_RPC_STAGE_UNSTAGE_VOLUME,
+		resp.Capabilities[0].GetRpc().GetType())
+}
+
+// detachDelay unset: NodeUnstageVolume returns immediately and records nothing.
+func TestNodeUnstageVolume_NoDelay(t *testing.T) {
+	ns := &nodeServer{}
+	_, err := ns.NodeUnstageVolume(t.Context(), &csi.NodeUnstageVolumeRequest{VolumeId: "vol-1"})
+	assert.NoError(t, err)
+	assert.False(t, ns.hasUnstageEntry("vol-1"))
+}
+
+// When the remaining delay is shorter than the per-call cap, the call waits only
+// that long and succeeds directly (no error, entry cleared).
+func TestNodeUnstageVolume_ShortDelaySucceeds(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		ns := &nodeServer{detachDelay: 500 * time.Millisecond}
+		start := time.Now()
+		_, err := ns.NodeUnstageVolume(t.Context(), &csi.NodeUnstageVolumeRequest{VolumeId: "vol-1"})
+		assert.NoError(t, err)
+		assert.Equal(t, 500*time.Millisecond, time.Since(start))
+		assert.False(t, ns.hasUnstageEntry("vol-1"))
+	})
+}
+
+const testDetachDelay = 10 * time.Minute
+
+// Across kubelet retries the detach completes exactly detachDelay after the
+// first call, regardless of how many capped calls it takes.
+func TestNodeUnstageVolume_RetryLoopCompletesAtDeadline(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		ns := &nodeServer{detachDelay: testDetachDelay}
+		start := time.Now()
+		drainUnstage(t, ns, "vol-1")
+		assert.Equal(t, testDetachDelay, time.Since(start))
+		assert.False(t, ns.hasUnstageEntry("vol-1"), "entry cleared once the delay elapses")
+	})
+}
+
+// A returning pod calls NodeStageVolume, which drops any leftover startTime so
+// the subsequent detach waits a full fresh delay instead of resuming the old
+// (already-elapsed) deadline.
+func TestNodeStageVolume_ResetsDelayForReuse(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		ns := &nodeServer{detachDelay: testDetachDelay}
+		req := &csi.NodeUnstageVolumeRequest{VolumeId: "vol-1"}
+
+		// First detach: one capped call leaves a startTime behind.
+		start := time.Now()
+		_, err := ns.NodeUnstageVolume(t.Context(), req)
+		assert.Equal(t, codes.DeadlineExceeded, status.Code(err))
+		assert.True(t, ns.hasUnstageEntry("vol-1"))
+
+		// Volume is reused before the delay elapsed.
+		_, err = ns.NodeStageVolume(t.Context(), &csi.NodeStageVolumeRequest{VolumeId: "vol-1"})
+		assert.NoError(t, err)
+		assert.False(t, ns.hasUnstageEntry("vol-1"))
+		assert.Less(t, time.Since(start), testDetachDelay)
+
+		// The next detach must run a full fresh delay from now.
+		restart := time.Now()
+		drainUnstage(t, ns, "vol-1")
+		assert.Equal(t, testDetachDelay, time.Since(restart))
+	})
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

The bmcpfs node plugin previously did not implement STAGE_UNSTAGE_VOLUME. This PR advertises the capability and adds a NodeUnstageVolume that, when the `BMCPFS_DETACH_DELAY` environment variable is set, defers reporting success until the delay has elapsed since the first unstage attempt. This keeps the volume attached for a window so that a returning pod can reuse the existing mount instead of paying a full detach + re-attach + re-mount cycle, which is expensive for CPFS.

The delay is enforced by a persisted per-volume start time rather than by parking the RPC. Each NodeUnstageVolume call returns after at most 1s with `DeadlineExceeded`, so a returning pod is never blocked behind an in-flight unstage — kubelet serializes mount and unmount on the same per-volume operation key, so a long in-flight unstage would otherwise delay the reuse it exists to enable. The start time survives across kubelet's retries, so the total delay stays bounded to `detachDelay` regardless of how many retries it takes. `NodeStageVolume` clears any leftover start time so a reused volume waits a full fresh delay on its next detach.

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:

`BMCPFS_DETACH_DELAY` is unset by default, so behavior is unchanged unless explicitly enabled; an unparseable value fails node-server startup rather than silently disabling the feature. It is intended for delays on the order of minutes. Because the design relies on kubelet's retry loop, the actual detach happens somewhere in `[t0 + detachDelay, t0 + detachDelay + kubelet_retry_interval]`, and each teardown logs `UnmountDevice failed: DeadlineExceeded` periodically for the duration of the delay — this is expected operation, not an error.

The timing-sensitive behavior is covered by unit tests using `testing/synctest` (fake clock), so they verify the full multi-minute delay deterministically and instantly.

#### Does this PR introduce a user-facing change?
```release-note
bmcpfs: added STAGE_UNSTAGE_VOLUME support with an optional `BMCPFS_DETACH_DELAY` to defer detach after unmount so a returning pod can reuse the existing mount.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```
