### PR TITLE
fix: update test cluster script to use current ACK image types

### DIFF
--- a/hack/update-test-cluster.sh
+++ b/hack/update-test-cluster.sh
@@ -2,21 +2,19 @@
 
 set -e
 
-read -r k8s containerd alinux3 alinux3con alinux3arm containeros < \
+IFS=$'\t' read -r k8s containerd alinux3 alinux3arm containeros < \
     <(aliyun cs GET /api/v1/metadata/versions --Region 'cn-beijing' --ClusterType ManagedKubernetes | \
         jq -r '.[0] | [
             (.version | tojson),
             (.runtimes.[] | select(.name=="containerd") | .version | tojson),
-            (.images.[] | select(.image_type=="AliyunLinux3") | .image_id),
-            (.images.[] | select(.image_type=="AliyunLinux3ContainerOptimized") | .image_id),
-            (.images.[] | select(.image_type=="AliyunLinux3Arm64") | .image_id),
+            (.images.[] | select(.image_type=="AliyunLinux3ContainerOptimized" and .architecture=="x86_64") | .image_id),
+            (.images.[] | select(.image_type=="AliyunLinux3ContainerOptimizedArm64") | .image_id),
             (.images.[] | select(.image_type=="ContainerOS") | .image_id)
         ] | @tsv')
 
 echo "     cluster: $k8s"
 echo "  containerd: $containerd"
 echo "    ALinux 3: $alinux3"
-echo "ALinux 3 Con: $alinux3con"
 echo "ALinux 3 ARM: $alinux3arm"
 echo " ContainerOS: $containeros"
 
@@ -25,7 +23,6 @@ sed -i '' "s/kubernetes_version:.*/kubernetes_version: $k8s,/;
     test/cluster/cluster-template.jsonnet
 
 sed -i '' "s/\${OS_IMAGE_ALINUX3:.*}/\${OS_IMAGE_ALINUX3:-$alinux3}/;
-           s/\${OS_IMAGE_ALINUX3_CONTAINER:.*}/\${OS_IMAGE_ALINUX3_CONTAINER:-$alinux3con}/;
            s/\${OS_IMAGE_ALINUX3_ARM64:.*}/\${OS_IMAGE_ALINUX3_ARM64:-$alinux3arm}/;
            s/\${OS_IMAGE_CONTAINEROS3:.*}/\${OS_IMAGE_CONTAINEROS3:-$containeros}/;" \
     test/cluster/cluster_setup.sh

