### PR TITLE
fix: let path validation get past a mount point with a dead filesystem

### DIFF
--- a/pkg/utils/auth.go
+++ b/pkg/utils/auth.go
@@ -17,11 +17,13 @@ limitations under the License.
 package utils
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"slices"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/aliyun/alibaba-cloud-sdk-go/sdk"
@@ -96,17 +98,49 @@ func isUnderPATH(resolved string) (string, bool) {
 	return "", false
 }
 
-// resolveSymlinks resolves symlinks for cleaned, tolerating non-existent
-// trailing components. It first tries to resolve the full path. Only when
-// that fails because the path does not exist yet does it recursively resolve
-// the parent directory, then re-append the missing trailing component, so the
-// result is the resolved deepest existing ancestor joined with the full
-// non-existent suffix. Symlinks in any existing ancestor directory are still
-// followed and cannot be used to bypass the sensitive-path checks. Any
-// resolution error other than non-existence is returned as-is, and an error
-// is also returned if no ancestor up to the root can be resolved.
+// evalSymlinks is a package variable so tests can simulate a mount point whose
+// filesystem is dead; that state cannot be created from a unit test.
+var evalSymlinks = filepath.EvalSymlinks
+
+// resolveSymlinks resolves symlinks for cleaned.
+//
+// A mount point whose filesystem is dead answers every lookup with ENOTCONN, which
+// would otherwise fail validation and stop the caller from ever unmounting it. Such a
+// component can only be the path we were asked about: mount(2) resolves symlinks
+// before mounting, so a mount point is always the leaf and always a directory.
+// Resolve its parent instead, which is an ordinary directory, and re-append the base
+// name. Ancestors go through resolveExistingAncestor untouched, so an ENOTCONN there
+// stays a hard error and no unverifiable suffix is ever re-appended.
+//
+// Only ENOTCONN is treated this way. That is narrower than mount-utils
+// IsCorruptedMnt, which also covers EACCES, EIO and ESTALE; ESTALE in particular means
+// the object may have been replaced, so it is not the crashed-daemon case.
 func resolveSymlinks(cleaned string) (string, error) {
-	resolved, err := filepath.EvalSymlinks(cleaned)
+	resolved, err := evalSymlinks(cleaned)
+	if err == nil {
+		return resolved, nil
+	}
+	if errors.Is(err, syscall.ENOTCONN) {
+		resolvedParent, perr := resolveExistingAncestor(filepath.Dir(cleaned))
+		if perr != nil {
+			return "", perr
+		}
+		return filepath.Join(resolvedParent, filepath.Base(cleaned)), nil
+	}
+	return resolveExistingAncestor(cleaned)
+}
+
+// resolveExistingAncestor resolves symlinks for cleaned, tolerating non-existent
+// trailing components. It first tries to resolve the full path. Only when that fails
+// because the path does not exist yet does it recursively resolve the parent
+// directory, then re-append the missing trailing component, so the result is the
+// resolved deepest existing ancestor joined with the full non-existent suffix.
+// Symlinks in any existing ancestor directory are still followed and cannot be used to
+// bypass the sensitive-path checks. Any resolution error other than non-existence is
+// returned as-is, and an error is also returned if no ancestor up to the root can be
+// resolved.
+func resolveExistingAncestor(cleaned string) (string, error) {
+	resolved, err := evalSymlinks(cleaned)
 	if err == nil {
 		return resolved, nil
 	}
@@ -118,7 +152,7 @@ func resolveSymlinks(cleaned string) (string, error) {
 		// Reached the root without resolving any ancestor.
 		return "", fmt.Errorf("cannot resolve any ancestor of %s: %w", cleaned, err)
 	}
-	resolvedParent, err := resolveSymlinks(parent)
+	resolvedParent, err := resolveExistingAncestor(parent)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/utils/auth_test.go
+++ b/pkg/utils/auth_test.go
@@ -19,9 +19,11 @@ package utils
 import (
 	"os"
 	"path/filepath"
+	"syscall"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGetAccessControl(t *testing.T) {
@@ -339,4 +341,48 @@ func TestResolveSymlinks(t *testing.T) {
 	got, err = resolveSymlinks(filepath.Join(regularFile, "leaf"))
 	assert.Error(t, err)
 	assert.Empty(t, got)
+}
+
+// A mount point whose filesystem is dead must not fail validation: both
+// NodePublishVolume and NodeUnpublishVolume resolve the target path first, so the
+// driver could neither re-establish nor clean up such a mount.
+func TestResolveSymlinks_DeadMountPoint(t *testing.T) {
+	// Resolve the temp dir up front: on macOS /var is a symlink to /private/var.
+	base, err := filepath.EvalSymlinks(t.TempDir())
+	require.NoError(t, err)
+	dead := filepath.Join(base, "deadmount")
+	require.NoError(t, os.MkdirAll(dead, 0o755))
+
+	orig := evalSymlinks
+	defer func() { evalSymlinks = orig }()
+	failWith := func(target string, errno syscall.Errno) {
+		evalSymlinks = func(path string) (string, error) {
+			if path == target {
+				return "", &os.PathError{Op: "lstat", Path: path, Err: errno}
+			}
+			return orig(path)
+		}
+	}
+
+	// Dead leaf: resolve the healthy parent and re-append the base name.
+	failWith(dead, syscall.ENOTCONN)
+	got, err := resolveSymlinks(dead)
+	assert.NoError(t, err)
+	assert.Equal(t, dead, got)
+
+	// A mount point is always the leaf, so an ENOTCONN ancestor is not tolerated:
+	// its contents are unreadable and the suffix could hide a symlink.
+	failWith(dead, syscall.ENOTCONN)
+	got, err = resolveSymlinks(filepath.Join(dead, "leaf"))
+	assert.Error(t, err)
+	assert.Empty(t, got)
+
+	// Errors IsCorruptedMnt would accept but that are not the crashed-daemon case
+	// stay hard failures.
+	for _, errno := range []syscall.Errno{syscall.ESTALE, syscall.EACCES, syscall.EIO, syscall.EPERM} {
+		failWith(dead, errno)
+		got, err = resolveSymlinks(dead)
+		assert.Error(t, err, "errno %v must not be resolved around", errno)
+		assert.Empty(t, got)
+	}
 }


### PR DESCRIPTION
When a FUSE daemon dies, the kernel answers every lookup of its mount point with ENOTCONN. ValidatePath resolves the target path before anything else runs, and EvalSymlinks only tolerates components that do not exist yet, so it turns that ENOTCONN into an error.

Both NodePublishVolume and NodeUnpublishVolume validate the target path first (pkg/oss/nodeserver.go, pkg/nas/nodeserver.go), so both fail with InvalidArgument for as long as the dead mount is there. The driver can then neither re-establish the mount nor tear it down, even though the code right behind the validation -- IsNotMountPoint and CleanupMountPoint -- exists precisely to unmount a corrupted mount point. The volume stays wedged until someone unmounts it by hand, and the pod cannot finish terminating.

Treat a dead mount point like a component that does not exist yet: resolve the deepest healthy ancestor and re-append the suffix.

Scope of the relaxation:

  - Only ENOTCONN. Narrower than mount-utils IsCorruptedMnt, which also covers EACCES, EIO and ESTALE; ESTALE in particular means the object may have been replaced, which is not this case.

  - Only at the leaf, the caller's own mount path. A missing component cannot be a symlink, but a dead mount point does exist and its contents are unreadable, so an ENOTCONN ancestor would mean re-appending a suffix that could hide a symlink from the sensitive-path checks. A dead mount point itself is always a directory, since mount(2) resolves symlinks before mounting.

The checks that do the real work are unaffected: "..' is rejected lexically and /proc is rejected on the literal path, both before any resolution happens. EvalSymlinks becomes injectable because a dead mount cannot be created from a unit test.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