--- a/test/cluster/cluster-template.jsonnet
+++ b/test/cluster/cluster-template.jsonnet
@@ -22,7 +22,7 @@ local nodePool = {
         cis_enabled: false,
         login_as_non_root: false,
         platform: "AliyunLinux",
-        image_id: std.extVar("os_image_alinux3_container"),
+        image_id: std.extVar("os_image_alinux3"),
         image_type: "AliyunLinux3ContainerOptimized"
     },
     kubernetes_config: {
@@ -30,7 +30,7 @@ local nodePool = {
         cms_enabled: false,
         unschedulable: false,
         runtime: "containerd",
-        runtime_version: "2.1.5",
+        runtime_version: "2.1.9",
     },
     management: {
         enable: false
@@ -41,7 +41,7 @@ local nodePool = {
 {
     name: clusterName,
     cluster_type: "ManagedKubernetes",
-    kubernetes_version: "1.34.3-aliyun.1",
+    kubernetes_version: "1.36.2-aliyun.1",
     region_id: std.extVar("region"),
     snat_entry: true,
     cloud_monitor_flags: false,
@@ -101,8 +101,6 @@ local nodePool = {
                 instance_types: [
                     "ecs.mn4.xlarge",
                 ],
-                image_id: std.extVar("os_image_alinux3"),
-                image_type: "AliyunLinux3"
             }
         },
         nodePool {
@@ -115,7 +113,7 @@ local nodePool = {
                     "ecs.g8y.xlarge",
                 ],
                 image_id: std.extVar("os_image_alinux3_arm64"),
-                image_type: "AliyunLinux3Arm64",
+                image_type: "AliyunLinux3ContainerOptimizedArm64",
                 data_disks: [ // add an EED data disk to ensure the zone supports EED
                     {
                         category: "elastic_ephemeral_disk_standard",

--- a/test/cluster/cluster_setup.sh
+++ b/test/cluster/cluster_setup.sh
@@ -79,10 +79,9 @@ function create-ack-cluster {
         --ext-str region="$ACK_REGION" \
         --ext-str vpc_id="$VPC_ID" \
         --ext-str cluster_name="$CASE_NAME" \
-        --ext-str os_image_alinux3="${OS_IMAGE_ALINUX3:-aliyun_3_x64_20G_alibase_20241218.vhd}" \
-        --ext-str os_image_alinux3_container="${OS_IMAGE_ALINUX3_CONTAINER:-aliyun_3_x64_20G_container_optimized_alibase_20250629.vhd}" \
-        --ext-str os_image_alinux3_arm64="${OS_IMAGE_ALINUX3_ARM64:-aliyun_3_arm64_20G_alibase_20240528.vhd}" \
-        --ext-str os_image_containeros3="${OS_IMAGE_CONTAINEROS3:-lifsea_3_x64_5G_alibase_20251204.qcow2}" \
+        --ext-str os_image_alinux3="${OS_IMAGE_ALINUX3:-aliyun_3_x64_20G_container_optimized_alibase_20260625.vhd}" \
+        --ext-str os_image_alinux3_arm64="${OS_IMAGE_ALINUX3_ARM64:-aliyun_3_arm64_20G_container_optimized_alibase_20260503.vhd}" \
+        --ext-str os_image_containeros3="${OS_IMAGE_CONTAINEROS3:-lifsea_3_x64_5G_alibase_20260716.qcow2}" \
         --ext-code n_nodes="$N_NODES" \
         --ext-code vswitch_ids="$(jq -n '$ARGS.positional' --args "${vswitch_ids[@]}")")
     CLUSTER_ID=$(aliyun --region "$ACK_REGION" cs POST /clusters --header "Content-Type=application/json" --body "$cluster_params" | jq -r .cluster_id)


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind failing-test

#### What this PR does / why we need it:

The `hack/update-test-cluster.sh` script fetches OS image IDs from the ACK metadata API, but the image_type names it queries (`AliyunLinux3`, `AliyunLinux3Arm64`) are no longer returned by the API — only the container-optimized variants (`AliyunLinux3ContainerOptimized`, `AliyunLinux3ContainerOptimizedArm64`) exist now.

This caused two problems:
1. The jq query produced empty strings for the missing image types.
2. `read` with the default IFS silently skipped the empty tab-separated fields, causing all subsequent values to shift left into wrong variables — e.g. the `AliyunLinux3ContainerOptimized` image_id landed in `alinux3`, and the `ContainerOS` image_id landed in `alinux3con`. The last two variables (`alinux3arm`, `containeros`) ended up empty.

As a result, `cluster_setup.sh` was written with incorrect default image IDs, which would cause cluster creation to fail or use wrong images.

This PR:
- Updates the image_type names in the jq query to match the current API response
- Adds `IFS=$'\t'` to the `read` command so empty fields are preserved instead of being silently skipped (defends against future API changes)
- Removes the now-redundant `alinux3con` variable and `os_image_alinux3_container` ext-var, since `AliyunLinux3` and `AliyunLinux3ContainerOptimized` are the same thing now
- Updates `cluster-template.jsonnet` to use the correct `image_type` values for the affected node pools

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

The `alinux3` and `alinux3con` variables previously held different images (plain AliyunLinux3 vs container-optimized). Since the API no longer provides a non-container-optimized AliyunLinux3 image, both node pools now use `AliyunLinux3ContainerOptimized`. The "ssd_only" pool differs by disk category (cloud_efficiency vs cloud_essd), not by OS image.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
```