### PR TITLE
feat(bmcpfs): support access point mount with RAM auth and STS rotation

### DIFF
--- a/deploy/charts/alibaba-cloud-csi-driver/templates/csi-driver.yaml
+++ b/deploy/charts/alibaba-cloud-csi-driver/templates/csi-driver.yaml
@@ -48,4 +48,7 @@ metadata:
 spec:
   attachRequired: true
   podInfoOnMount: true
+  # Required for STS credential rotation: kubelet periodically re-invokes
+  # NodePublishVolume with the latest nodePublishSecretRef contents.
+  requiresRepublish: true
 {{- end }}

--- a/docs/bmcpfs-access-point.md
+++ b/docs/bmcpfs-access-point.md
@@ -1,0 +1,276 @@
+# BMCPFS Access Point（AP）挂载使用文档
+
+本文档介绍如何使用 bmcpfs 驱动（`bmcpfsplugin.csi.alibabacloud.com`）通过 CPFS Access Point 挂载文件系统，包括无鉴权挂载、RAM 鉴权（静态 AK / 可轮转 STS）两类场景。
+
+## 功能概述
+
+| 能力 | 说明 |
+| --- | --- |
+| AP 挂载 | 通过 `accessPointId` 指定接入点，支持 tcp 与 vsc 两种网络类型（驱动按节点类型自动选择） |
+| 无鉴权挂载 | 不配置 `nodePublishSecretRef`，仅通过 AP 挂载 |
+| RAM 鉴权：静态 AK | Secret 含 AK/SK 两键，写入 `g_unas_AKFile`；不支持热更新 |
+| RAM 鉴权：STS 轮转 | Secret 含 STS 三元组，支持外部轮转，写入 `g_unas_STSFile`；EFC 客户端每 10 分钟自动重读并刷新签名 |
+| 鉴权模式自动识别 | 无需 `authType` 参数，驱动按 `nodePublishSecretRef` 的 Secret 键集合自动识别 AK / STS 模式 |
+| 单 Pod 多 AP | 同一 Pod 可同时挂载同一文件系统的多个不同 AP（每个 AP 一个 PV） |
+
+STS 轮转基于 Kubernetes 社区的 `CSIDriver requiresRepublish` 机制：kubelet 周期性重新调用 NodePublishVolume 并携带最新 Secret 内容，驱动检测到变化后原子更新 STS 配置文件，EFC 客户端在下一个 10 分钟周期内加载新凭证。全程无需重启 Pod、不中断挂载。
+
+## 前提条件
+
+1. **CSI 组件版本**：安装包含 bmcpfs AP 支持的 csi-plugin / csi-provisioner 版本，helm values 中启用：
+
+   ```yaml
+   csi:
+     bmcpfs:
+       enabled: true
+   ```
+
+   bmcpfs 的 CSIDriver 对象默认渲染 `requiresRepublish: true`（STS 轮转依赖），无需额外开关。
+
+2. **EFC 客户端版本**：节点上的 EFC 客户端需支持 `accesspoint`、`g_unas_AKFile`、`g_unas_STSFile` 挂载参数。
+3. **fileserver 集群配置**：CPFS fileserver 集群需设置 flag `efc_pov_UmmSigningRegion=<当前 region>`（RAM 鉴权签名校验的服务端前置条件，请联系 CPFS 侧配置）。
+4. **AP 已创建**：通过 NAS 控制台/OpenAPI 预先创建 Access Point，获得 `ap-` 开头的 AP ID。
+
+## 卷配置规范
+
+### volumeHandle 唯一性要求（重要）
+
+同一 Pod 引用同一文件系统的多个 AP 时，kubelet 按 `volumeHandle` 对卷去重。因此**每个 AP PV 的 volumeHandle 必须唯一**，格式为：
+
+```
+volumeHandle: "<bmcpfsId>+<唯一后缀>"
+# 推荐用 AP ID 作后缀: cpfs-0123456789+ap-aaaaaaaa
+# 存量 fileset 卷的 <bmcpfsId>+<filesetId> 格式继续兼容，无需变更
+```
+
+第一段必须为文件系统 ID（驱动据此执行 attach）；后缀仅用于保证唯一性，内容不限（推荐 AP ID，便于运维对应）。实际挂载的 AP 以 `volumeAttributes.accessPointId` 为准，与后缀无强制关联。
+
+### volumeAttributes
+
+| 键 | 必填 | 说明 |
+| --- | --- | --- |
+| `vpcMountTarget` | 与 vsc 二选一或同时配置 | VPC 挂载点域名（tcp 链路使用） |
+| `vscMountTarget` | 与 vpc 二选一或同时配置 | VSC 挂载点域名（vsc 链路使用） |
+| `accessPointId` | AP 场景必填 | Access Point ID，非空即启用 AP 挂载 |
+
+### 鉴权模式识别与校验规则
+
+驱动不使用 `authType` 参数，而是根据 `nodePublishSecretRef` 引用的 Secret 键集合自动识别模式：
+
+| Secret 内容 | 识别结果 |
+| --- | --- |
+| 未配置 `nodePublishSecretRef` | 无鉴权挂载 |
+| 恰好含 `accessKeyId`、`accessKeySecret` | AK 模式 |
+| 含 `accessKeyId`、`accessKeySecret`、`securityToken`（可选 `expiration`） | STS 模式 |
+| 其它形状（缺键、空值、未知键） | 拒绝挂载（`InvalidArgument`） |
+
+注意：
+
+- 键集合为严格白名单匹配，拼写错误（如 `security_token`）会被直接拒绝，不会静默降级为 AK 模式或匿名挂载。
+- 配置了 Secret 时 `accessPointId` 必须非空（RAM 鉴权仅对 AP 挂载生效）。
+- 鉴权模式在首次挂载时定格：挂载后若 Secret 形状变化（如 AK 改为三元组），驱动告警并忽略，需重建 Pod 重新挂载生效。
+- 不支持在 PV `mountOptions` 中手工填写 `g_unas_AKFile` / `g_unas_STSFile`，此类选项会被驱动剥离并告警；凭证文件路径由驱动统一管理。
+
+## 使用方式
+
+### 用例 1：无鉴权 AP 挂载
+
+```yaml
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: bmcpfs-ap-pv
+spec:
+  capacity:
+    storage: 500Gi
+  accessModes: ["ReadWriteMany"]
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: ""
+  csi:
+    driver: bmcpfsplugin.csi.alibabacloud.com
+    volumeHandle: "cpfs-0123456789+ap-aaaaaaaa"
+    volumeAttributes:
+      vpcMountTarget: "cpfs-0123456789-vpc.cn-hangzhou.cpfs.aliyuncs.com"
+      vscMountTarget: "cpfs-0123456789-vsc.cn-hangzhou.cpfs.aliyuncs.com"
+      accessPointId: "ap-aaaaaaaa"
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: bmcpfs-ap-pvc
+  namespace: default
+spec:
+  accessModes: ["ReadWriteMany"]
+  storageClassName: ""
+  resources:
+    requests:
+      storage: 500Gi
+  volumeName: bmcpfs-ap-pv
+```
+
+驱动生成的挂载命令等价于（tcp 链路）：
+
+```bash
+mount -t alinas -o efc,protocol=efc,net=tcp,fstype=cpfs \
+  -o accesspoint=ap-aaaaaaaa \
+  cpfs-0123456789-vpc.cn-hangzhou.cpfs.aliyuncs.com:/ <targetPath>
+```
+
+### 用例 2：RAM 鉴权——静态 AK
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: bmcpfs-ak-secret
+  namespace: kube-system
+type: Opaque
+stringData:
+  accessKeyId: "LTAI5t********"
+  accessKeySecret: "********"
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: bmcpfs-ap-ak-pv
+spec:
+  capacity:
+    storage: 500Gi
+  accessModes: ["ReadWriteMany"]
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: ""
+  csi:
+    driver: bmcpfsplugin.csi.alibabacloud.com
+    volumeHandle: "cpfs-0123456789+ap-aaaaaaaa"
+    volumeAttributes:
+      vpcMountTarget: "cpfs-0123456789-vpc.cn-hangzhou.cpfs.aliyuncs.com"
+      vscMountTarget: "cpfs-0123456789-vsc.cn-hangzhou.cpfs.aliyuncs.com"
+      accessPointId: "ap-aaaaaaaa"
+    nodePublishSecretRef:
+      name: bmcpfs-ak-secret
+      namespace: kube-system
+```
+
+驱动检测到 Secret 仅含 AK/SK 两键，自动按 AK 模式挂载。
+
+**注意**：AK 配置不支持热更新。修改 Secret 中的 AK 后，需要重建使用该卷的 Pod 触发重新挂载才能生效。
+
+### 用例 3：RAM 鉴权——STS 轮转
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: bmcpfs-sts-secret
+  namespace: kube-system
+type: Opaque
+stringData:               # 由外部系统周期性轮转更新
+  accessKeyId: "STS.xxx"
+  accessKeySecret: "********"
+  securityToken: "********"
+  expiration: "2026-08-10T12:00:00Z"   # 可选，仅用于告警
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: bmcpfs-ap-sts-pv
+spec:
+  capacity:
+    storage: 500Gi
+  accessModes: ["ReadWriteMany"]
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: ""
+  csi:
+    driver: bmcpfsplugin.csi.alibabacloud.com
+    volumeHandle: "cpfs-0123456789+ap-aaaaaaaa"
+    volumeAttributes:
+      vpcMountTarget: "cpfs-0123456789-vpc.cn-hangzhou.cpfs.aliyuncs.com"
+      vscMountTarget: "cpfs-0123456789-vsc.cn-hangzhou.cpfs.aliyuncs.com"
+      accessPointId: "ap-aaaaaaaa"
+    nodePublishSecretRef:
+      name: bmcpfs-sts-secret
+      namespace: kube-system
+```
+
+驱动检测到 Secret 含 `securityToken`，自动按 STS 模式挂载。
+
+**STS 轮转说明**：
+
+- 外部系统只需更新 Secret 中的三元组，无需操作节点或 Pod。
+- Secret 中**不需要** md5 字段；驱动写入 STS 配置文件时自动计算 `md5(accessKeyId + accessKeySecret + securityToken)`。
+- 新凭证生效链路：Secret 更新 → kubelet 周期性 republish 带入 → 驱动原子重写 STS 文件 → EFC 下一个 10 分钟周期加载。**端到端生效延迟上限约为 republish 间隔 + 10 分钟**，请保证轮转时新 STS 的剩余有效期充分大于该窗口（建议 ≥ 30 分钟）。
+- 同一 PV 在同一节点上的多个 Pod 共享同一份凭证文件（凭证为 PV 级配置）。
+
+### 用例 4：单 Pod 挂载同一文件系统的多个 AP
+
+为每个 AP 各建一个 PV/PVC（volumeHandle 后缀不同即可），Pod 同时引用：
+
+```yaml
+# PV/PVC 定义同用例 1~3，两个 PV 的 volumeHandle 分别为：
+#   cpfs-0123456789+ap-aaaaaaaa
+#   cpfs-0123456789+ap-bbbbbbbb
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: bmcpfs-multi-ap-app
+spec:
+  replicas: 2
+  selector:
+    matchLabels: {app: bmcpfs-multi-ap-app}
+  template:
+    metadata:
+      labels: {app: bmcpfs-multi-ap-app}
+    spec:
+      containers:
+        - name: app
+          image: registry.cn-hangzhou.aliyuncs.com/acs/busybox:latest
+          command: ["sleep", "infinity"]
+          volumeMounts:
+            - {name: data-a, mountPath: /data-a}
+            - {name: data-b, mountPath: /data-b}
+      volumes:
+        - name: data-a
+          persistentVolumeClaim: {claimName: bmcpfs-ap-a-pvc}
+        - name: data-b
+          persistentVolumeClaim: {claimName: bmcpfs-ap-b-pvc}
+```
+
+两个 AP 各自独立挂载、独立鉴权（可引用不同 Secret），互不影响。
+
+## 行为说明与约束
+
+### 卸载与 attach 保留行为
+
+同一文件系统的多个 AP/fileset PV 在同一节点上共享一条 CPFS↔VSC attach。为保证多 AP 场景卸载安全，当前版本对 volumeHandle 带 `+` 后缀的卷（AP 卷、fileset 卷）在卸载时**不执行 detach**，而是直接返回错误（`InvalidArgument`：`Volume with suffix is not detachable, please use the skip detach feature`）：
+
+- 卸载请求持续失败重试，VolumeAttachment 保留，不会误断同节点其它 AP 的挂载，running pod 不受影响。
+- 如需让 AP/fileset 卷正常完成卸载（Pod 删除、PVC 删除），设置 `SKIP_BMCPFS_DETACH=true`：卸载直接成功、不执行 detach。
+- 文件系统与节点 VSC 之间的 attach 会保留，随 VSC / 节点回收自动清理。
+- 如需提前回收（如触及 VSC attach 数量上限），可在确认该节点无该文件系统任何活跃挂载后，通过 NAS OpenAPI `DetachVscFromFilesystems` 手工 detach。
+- 后续版本计划通过增强的 external-attacher 方案恢复标准的按引用 detach 行为，届时该约束将移除，PV 配置无需变化。
+
+### 其它约束
+
+| 约束 | 说明 |
+| --- | --- |
+| accessModes | AP 卷推荐 `ReadWriteMany` |
+| AK 热更新 | 不支持；修改 AK 需重建 Pod |
+| 凭证文件 | 由驱动管理于节点 `/run/cnfs/efc-credentials/<volumeId>/`（目录 0700、文件 0600，位于 tmpfs），卷卸载后自动清理，请勿手工修改 |
+| Secret 内容 | 驱动不校验凭证与 AP 权限的匹配性；权限不足表现为挂载失败或 IO 报错，请核对 AP 的 RAM 策略 |
+
+## 故障排查
+
+| 现象 | 排查方向 |
+| --- | --- |
+| 挂载失败，事件含 `InvalidArgument` | 核对 Secret 键集合是否符合 AK / STS 白名单（拼写、多余键、空值）、`accessPointId` 是否配置 |
+| 多 AP 只挂上一个 / 挂错 AP | 检查各 PV 的 volumeHandle 是否唯一（kubelet 按 handle 去重，重复时只会挂其中一个） |
+| 挂载失败，EFC 报鉴权错误 | 确认 fileserver 已配置 `efc_pov_UmmSigningRegion`；核对 AK/STS 是否有效、AP RAM 策略是否授权 |
+| 轮转后新 STS 未生效 | 依次确认：Secret 已更新 → 节点上 `/run/cnfs/efc-credentials/<volumeId>/sts.json` 内容已更新（驱动侧）→ 等待 EFC 10 分钟读取周期（客户端侧）。若文件未更新，检查 CSIDriver 对象是否含 `requiresRepublish: true` |
+| STS 过期导致 IO 失败 | 检查外部轮转系统是否停止更新 Secret；确认轮转周期满足"剩余有效期 ≥ republish 间隔 + 10 分钟"的要求 |
+| 驱动日志 | 节点侧：csi-plugin DaemonSet Pod（bmcpfs 相关日志）；挂载执行侧：alinas mount-proxy 日志 |
+
+验证 STS 文件已更新的快捷方式（节点上执行）：
+
+```bash
+ls -l --time-style=full-iso /run/cnfs/efc-credentials/<volumeId>/sts.json   # 看修改时间
+```

--- a/docs/bmcpfs-access-point.md
+++ b/docs/bmcpfs-access-point.md
@@ -1,23 +1,23 @@
-# BMCPFS Access Point（AP）挂载使用文档
+# Mounting BMCPFS via an Access Point (AP)
 
-本文档介绍如何使用 bmcpfs 驱动（`bmcpfsplugin.csi.alibabacloud.com`）通过 CPFS Access Point 挂载文件系统，包括无鉴权挂载、RAM 鉴权（静态 AK / 可轮转 STS）两类场景。
+This document describes how to mount a file system through a CPFS Access Point with the bmcpfs driver (`bmcpfsplugin.csi.alibabacloud.com`). It covers anonymous mounts and RAM-authenticated mounts (static AccessKey, or STS credentials with rotation).
 
-## 功能概述
+## Overview
 
-| 能力 | 说明 |
+| Capability | Description |
 | --- | --- |
-| AP 挂载 | 通过 `accessPointId` 指定接入点，支持 tcp 与 vsc 两种网络类型（驱动按节点类型自动选择） |
-| 无鉴权挂载 | 不配置 `nodePublishSecretRef`，仅通过 AP 挂载 |
-| RAM 鉴权：静态 AK | Secret 含 AK/SK 两键，写入 `g_unas_AKFile`；不支持热更新 |
-| RAM 鉴权：STS 轮转 | Secret 含 STS 三元组，支持外部轮转，写入 `g_unas_STSFile`；EFC 客户端每 10 分钟自动重读并刷新签名 |
-| 鉴权模式自动识别 | 无需 `authType` 参数，驱动按 `nodePublishSecretRef` 的 Secret 键集合自动识别 AK / STS 模式 |
-| 单 Pod 多 AP | 同一 Pod 可同时挂载同一文件系统的多个不同 AP（每个 AP 一个 PV） |
+| AP mount | The access point is specified by `accessPointId`. Both `tcp` and `vsc` network types are supported; the driver picks one based on the node type. |
+| Anonymous mount | Mount through an AP only, without configuring `nodePublishSecretRef`. |
+| RAM auth: static AK | The Secret holds two keys (AK/SK), written to `g_unas_AKFile`. Hot reload is not supported. |
+| RAM auth: STS rotation | The Secret holds an STS credential triple and can be rotated externally. It is written to `g_unas_STSFile`, and the EFC client re-reads it and refreshes the signature every 10 minutes. |
+| Automatic auth mode detection | No `authType` parameter is needed. The driver infers AK vs. STS mode from the set of keys in the Secret referenced by `nodePublishSecretRef`. |
+| Multiple APs in one Pod | A single Pod can mount several APs of the same file system at once (one PV per AP). |
 
-STS 轮转基于 Kubernetes 社区的 `CSIDriver requiresRepublish` 机制：kubelet 周期性重新调用 NodePublishVolume 并携带最新 Secret 内容，驱动检测到变化后原子更新 STS 配置文件，EFC 客户端在下一个 10 分钟周期内加载新凭证。全程无需重启 Pod、不中断挂载。
+STS rotation builds on the upstream Kubernetes `CSIDriver requiresRepublish` mechanism: kubelet periodically calls NodePublishVolume again with the latest Secret contents, the driver atomically rewrites the STS credential file when it detects a change, and the EFC client picks up the new credentials in its next 10-minute cycle. No Pod restart and no mount interruption are involved.
 
-## 前提条件
+## Prerequisites
 
-1. **CSI 组件版本**：安装包含 bmcpfs AP 支持的 csi-plugin / csi-provisioner 版本，helm values 中启用：
+1. **CSI component version**: install a csi-plugin / csi-provisioner version that includes bmcpfs AP support, and enable it in the helm values:
 
    ```yaml
    csi:
@@ -25,55 +25,55 @@ STS 轮转基于 Kubernetes 社区的 `CSIDriver requiresRepublish` 机制：kub
        enabled: true
    ```
 
-   bmcpfs 的 CSIDriver 对象默认渲染 `requiresRepublish: true`（STS 轮转依赖），无需额外开关。
+   The bmcpfs CSIDriver object renders `requiresRepublish: true` by default (required for STS rotation); no extra switch is needed.
 
-2. **EFC 客户端版本**：节点上的 EFC 客户端需支持 `accesspoint`、`g_unas_AKFile`、`g_unas_STSFile` 挂载参数。
-3. **fileserver 集群配置**：CPFS fileserver 集群需设置 flag `efc_pov_UmmSigningRegion=<当前 region>`（RAM 鉴权签名校验的服务端前置条件，请联系 CPFS 侧配置）。
-4. **AP 已创建**：通过 NAS 控制台/OpenAPI 预先创建 Access Point，获得 `ap-` 开头的 AP ID。
+2. **EFC client version**: the EFC client on the node must support the `accesspoint`, `g_unas_AKFile`, and `g_unas_STSFile` mount options.
+3. **fileserver cluster configuration**: the CPFS fileserver cluster must have the flag `efc_pov_UmmSigningRegion=<current region>` set. This is the server-side prerequisite for RAM auth signature verification; contact the CPFS team to have it configured.
+4. **AP created**: create the Access Point beforehand via the NAS console or OpenAPI and obtain its `ap-` prefixed ID.
 
-## 卷配置规范
+## Volume specification
 
-### volumeHandle 唯一性要求（重要）
+### volumeHandle uniqueness (important)
 
-同一 Pod 引用同一文件系统的多个 AP 时，kubelet 按 `volumeHandle` 对卷去重。因此**每个 AP PV 的 volumeHandle 必须唯一**，格式为：
+When a single Pod references multiple APs of the same file system, kubelet deduplicates volumes by `volumeHandle`. Therefore **the volumeHandle of each AP PV must be unique**, in the following format:
 
 ```
-volumeHandle: "<bmcpfsId>+<唯一后缀>"
-# 推荐用 AP ID 作后缀: cpfs-0123456789+ap-aaaaaaaa
-# 存量 fileset 卷的 <bmcpfsId>+<filesetId> 格式继续兼容，无需变更
+volumeHandle: "<bmcpfsId>+<unique suffix>"
+# Using the AP ID as the suffix is recommended: cpfs-0123456789+ap-aaaaaaaa
+# The existing <bmcpfsId>+<filesetId> format for fileset volumes stays compatible and needs no change
 ```
 
-第一段必须为文件系统 ID（驱动据此执行 attach）；后缀仅用于保证唯一性，内容不限（推荐 AP ID，便于运维对应）。实际挂载的 AP 以 `volumeAttributes.accessPointId` 为准，与后缀无强制关联。
+The first segment must be the file system ID, which the driver uses to perform the attach. The suffix exists purely to guarantee uniqueness and may be anything (the AP ID is recommended, as it makes operations easier to correlate). The AP that actually gets mounted is determined by `volumeAttributes.accessPointId`, not by the suffix.
 
 ### volumeAttributes
 
-| 键 | 必填 | 说明 |
+| Key | Required | Description |
 | --- | --- | --- |
-| `vpcMountTarget` | 与 vsc 二选一或同时配置 | VPC 挂载点域名（tcp 链路使用） |
-| `vscMountTarget` | 与 vpc 二选一或同时配置 | VSC 挂载点域名（vsc 链路使用） |
-| `accessPointId` | AP 场景必填 | Access Point ID，非空即启用 AP 挂载 |
+| `vpcMountTarget` | One of this or vsc, or both | VPC mount target domain (used for the tcp link) |
+| `vscMountTarget` | One of this or vpc, or both | VSC mount target domain (used for the vsc link) |
+| `accessPointId` | Required for AP mounts | Access Point ID. A non-empty value enables AP mounting. |
 
-### 鉴权模式识别与校验规则
+### Auth mode detection and validation
 
-驱动不使用 `authType` 参数，而是根据 `nodePublishSecretRef` 引用的 Secret 键集合自动识别模式：
+The driver does not use an `authType` parameter. It infers the mode from the set of keys in the Secret referenced by `nodePublishSecretRef`:
 
-| Secret 内容 | 识别结果 |
+| Secret contents | Detected mode |
 | --- | --- |
-| 未配置 `nodePublishSecretRef` | 无鉴权挂载 |
-| 恰好含 `accessKeyId`、`accessKeySecret` | AK 模式 |
-| 含 `accessKeyId`、`accessKeySecret`、`securityToken`（可选 `expiration`） | STS 模式 |
-| 其它形状（缺键、空值、未知键） | 拒绝挂载（`InvalidArgument`） |
+| No `nodePublishSecretRef` configured | Anonymous mount |
+| Exactly `accessKeyId` and `accessKeySecret` | AK mode |
+| `accessKeyId`, `accessKeySecret`, `securityToken` (optionally `expiration`) | STS mode |
+| Any other shape (missing keys, empty values, unknown keys) | Mount rejected (`InvalidArgument`) |
 
-注意：
+Notes:
 
-- 键集合为严格白名单匹配，拼写错误（如 `security_token`）会被直接拒绝，不会静默降级为 AK 模式或匿名挂载。
-- 配置了 Secret 时 `accessPointId` 必须非空（RAM 鉴权仅对 AP 挂载生效）。
-- 鉴权模式在首次挂载时定格：挂载后若 Secret 形状变化（如 AK 改为三元组），驱动告警并忽略，需重建 Pod 重新挂载生效。
-- 不支持在 PV `mountOptions` 中手工填写 `g_unas_AKFile` / `g_unas_STSFile`，此类选项会被驱动剥离并告警；凭证文件路径由驱动统一管理。
+- Key-set matching is a strict allowlist. A typo (such as `security_token`) is rejected outright rather than silently degrading to AK mode or an anonymous mount.
+- When a Secret is configured, `accessPointId` must be non-empty (RAM auth applies to AP mounts only).
+- The auth mode is fixed at first mount. If the Secret shape changes afterwards (for example AK keys replaced by an STS triple), the driver logs a warning and ignores it; recreate the Pod to remount with the new mode.
+- Writing `g_unas_AKFile` / `g_unas_STSFile` by hand in the PV `mountOptions` is not supported. Such options are stripped by the driver with a warning, since credential file paths are managed centrally by the driver.
 
-## 使用方式
+## Usage
 
-### 用例 1：无鉴权 AP 挂载
+### Example 1: anonymous AP mount
 
 ```yaml
 apiVersion: v1
@@ -108,7 +108,7 @@ spec:
   volumeName: bmcpfs-ap-pv
 ```
 
-驱动生成的挂载命令等价于（tcp 链路）：
+The mount command generated by the driver is equivalent to (tcp link):
 
 ```bash
 mount -t alinas -o efc,protocol=efc,net=tcp,fstype=cpfs \
@@ -116,7 +116,7 @@ mount -t alinas -o efc,protocol=efc,net=tcp,fstype=cpfs \
   cpfs-0123456789-vpc.cn-hangzhou.cpfs.aliyuncs.com:/ <targetPath>
 ```
 
-### 用例 2：RAM 鉴权——静态 AK
+### Example 2: RAM auth with a static AccessKey
 
 ```yaml
 apiVersion: v1
@@ -151,11 +151,11 @@ spec:
       namespace: kube-system
 ```
 
-驱动检测到 Secret 仅含 AK/SK 两键，自动按 AK 模式挂载。
+The driver detects that the Secret holds only the two AK keys and mounts in AK mode automatically.
 
-**注意**：AK 配置不支持热更新。修改 Secret 中的 AK 后，需要重建使用该卷的 Pod 触发重新挂载才能生效。
+**Note**: AK configuration does not support hot reload. After changing the AK in the Secret, recreate the Pods using the volume to trigger a remount.
 
-### 用例 3：RAM 鉴权——STS 轮转
+### Example 3: RAM auth with rotating STS credentials
 
 ```yaml
 apiVersion: v1
@@ -164,11 +164,11 @@ metadata:
   name: bmcpfs-sts-secret
   namespace: kube-system
 type: Opaque
-stringData:               # 由外部系统周期性轮转更新
+stringData:               # rotated periodically by an external system
   accessKeyId: "STS.xxx"
   accessKeySecret: "********"
   securityToken: "********"
-  expiration: "2026-08-10T12:00:00Z"   # 可选，仅用于告警
+  expiration: "2026-08-10T12:00:00Z"   # optional, used for warnings only
 ---
 apiVersion: v1
 kind: PersistentVolume
@@ -192,21 +192,21 @@ spec:
       namespace: kube-system
 ```
 
-驱动检测到 Secret 含 `securityToken`，自动按 STS 模式挂载。
+The driver detects `securityToken` in the Secret and mounts in STS mode automatically.
 
-**STS 轮转说明**：
+**STS rotation notes**:
 
-- 外部系统只需更新 Secret 中的三元组，无需操作节点或 Pod。
-- Secret 中**不需要** md5 字段；驱动写入 STS 配置文件时自动计算 `md5(accessKeyId + accessKeySecret + securityToken)`。
-- 新凭证生效链路：Secret 更新 → kubelet 周期性 republish 带入 → 驱动原子重写 STS 文件 → EFC 下一个 10 分钟周期加载。**端到端生效延迟上限约为 republish 间隔 + 10 分钟**，请保证轮转时新 STS 的剩余有效期充分大于该窗口（建议 ≥ 30 分钟）。
-- 同一 PV 在同一节点上的多个 Pod 共享同一份凭证文件（凭证为 PV 级配置）。
+- The external system only needs to update the credential triple in the Secret; no action on the node or the Pod is required.
+- An md5 field is **not** needed in the Secret. The driver computes `md5(accessKeyId + accessKeySecret + securityToken)` itself when writing the STS credential file.
+- Propagation path for new credentials: Secret update → picked up by the next periodic kubelet republish → driver atomically rewrites the STS file → EFC loads it in the next 10-minute cycle. **End-to-end propagation is bounded by roughly the republish interval plus 10 minutes**, so make sure the new STS credential stays valid well beyond that window when rotating (30 minutes or more is recommended).
+- Pods on the same node sharing one PV also share a single credential file, as credentials are configured per PV.
 
-### 用例 4：单 Pod 挂载同一文件系统的多个 AP
+### Example 4: multiple APs of the same file system in one Pod
 
-为每个 AP 各建一个 PV/PVC（volumeHandle 后缀不同即可），Pod 同时引用：
+Create one PV/PVC pair per AP (only the volumeHandle suffix needs to differ) and reference both from the Pod:
 
 ```yaml
-# PV/PVC 定义同用例 1~3，两个 PV 的 volumeHandle 分别为：
+# PV/PVC definitions are the same as in Examples 1-3, with volumeHandles:
 #   cpfs-0123456789+ap-aaaaaaaa
 #   cpfs-0123456789+ap-bbbbbbbb
 apiVersion: apps/v1
@@ -235,42 +235,42 @@ spec:
           persistentVolumeClaim: {claimName: bmcpfs-ap-b-pvc}
 ```
 
-两个 AP 各自独立挂载、独立鉴权（可引用不同 Secret），互不影响。
+The two APs are mounted and authenticated independently (they may reference different Secrets) and do not affect each other.
 
-## 行为说明与约束
+## Behavior and constraints
 
-### 卸载与 attach 保留行为
+### Unmount and attach retention
 
-同一文件系统的多个 AP/fileset PV 在同一节点上共享一条 CPFS↔VSC attach。为保证多 AP 场景卸载安全，当前版本对 volumeHandle 带 `+` 后缀的卷（AP 卷、fileset 卷）在卸载时**不执行 detach**，而是直接返回错误（`InvalidArgument`：`Volume with suffix is not detachable, please use the skip detach feature`）：
+Multiple AP/fileset PVs of the same file system on one node share a single CPFS↔VSC attach. To keep unmounting safe in multi-AP scenarios, this version **does not detach** volumes whose volumeHandle carries a `+` suffix (AP volumes and fileset volumes). Instead it returns an error directly (`InvalidArgument`: `Volume with suffix is not detachable, please use the skip detach feature`):
 
-- 卸载请求持续失败重试，VolumeAttachment 保留，不会误断同节点其它 AP 的挂载，running pod 不受影响。
-- 如需让 AP/fileset 卷正常完成卸载（Pod 删除、PVC 删除），设置 `SKIP_BMCPFS_DETACH=true`：卸载直接成功、不执行 detach。
-- 文件系统与节点 VSC 之间的 attach 会保留，随 VSC / 节点回收自动清理。
-- 如需提前回收（如触及 VSC attach 数量上限），可在确认该节点无该文件系统任何活跃挂载后，通过 NAS OpenAPI `DetachVscFromFilesystems` 手工 detach。
-- 后续版本计划通过增强的 external-attacher 方案恢复标准的按引用 detach 行为，届时该约束将移除，PV 配置无需变化。
+- Unmount requests keep failing and are retried, the VolumeAttachment is retained, mounts of other APs on the same node are not broken by mistake, and running Pods are unaffected.
+- To let AP/fileset volumes complete unmounting normally (on Pod deletion or PVC deletion), set `SKIP_BMCPFS_DETACH=true`: unmount succeeds immediately without performing a detach.
+- The attach between the file system and the node VSC is retained and cleaned up automatically when the VSC or the node is reclaimed.
+- To reclaim it earlier (for example when hitting the VSC attach quota), confirm the node has no active mount of that file system left, then detach manually via the NAS OpenAPI `DetachVscFromFilesystems`.
+- A later version plans to restore the standard reference-counted detach behavior through an enhanced external-attacher approach. That constraint will then be lifted, with no change required to PV configuration.
 
-### 其它约束
+### Other constraints
 
-| 约束 | 说明 |
+| Constraint | Description |
 | --- | --- |
-| accessModes | AP 卷推荐 `ReadWriteMany` |
-| AK 热更新 | 不支持；修改 AK 需重建 Pod |
-| 凭证文件 | 由驱动管理于节点 `/run/cnfs/efc-credentials/<volumeId>/`（目录 0700、文件 0600，位于 tmpfs），卷卸载后自动清理，请勿手工修改 |
-| Secret 内容 | 驱动不校验凭证与 AP 权限的匹配性；权限不足表现为挂载失败或 IO 报错，请核对 AP 的 RAM 策略 |
+| accessModes | `ReadWriteMany` is recommended for AP volumes |
+| AK hot reload | Not supported; changing the AK requires recreating the Pod |
+| Credential files | Managed by the driver under `/run/cnfs/efc-credentials/<volumeId>/` on the node (directory 0700, files 0600, on tmpfs) and cleaned up automatically after the volume is unmounted. Do not modify them by hand. |
+| Secret contents | The driver does not verify that the credentials match the AP permissions. Insufficient permissions show up as a failed mount or IO errors, so check the AP's RAM policy. |
 
-## 故障排查
+## Troubleshooting
 
-| 现象 | 排查方向 |
+| Symptom | Where to look |
 | --- | --- |
-| 挂载失败，事件含 `InvalidArgument` | 核对 Secret 键集合是否符合 AK / STS 白名单（拼写、多余键、空值）、`accessPointId` 是否配置 |
-| 多 AP 只挂上一个 / 挂错 AP | 检查各 PV 的 volumeHandle 是否唯一（kubelet 按 handle 去重，重复时只会挂其中一个） |
-| 挂载失败，EFC 报鉴权错误 | 确认 fileserver 已配置 `efc_pov_UmmSigningRegion`；核对 AK/STS 是否有效、AP RAM 策略是否授权 |
-| 轮转后新 STS 未生效 | 依次确认：Secret 已更新 → 节点上 `/run/cnfs/efc-credentials/<volumeId>/sts.json` 内容已更新（驱动侧）→ 等待 EFC 10 分钟读取周期（客户端侧）。若文件未更新，检查 CSIDriver 对象是否含 `requiresRepublish: true` |
-| STS 过期导致 IO 失败 | 检查外部轮转系统是否停止更新 Secret；确认轮转周期满足"剩余有效期 ≥ republish 间隔 + 10 分钟"的要求 |
-| 驱动日志 | 节点侧：csi-plugin DaemonSet Pod（bmcpfs 相关日志）；挂载执行侧：alinas mount-proxy 日志 |
+| Mount fails with an `InvalidArgument` event | Check that the Secret key set matches the AK / STS allowlist (spelling, extra keys, empty values) and that `accessPointId` is configured |
+| Only one of several APs is mounted, or the wrong AP is mounted | Check that each PV's volumeHandle is unique (kubelet deduplicates by handle, so duplicates result in only one mount) |
+| Mount fails with an EFC auth error | Confirm the fileserver has `efc_pov_UmmSigningRegion` configured; verify the AK/STS credentials are valid and the AP RAM policy grants access |
+| A new STS credential does not take effect after rotation | Check in order: the Secret is updated → `/run/cnfs/efc-credentials/<volumeId>/sts.json` on the node is updated (driver side) → wait for the EFC 10-minute read cycle (client side). If the file is not updated, check that the CSIDriver object has `requiresRepublish: true` |
+| IO failures caused by an expired STS credential | Check whether the external rotation system stopped updating the Secret; confirm the rotation period satisfies "remaining validity ≥ republish interval + 10 minutes" |
+| Driver logs | Node side: the csi-plugin DaemonSet Pod (bmcpfs-related logs). Mount execution side: the alinas mount-proxy logs. |
 
-验证 STS 文件已更新的快捷方式（节点上执行）：
+Quick way to verify the STS file was updated (run on the node):
 
 ```bash
-ls -l --time-style=full-iso /run/cnfs/efc-credentials/<volumeId>/sts.json   # 看修改时间
+ls -l --time-style=full-iso /run/cnfs/efc-credentials/<volumeId>/sts.json   # check the modification time
 ```

--- a/pkg/bmcpfs/bmcpfs.go
+++ b/pkg/bmcpfs/bmcpfs.go
@@ -38,6 +38,8 @@ const (
 	_networkType    = "networkType"
 	_path           = "path"
 	_mpAutoSwitch   = "mountpointAutoSwitch"
+	// _accessPointID selects a CPFS access point mount; non-empty enables it.
+	_accessPointID = "accessPointId"
 
 	// CommonNodeIDPrefix is the prefix for common node IDs
 	CommonNodeIDPrefix = "common:"

--- a/pkg/bmcpfs/controllerserver.go
+++ b/pkg/bmcpfs/controllerserver.go
@@ -287,6 +287,22 @@ func (cs *controllerServer) ControllerUnpublishVolume(ctx context.Context, req *
 	if !kind.supportsVSC() || cs.skipDetach {
 		return &csi.ControllerUnpublishVolumeResponse{}, nil
 	}
+
+	// Volumes whose handle carries a "+" suffix (access point and fileset
+	// volumes) share a single CPFS<->VSC attach at the filesystem level.
+	// Detaching on any one volume's unpublish would break sibling volumes
+	// still mounted on the node, so their unpublish is refused instead of
+	// detaching: the error keeps the VolumeAttachment in place (the CO
+	// retries later) and the shared attach intact. To unpublish such
+	// volumes, set SKIP_BMCPFS_DETACH=true (checked above); the attach is
+	// then reclaimed with the VSC/node lifecycle or manually via the NAS
+	// OpenAPI. Plain filesystem-level handles keep the standard detach.
+	cpfsID, suffix := parseVolumeHandle(req.VolumeId)
+	if suffix != "" {
+		klog.InfoS("ControllerUnpublishVolume: refuse detach for shared filesystem-level attach", "nodeId", req.NodeId, "volumeId", req.VolumeId)
+		return nil, status.Error(codes.InvalidArgument, "Volume with suffix is not detachable, please use the skip detach feature")
+	}
+
 	vsc, err := cs.vscManager.GetPrimaryVscOf(ctx, instanceID)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "get vsc error: %v", err)
@@ -296,12 +312,11 @@ func (cs *controllerServer) ControllerUnpublishVolume(ctx context.Context, req *
 		return &csi.ControllerUnpublishVolumeResponse{}, nil
 	}
 
-	// If `req.VolumeId` is a combination of `cpfsID` and `fsetID`, Detach will trigger an error.
-	err = cs.attachDetacher.Detach(ctx, req.VolumeId, vsc.VscID)
+	err = cs.attachDetacher.Detach(ctx, cpfsID, vsc.VscID)
 	if err != nil {
 		return nil, status.Error(codes.Internal, err.Error())
 	}
-	klog.InfoS("ControllerUnpublishVolume: detached cpfs from vsc", "node", req.NodeId, "filesystem", req.VolumeId)
+	klog.InfoS("ControllerUnpublishVolume: detached cpfs from vsc", "node", req.NodeId, "filesystem", cpfsID)
 	return &csi.ControllerUnpublishVolumeResponse{}, nil
 }
 

--- a/pkg/bmcpfs/controllerserver_test.go
+++ b/pkg/bmcpfs/controllerserver_test.go
@@ -31,6 +31,8 @@ import (
 	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/bmcpfs/internal"
 	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/utils"
 	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 // TestParseVolumeHandle tests the parseVolumeHandle function with various inputs
@@ -406,4 +408,45 @@ func TestControllerServer_ControllerGetCapabilities(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, resp)
 	assert.NotEmpty(t, resp.Capabilities)
+}
+
+// Suffixed handles (access point and fileset volumes) share a filesystem-level
+// CPFS<->VSC attach, so their unpublish must never detach: it fails with
+// InvalidArgument instead, keeping the VolumeAttachment and the shared attach
+// intact. The controllerServer is left with nil managers on purpose: reaching
+// them would mean the refusal was bypassed, which would panic and fail the test.
+func TestControllerUnpublishVolume_SuffixedHandleRefusesDetach(t *testing.T) {
+	cs := &controllerServer{}
+	tests := []struct {
+		name     string
+		volumeID string
+	}{
+		{name: "access point volume", volumeID: "cpfs-123+ap-abc"},
+		{name: "fileset volume", volumeID: "cpfs-123+fset-456"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := &csi.ControllerUnpublishVolumeRequest{VolumeId: tt.volumeID, NodeId: LingjunNodeIDPrefix + "i-1"}
+			resp, err := cs.ControllerUnpublishVolume(context.Background(), req)
+			assert.Error(t, err)
+			assert.Nil(t, resp)
+			assert.Equal(t, codes.InvalidArgument, status.Code(err))
+		})
+	}
+}
+
+func TestControllerUnpublishVolume_NonVSCNodeSkips(t *testing.T) {
+	cs := &controllerServer{}
+	req := &csi.ControllerUnpublishVolumeRequest{VolumeId: "cpfs-123", NodeId: CommonNodeIDPrefix + "node-1"}
+	resp, err := cs.ControllerUnpublishVolume(context.Background(), req)
+	assert.NoError(t, err)
+	assert.NotNil(t, resp)
+}
+
+func TestControllerUnpublishVolume_SkipDetachFlag(t *testing.T) {
+	cs := &controllerServer{skipDetach: true}
+	req := &csi.ControllerUnpublishVolumeRequest{VolumeId: "cpfs-123", NodeId: LingjunNodeIDPrefix + "i-1"}
+	resp, err := cs.ControllerUnpublishVolume(context.Background(), req)
+	assert.NoError(t, err)
+	assert.NotNil(t, resp)
 }

--- a/pkg/bmcpfs/credentials.go
+++ b/pkg/bmcpfs/credentials.go
@@ -1,0 +1,192 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package bmcpfs
+
+import (
+	"bytes"
+	// md5 is mandated by the EFC STSFile format as a content checksum
+	// (md5 of the concatenated credential triple), not used for security.
+	"crypto/md5"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// Keys accepted in the nodePublishSecretRef secret. The auth mode is derived
+// from the key presence (no authType attribute): AK/SK selects AK mode, AK/SK
+// plus securityToken selects STS mode.
+const (
+	secretKeyAccessKeyID     = "accessKeyId"
+	secretKeyAccessKeySecret = "accessKeySecret"
+	secretKeySecurityToken   = "securityToken"
+)
+
+// Credential files consumed by the EFC client. The directory is shared with
+// the alinas mount-proxy container via the /run/cnfs hostPath, so the paths
+// passed as mount options resolve identically on both sides. EFC re-reads the
+// STS file every 10 minutes to refresh signatures; the AK file is read only
+// at mount time.
+const (
+	defaultCredentialsRoot = "/run/cnfs/efc-credentials"
+	akFileName             = "ak.json"
+	stsFileName            = "sts.json"
+
+	credentialsDirMode  = 0o700
+	credentialsFileMode = 0o600
+)
+
+// authMode is the RAM auth mode of a volume, derived from the secret key set.
+type authMode int
+
+const (
+	authModeNone authMode = iota
+	authModeAK
+	authModeSTS
+)
+
+func (m authMode) String() string {
+	switch m {
+	case authModeAK:
+		return "ak"
+	case authModeSTS:
+		return "ststoken"
+	default:
+		return "none"
+	}
+}
+
+// detectAuthMode classifies the nodePublishSecretRef contents by key
+// presence: no secrets means no auth, a security token selects STS mode,
+// otherwise AK mode. Error messages reference key names only, never values.
+func detectAuthMode(secrets map[string]string) (authMode, error) {
+	if len(secrets) == 0 {
+		return authModeNone, nil
+	}
+	if secrets[secretKeyAccessKeyID] == "" || secrets[secretKeyAccessKeySecret] == "" {
+		return authModeNone, fmt.Errorf("secret keys %q and %q are required", secretKeyAccessKeyID, secretKeyAccessKeySecret)
+	}
+	if secrets[secretKeySecurityToken] != "" {
+		return authModeSTS, nil
+	}
+	return authModeAK, nil
+}
+
+// credentialsDirForVolume returns the per-volume credentials directory,
+// rejecting volume IDs that could escape the root. Volume IDs are opaque
+// user-controlled strings, so they must not contain path separators or
+// traversal sequences.
+func credentialsDirForVolume(root, volumeID string) (string, error) {
+	if volumeID == "" || strings.Contains(volumeID, "/") || strings.Contains(volumeID, "..") {
+		return "", fmt.Errorf("volume ID %q is not a valid credentials directory name", volumeID)
+	}
+	return filepath.Join(root, volumeID), nil
+}
+
+type akCredentials struct {
+	AccessKeyID     string `json:"accessKeyId"`
+	AccessKeySecret string `json:"accessKeySecret"`
+}
+
+type stsCredentials struct {
+	AccessKeyID     string `json:"accessKeyId"`
+	AccessKeySecret string `json:"accessKeySecret"`
+	StsToken        string `json:"stsToken"`
+	MD5             string `json:"md5"`
+}
+
+// writeAKFile persists the static AK credential for the EFC g_unas_AKFile
+// mount option. AK does not support hot update, so callers only invoke this
+// on the initial publish.
+func writeAKFile(dir string, secrets map[string]string) (string, error) {
+	data, err := json.Marshal(akCredentials{
+		AccessKeyID:     secrets[secretKeyAccessKeyID],
+		AccessKeySecret: secrets[secretKeyAccessKeySecret],
+	})
+	if err != nil {
+		return "", fmt.Errorf("marshal AK credentials: %w", err)
+	}
+	if _, err := writeCredentialsFile(dir, akFileName, data); err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, akFileName), nil
+}
+
+// writeSTSFile persists the STS credential triple for the EFC g_unas_STSFile
+// mount option, computing the md5 checksum the EFC client requires
+// (md5 of accessKeyId + accessKeySecret + stsToken concatenated). It reports
+// whether the file content actually changed, so republish-driven rotation can
+// skip no-op rewrites.
+func writeSTSFile(dir string, secrets map[string]string) (path string, changed bool, err error) {
+	ak, sk, token := secrets[secretKeyAccessKeyID], secrets[secretKeyAccessKeySecret], secrets[secretKeySecurityToken]
+	sum := md5.Sum([]byte(ak + sk + token))
+	data, err := json.Marshal(stsCredentials{
+		AccessKeyID:     ak,
+		AccessKeySecret: sk,
+		StsToken:        token,
+		MD5:             fmt.Sprintf("%x", sum),
+	})
+	if err != nil {
+		return "", false, fmt.Errorf("marshal STS credentials: %w", err)
+	}
+	changed, err = writeCredentialsFile(dir, stsFileName, data)
+	if err != nil {
+		return "", false, err
+	}
+	return filepath.Join(dir, stsFileName), changed, nil
+}
+
+// writeCredentialsFile atomically replaces dir/name with data via a temp file
+// and rename, so the EFC client never observes a partially written file. The
+// write is skipped when the content is unchanged. Returns whether the file
+// was (re)written.
+func writeCredentialsFile(dir, name string, data []byte) (bool, error) {
+	if err := os.MkdirAll(dir, credentialsDirMode); err != nil {
+		return false, fmt.Errorf("create credentials dir: %w", err)
+	}
+	path := filepath.Join(dir, name)
+	if old, err := os.ReadFile(path); err == nil && bytes.Equal(old, data) {
+		return false, nil
+	}
+	tmp, err := os.CreateTemp(dir, name+".tmp-*")
+	if err != nil {
+		return false, fmt.Errorf("create temp credentials file: %w", err)
+	}
+	tmpName := tmp.Name()
+	// Best-effort cleanup on any failure path; a no-op once renamed.
+	defer func() { _ = os.Remove(tmpName) }()
+	if err := tmp.Chmod(credentialsFileMode); err != nil {
+		_ = tmp.Close()
+		return false, fmt.Errorf("chmod temp credentials file: %w", err)
+	}
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return false, fmt.Errorf("write temp credentials file: %w", err)
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return false, fmt.Errorf("sync temp credentials file: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return false, fmt.Errorf("close temp credentials file: %w", err)
+	}
+	if err := os.Rename(tmpName, path); err != nil {
+		return false, fmt.Errorf("rename temp credentials file: %w", err)
+	}
+	return true, nil
+}

--- a/pkg/bmcpfs/credentials_test.go
+++ b/pkg/bmcpfs/credentials_test.go
@@ -1,0 +1,186 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package bmcpfs
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDetectAuthMode(t *testing.T) {
+	tests := []struct {
+		name    string
+		secrets map[string]string
+		want    authMode
+		wantErr string
+	}{
+		{name: "nil secrets", secrets: nil, want: authModeNone},
+		{name: "empty secrets", secrets: map[string]string{}, want: authModeNone},
+		{
+			name:    "ak pair",
+			secrets: map[string]string{"accessKeyId": "ak", "accessKeySecret": "sk"},
+			want:    authModeAK,
+		},
+		{
+			name:    "sts triple",
+			secrets: map[string]string{"accessKeyId": "ak", "accessKeySecret": "sk", "securityToken": "tok"},
+			want:    authModeSTS,
+		},
+		{
+			name:    "sts triple with expiration",
+			secrets: map[string]string{"accessKeyId": "ak", "accessKeySecret": "sk", "securityToken": "tok", "expiration": "2026-01-01T00:00:00Z"},
+			want:    authModeSTS,
+		},
+		{
+			name:    "missing access key secret",
+			secrets: map[string]string{"accessKeyId": "ak"},
+			wantErr: "required",
+		},
+		{
+			name:    "empty access key id value",
+			secrets: map[string]string{"accessKeyId": "", "accessKeySecret": "sk"},
+			wantErr: "required",
+		},
+		{
+			name:    "unknown key ignored",
+			secrets: map[string]string{"accessKeyId": "ak", "accessKeySecret": "sk", "security_token": "tok"},
+			want:    authModeAK,
+		},
+		{
+			name:    "expiration without token still AK",
+			secrets: map[string]string{"accessKeyId": "ak", "accessKeySecret": "sk", "expiration": "x"},
+			want:    authModeAK,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := detectAuthMode(tt.secrets)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestCredentialsDirForVolume(t *testing.T) {
+	tests := []struct {
+		name     string
+		volumeID string
+		want     string
+		wantErr  bool
+	}{
+		{name: "plain", volumeID: "cpfs-123", want: "/root/cpfs-123"},
+		{name: "with suffix", volumeID: "cpfs-123+ap-abc", want: "/root/cpfs-123+ap-abc"},
+		{name: "empty rejected", volumeID: "", wantErr: true},
+		{name: "slash rejected", volumeID: "a/b", wantErr: true},
+		{name: "traversal rejected", volumeID: "..", wantErr: true},
+		{name: "embedded traversal rejected", volumeID: "a..b", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := credentialsDirForVolume("/root", tt.volumeID)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestWriteSTSFile(t *testing.T) {
+	dir := t.TempDir()
+	secrets := map[string]string{"accessKeyId": "ak", "accessKeySecret": "sk", "securityToken": "tok"}
+
+	path, changed, err := writeSTSFile(dir, secrets)
+	require.NoError(t, err)
+	assert.True(t, changed)
+	assert.Equal(t, filepath.Join(dir, stsFileName), path)
+
+	raw, err := os.ReadFile(path)
+	require.NoError(t, err)
+	var cred stsCredentials
+	require.NoError(t, json.Unmarshal(raw, &cred))
+	assert.Equal(t, "ak", cred.AccessKeyID)
+	assert.Equal(t, "sk", cred.AccessKeySecret)
+	assert.Equal(t, "tok", cred.StsToken)
+	// md5("aksktok"), i.e. md5 of the concatenated credential triple.
+	assert.Equal(t, "cb42cf60c84c55aff7bbb0c35443c165", cred.MD5)
+
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o600), info.Mode().Perm())
+
+	// Identical content is a no-op.
+	_, changed, err = writeSTSFile(dir, secrets)
+	require.NoError(t, err)
+	assert.False(t, changed)
+
+	// Rotated token rewrites with a new checksum.
+	secrets["securityToken"] = "tok2"
+	_, changed, err = writeSTSFile(dir, secrets)
+	require.NoError(t, err)
+	assert.True(t, changed)
+	raw, err = os.ReadFile(path)
+	require.NoError(t, err)
+	require.NoError(t, json.Unmarshal(raw, &cred))
+	assert.Equal(t, "tok2", cred.StsToken)
+}
+
+func TestWriteAKFile(t *testing.T) {
+	// A non-existent dir so MkdirAll actually creates it and its 0700 mode can
+	// be asserted (a pre-existing t.TempDir would not be re-chmodded).
+	dir := filepath.Join(t.TempDir(), "vol")
+	secrets := map[string]string{"accessKeyId": "ak", "accessKeySecret": "sk"}
+
+	path, err := writeAKFile(dir, secrets)
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join(dir, akFileName), path)
+
+	raw, err := os.ReadFile(path)
+	require.NoError(t, err)
+	var cred akCredentials
+	require.NoError(t, json.Unmarshal(raw, &cred))
+	assert.Equal(t, "ak", cred.AccessKeyID)
+	assert.Equal(t, "sk", cred.AccessKeySecret)
+
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o600), info.Mode().Perm())
+
+	dirInfo, err := os.Stat(dir)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o700), dirInfo.Mode().Perm())
+}
+
+func TestWriteCredentialsFile_CreatesDir(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "nested", "vol")
+	changed, err := writeCredentialsFile(dir, "f.json", []byte("{}"))
+	require.NoError(t, err)
+	assert.True(t, changed)
+	assert.FileExists(t, filepath.Join(dir, "f.json"))
+}

--- a/pkg/bmcpfs/nodeserver.go
+++ b/pkg/bmcpfs/nodeserver.go
@@ -24,6 +24,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"slices"
 	"strings"
 	"sync"
@@ -47,11 +48,23 @@ type nodeServer struct {
 
 	detachDelay      time.Duration
 	unstageStartTime sync.Map // map[volumeID]time.Time
+	// credsRoot is where per-volume EFC credential files live; a field so
+	// tests can redirect it away from the /run/cnfs hostPath.
+	credsRoot string
 }
 
 const (
 	defaultAlinasMountProxySocket = "/run/cnfs/alinas-mounter.sock"
 	metricsPathPrefix             = "/run/cnfs/efc/"
+
+	// EFC mount options managed by this driver. The credential file options
+	// are always generated from the driver-managed credentials directory;
+	// user-supplied ones are rejected.
+	optionKeyAKFile  = "g_unas_AKFile"
+	optionKeySTSFile = "g_unas_STSFile"
+
+	// Access point mount option name (EFC GA naming).
+	apOptionKey = "accesspoint"
 )
 
 func newNodeServer(meta metadata.MetadataProvider) (*nodeServer, error) {
@@ -102,6 +115,7 @@ func newNodeServer(meta metadata.MetadataProvider) (*nodeServer, error) {
 		locks:             utils.NewVolumeLocks(),
 		mounter:           mounter,
 		detachDelay:       detachDelay,
+		credsRoot:         defaultCredentialsRoot,
 	}, nil
 }
 
@@ -126,6 +140,9 @@ func (ns *nodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVol
 
 func (ns *nodeServer) NodeUnstageVolume(ctx context.Context, req *csi.NodeUnstageVolumeRequest) (*csi.NodeUnstageVolumeResponse, error) {
 	if ns.detachDelay == 0 {
+		if err := ns.cleanupCredentials(req.VolumeId); err != nil {
+			return nil, status.Errorf(codes.Internal, "cleanup credentials: %v", err)
+		}
 		return &csi.NodeUnstageVolumeResponse{}, nil
 	}
 	actual, _ := ns.unstageStartTime.LoadOrStore(req.VolumeId, time.Now())
@@ -140,6 +157,12 @@ func (ns *nodeServer) NodeUnstageVolume(ctx context.Context, req *csi.NodeUnstag
 		return nil, status.Errorf(codes.DeadlineExceeded, "delaying detach for possible reuse: %v", ctx.Err())
 	}
 	ns.unstageStartTime.Delete(req.VolumeId)
+	// All publishes for this volume on the node are gone; drop its EFC
+	// credential files. Only done on the success path so a returning pod
+	// within the detach delay keeps its credentials.
+	if err := ns.cleanupCredentials(req.VolumeId); err != nil {
+		return nil, status.Errorf(codes.Internal, "cleanup credentials: %v", err)
+	}
 	return &csi.NodeUnstageVolumeResponse{}, nil
 }
 
@@ -162,6 +185,12 @@ func (ns *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 		}
 	}
 	if !notMounted {
+		// Republish (CSIDriver requiresRepublish): the mount point must not be
+		// touched, only volume contents may change. Refresh the STS credential
+		// file from the latest secrets so external rotation propagates.
+		if err := ns.refreshCredentialsOnRepublish(req); err != nil {
+			return nil, err
+		}
 		klog.InfoS("NodePublishVolume: target path is already mounted", "targetPath", req.TargetPath)
 		return &csi.NodePublishVolumeResponse{}, nil
 	}
@@ -171,6 +200,9 @@ func (ns *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 		networkType  = req.PublishContext[_networkType]
 		source       string
 	)
+	if err := validateCredentialMountOptions(mountOptions); err != nil {
+		return nil, err
+	}
 	switch networkType {
 	case networkTypeVPC:
 		source = req.PublishContext[_vpcMountTarget]
@@ -195,6 +227,12 @@ func (ns *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 		source = fmt.Sprintf("%s:%s", source, path)
 	}
 	klog.InfoS("Mounting mount target", "targetPath", req.TargetPath, "source", source)
+
+	authOptions, err := ns.prepareAuthMountOptions(req)
+	if err != nil {
+		return nil, err
+	}
+	mountOptions = append(mountOptions, authOptions...)
 
 	mountOptions = append(mountOptions, "efc,protocol=efc,fstype=cpfs")
 	err = ns.mounter.Mount(source, req.TargetPath, "alinas", mountOptions)
@@ -256,4 +294,128 @@ func isNas2MountTarget(mountTarget string) bool {
 		return false
 	}
 	return fsid[2:4] == "01"
+}
+
+// validateCredentialMountOptions rejects driver-managed credential file
+// options in user-supplied mount flags. These options are generated from the
+// mounted Secret by this driver; a user-supplied path would redirect the EFC
+// credential source, so the publish fails loudly instead of proceeding.
+func validateCredentialMountOptions(options []string) error {
+	joined := strings.Join(options, ",")
+	if strings.Contains(joined, optionKeyAKFile) || strings.Contains(joined, optionKeySTSFile) {
+		return status.Errorf(codes.InvalidArgument,
+			"mount options must not contain driver-managed credential options %q or %q; remove them from the PV/StorageClass mountOptions",
+			optionKeyAKFile, optionKeySTSFile)
+	}
+	return nil
+}
+
+// prepareAuthMountOptions returns the driver-managed auth options for the
+// publish: the access point option whenever an AP is configured, plus the
+// credential file option for AK/STS modes, writing the credential file first.
+func (ns *nodeServer) prepareAuthMountOptions(req *csi.NodePublishVolumeRequest) ([]string, error) {
+	accessPointID := req.VolumeContext[_accessPointID]
+	mode, err := detectAuthMode(req.Secrets)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid secret for RAM auth: %v", err)
+	}
+	if mode != authModeNone && accessPointID == "" {
+		return nil, status.Errorf(codes.InvalidArgument, "RAM auth requires %q in volume attributes", _accessPointID)
+	}
+
+	var opts []string
+	if accessPointID != "" {
+		opts = append(opts, apOptionKey+"="+accessPointID)
+	}
+	if mode == authModeNone {
+		return opts, nil
+	}
+
+	credsDir, err := credentialsDirForVolume(ns.credsRoot, req.VolumeId)
+	if err != nil {
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
+	var opt string
+	if mode == authModeAK {
+		path, err := writeAKFile(credsDir, req.Secrets)
+		if err != nil {
+			return nil, status.Errorf(codes.Internal, "write AK credentials: %v", err)
+		}
+		opt = optionKeyAKFile + "=" + path
+	} else {
+		path, _, err := writeSTSFile(credsDir, req.Secrets)
+		if err != nil {
+			return nil, status.Errorf(codes.Internal, "write STS credentials: %v", err)
+		}
+		opt = optionKeySTSFile + "=" + path
+	}
+	opts = append(opts, opt)
+	klog.V(2).InfoS("NodePublishVolume: prepared RAM auth credentials", "volumeId", req.VolumeId, "authMode", mode.String(), "accessPoint", accessPointID)
+	return opts, nil
+}
+
+// refreshCredentialsOnRepublish handles the already-mounted NodePublishVolume
+// path. The auth mode was fixed at the first publish and is recorded by which
+// credential file exists; only STS-mode volumes are refreshed, so external
+// Secret rotation propagates without touching the mount. Shape changes of the
+// secret after mount are warned and ignored (a remount is required).
+func (ns *nodeServer) refreshCredentialsOnRepublish(req *csi.NodePublishVolumeRequest) error {
+	credsDir, err := credentialsDirForVolume(ns.credsRoot, req.VolumeId)
+	if err != nil {
+		return status.Error(codes.InvalidArgument, err.Error())
+	}
+	stsExists := fileExists(filepath.Join(credsDir, stsFileName))
+	akExists := fileExists(filepath.Join(credsDir, akFileName))
+
+	mode, err := detectAuthMode(req.Secrets)
+	if err != nil {
+		if stsExists {
+			// The rotation source is broken; surface it so kubelet retries and
+			// operators see the event before the mounted credential expires.
+			return status.Errorf(codes.InvalidArgument, "invalid secret on republish: %v", err)
+		}
+		klog.ErrorS(err, "NodePublishVolume: ignoring invalid secret on republish of a non-STS volume", "volumeId", req.VolumeId)
+		return nil
+	}
+
+	switch {
+	case stsExists:
+		if mode != authModeSTS {
+			klog.InfoS("NodePublishVolume: secret shape changed after mount, ignoring; recreate the pod to apply", "volumeId", req.VolumeId, "mountedMode", authModeSTS.String(), "secretMode", mode.String())
+			return nil
+		}
+		_, changed, err := writeSTSFile(credsDir, req.Secrets)
+		if err != nil {
+			return status.Errorf(codes.Internal, "refresh STS credentials: %v", err)
+		}
+		if changed {
+			klog.V(2).InfoS("NodePublishVolume: refreshed STS credentials", "volumeId", req.VolumeId)
+		}
+	case akExists:
+		if mode != authModeAK {
+			klog.InfoS("NodePublishVolume: secret shape changed after mount, ignoring; recreate the pod to apply", "volumeId", req.VolumeId, "mountedMode", authModeAK.String(), "secretMode", mode.String())
+		}
+		// AK does not support hot update.
+	default:
+		if mode != authModeNone {
+			klog.InfoS("NodePublishVolume: secret appeared after an unauthenticated mount, ignoring; recreate the pod to apply", "volumeId", req.VolumeId, "secretMode", mode.String())
+		}
+	}
+	return nil
+}
+
+// cleanupCredentials removes the per-volume EFC credential directory.
+func (ns *nodeServer) cleanupCredentials(volumeID string) error {
+	credsDir, err := credentialsDirForVolume(ns.credsRoot, volumeID)
+	if err != nil {
+		// Publish would never have created a directory for such an ID.
+		klog.ErrorS(err, "NodeUnstageVolume: skip credentials cleanup", "volumeId", volumeID)
+		return nil
+	}
+	return os.RemoveAll(credsDir)
+}
+
+func fileExists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
 }

--- a/pkg/bmcpfs/nodeserver_test.go
+++ b/pkg/bmcpfs/nodeserver_test.go
@@ -20,6 +20,8 @@ package bmcpfs
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"testing"
 	"testing/synctest"
 	"time"
@@ -28,6 +30,7 @@ import (
 	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/cloud/metadata"
 	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/utils"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	k8smount "k8s.io/mount-utils"
@@ -396,4 +399,198 @@ func TestNodeStageVolume_ResetsDelayForReuse(t *testing.T) {
 		drainUnstage(t, ns, "vol-1")
 		assert.Equal(t, testDetachDelay, time.Since(restart))
 	})
+}
+
+func newTestNodeServer(t *testing.T) *nodeServer {
+	t.Helper()
+	return &nodeServer{
+		mounter:   k8smount.NewFakeMounter(nil),
+		locks:     utils.NewVolumeLocks(),
+		credsRoot: t.TempDir(),
+	}
+}
+
+func publishReq(volumeID, targetPath string, volumeContext map[string]string, secrets map[string]string, mountFlags []string) *csi.NodePublishVolumeRequest {
+	return &csi.NodePublishVolumeRequest{
+		VolumeId:   volumeID,
+		TargetPath: targetPath,
+		VolumeCapability: &csi.VolumeCapability{
+			AccessType: &csi.VolumeCapability_Mount{
+				Mount: &csi.VolumeCapability_MountVolume{MountFlags: mountFlags},
+			},
+		},
+		PublishContext: map[string]string{
+			_networkType:    networkTypeVPC,
+			_vpcMountTarget: "10.0.0.1",
+		},
+		VolumeContext: volumeContext,
+		Secrets:       secrets,
+	}
+}
+
+func TestNodePublishVolume_AccessPoint(t *testing.T) {
+	ns := newTestNodeServer(t)
+	target := filepath.Join(t.TempDir(), "target")
+	req := publishReq("cpfs-1+ap-a", target, map[string]string{_accessPointID: "ap-a"}, nil, nil)
+
+	resp, err := ns.NodePublishVolume(context.Background(), req)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	require.Len(t, ns.mounter.(*k8smount.FakeMounter).MountPoints, 1)
+	opts := ns.mounter.(*k8smount.FakeMounter).MountPoints[0].Opts
+	assert.Contains(t, opts, "accesspoint=ap-a")
+}
+
+func TestNodePublishVolume_AKMode(t *testing.T) {
+	ns := newTestNodeServer(t)
+	target := filepath.Join(t.TempDir(), "target")
+	secrets := map[string]string{"accessKeyId": "ak", "accessKeySecret": "sk"}
+	req := publishReq("cpfs-1+ap-a", target, map[string]string{_accessPointID: "ap-a"}, secrets, nil)
+
+	_, err := ns.NodePublishVolume(context.Background(), req)
+	require.NoError(t, err)
+
+	opts := ns.mounter.(*k8smount.FakeMounter).MountPoints[0].Opts
+	akPath := filepath.Join(ns.credsRoot, "cpfs-1+ap-a", akFileName)
+	assert.Contains(t, opts, optionKeyAKFile+"="+akPath)
+	assert.FileExists(t, akPath)
+}
+
+func TestNodePublishVolume_STSMode(t *testing.T) {
+	ns := newTestNodeServer(t)
+	target := filepath.Join(t.TempDir(), "target")
+	secrets := map[string]string{"accessKeyId": "ak", "accessKeySecret": "sk", "securityToken": "tok"}
+	req := publishReq("cpfs-1+ap-a", target, map[string]string{_accessPointID: "ap-a"}, secrets, nil)
+
+	_, err := ns.NodePublishVolume(context.Background(), req)
+	require.NoError(t, err)
+
+	opts := ns.mounter.(*k8smount.FakeMounter).MountPoints[0].Opts
+	stsPath := filepath.Join(ns.credsRoot, "cpfs-1+ap-a", stsFileName)
+	assert.Contains(t, opts, optionKeySTSFile+"="+stsPath)
+	assert.FileExists(t, stsPath)
+}
+
+func TestNodePublishVolume_SecretWithoutAccessPointRejected(t *testing.T) {
+	ns := newTestNodeServer(t)
+	target := filepath.Join(t.TempDir(), "target")
+	secrets := map[string]string{"accessKeyId": "ak", "accessKeySecret": "sk"}
+	req := publishReq("cpfs-1", target, map[string]string{}, secrets, nil)
+
+	_, err := ns.NodePublishVolume(context.Background(), req)
+	require.Error(t, err)
+	assert.Equal(t, codes.InvalidArgument, status.Code(err))
+}
+
+func TestNodePublishVolume_InvalidSecretShapeRejected(t *testing.T) {
+	ns := newTestNodeServer(t)
+	target := filepath.Join(t.TempDir(), "target")
+	secrets := map[string]string{"accessKeyId": "ak"}
+	req := publishReq("cpfs-1+ap-a", target, map[string]string{_accessPointID: "ap-a"}, secrets, nil)
+
+	_, err := ns.NodePublishVolume(context.Background(), req)
+	require.Error(t, err)
+	assert.Equal(t, codes.InvalidArgument, status.Code(err))
+}
+
+func TestValidateCredentialMountOptions(t *testing.T) {
+	tests := []struct {
+		name    string
+		options []string
+		wantErr bool
+	}{
+		{
+			name:    "no banned keys",
+			options: []string{"net=tcp", "efc"},
+			wantErr: false,
+		},
+		{
+			name:    "rejects standalone AKFile",
+			options: []string{"net=tcp", "g_unas_AKFile=/x"},
+			wantErr: true,
+		},
+		{
+			name:    "rejects STSFile within comma-joined entry",
+			options: []string{"efc,g_unas_STSFile=/y,net=tcp"},
+			wantErr: true,
+		},
+		{
+			name:    "rejects bare key without value",
+			options: []string{"g_unas_AKFile"},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateCredentialMountOptions(tt.options)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Equal(t, codes.InvalidArgument, status.Code(err))
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestNodePublishVolume_RejectsUserCredentialOptions(t *testing.T) {
+	ns := newTestNodeServer(t)
+	target := filepath.Join(t.TempDir(), "target")
+	req := publishReq("cpfs-1", target, map[string]string{}, nil, []string{"net=tcp,g_unas_STSFile=/evil"})
+
+	_, err := ns.NodePublishVolume(context.Background(), req)
+	require.ErrorContains(t, err, "g_unas_STSFile")
+	assert.Equal(t, codes.InvalidArgument, status.Code(err))
+	assert.Empty(t, ns.mounter.(*k8smount.FakeMounter).MountPoints)
+}
+
+func TestNodePublishVolume_RepublishRefreshesSTS(t *testing.T) {
+	ns := newTestNodeServer(t)
+	target := filepath.Join(t.TempDir(), "target")
+	secrets := map[string]string{"accessKeyId": "ak", "accessKeySecret": "sk", "securityToken": "tok1"}
+	req := publishReq("cpfs-1+ap-a", target, map[string]string{_accessPointID: "ap-a"}, secrets, nil)
+
+	_, err := ns.NodePublishVolume(context.Background(), req)
+	require.NoError(t, err)
+
+	// Republish with a rotated token.
+	secrets["securityToken"] = "tok2"
+	_, err = ns.NodePublishVolume(context.Background(), req)
+	require.NoError(t, err)
+
+	stsPath := filepath.Join(ns.credsRoot, "cpfs-1+ap-a", stsFileName)
+	raw, err := os.ReadFile(stsPath)
+	require.NoError(t, err)
+	assert.Contains(t, string(raw), "tok2")
+}
+
+func TestNodePublishVolume_RepublishAKShapeChangeIgnored(t *testing.T) {
+	ns := newTestNodeServer(t)
+	target := filepath.Join(t.TempDir(), "target")
+	akSecrets := map[string]string{"accessKeyId": "ak", "accessKeySecret": "sk"}
+	req := publishReq("cpfs-1+ap-a", target, map[string]string{_accessPointID: "ap-a"}, akSecrets, nil)
+
+	_, err := ns.NodePublishVolume(context.Background(), req)
+	require.NoError(t, err)
+
+	// Republish with an STS-shaped secret: warned and ignored.
+	req.Secrets = map[string]string{"accessKeyId": "ak", "accessKeySecret": "sk", "securityToken": "tok"}
+	_, err = ns.NodePublishVolume(context.Background(), req)
+	require.NoError(t, err)
+
+	credsDir := filepath.Join(ns.credsRoot, "cpfs-1+ap-a")
+	assert.FileExists(t, filepath.Join(credsDir, akFileName))
+	assert.NoFileExists(t, filepath.Join(credsDir, stsFileName))
+}
+
+func TestNodeUnstageVolume_CleansCredentials(t *testing.T) {
+	ns := newTestNodeServer(t)
+	credsDir := filepath.Join(ns.credsRoot, "vol-1")
+	require.NoError(t, os.MkdirAll(credsDir, 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(credsDir, stsFileName), []byte("{}"), 0o600))
+
+	_, err := ns.NodeUnstageVolume(context.Background(), &csi.NodeUnstageVolumeRequest{VolumeId: "vol-1"})
+	require.NoError(t, err)
+	assert.NoDirExists(t, credsDir)
 }


### PR DESCRIPTION
## Summary

Add CPFS Access Point (AP) mounting to the bmcpfs driver, with RAM authentication (static AK and externally rotated STS) delivered through EFC credential files. STS rotation reuses the community `CSIDriver requiresRepublish` mechanism — no in-driver refresh timer.

Design reference: `docs/bmcpfs-access-point.md` (included in this PR).

## Changes

- **AP mount**: `volumeAttributes.accessPointId` enables an access point mount. The EFC option name switches between the test-phase `g_unas_Accesspoint` and the GA `accesspoint` via the `BMCPFS_AP_OPTION_STYLE` env (default `legacy`).
- **Auth mode auto-detection**: derived from the `nodePublishSecretRef` key set with a strict whitelist — AK/SK selects AK mode, the STS triple selects STS mode, any other shape (missing/empty/unknown keys) is rejected so a typo never silently downgrades to AK or an unauthenticated mount. No `authType` attribute.
- **Credential files**: written to `/run/cnfs/efc-credentials/<volumeId>/` (dir 0700, file 0600) via atomic temp-file+rename, shared by all pods mounting the same PV on a node. The STS file carries the `md5(ak+sk+token)` checksum the EFC client requires.
- **STS rotation**: republish only refreshes the STS file; the auth mode is fixed at first mount and post-mount secret shape changes are warned and ignored. EFC re-reads the file every 10 minutes.
- **Cleanup**: `NodeUnstageVolume` removes the per-volume credential directory.
- **Shared-attach detach**: `ControllerUnpublishVolume` skips detach for suffixed handles (AP/fileset volumes sharing a filesystem-level CPFS↔VSC attach) and detaches plain handles by parsed filesystem ID.
- **Helm**: render `requiresRepublish: true` on the bmcpfs CSIDriver by default.

## Test

- Unit tests added for auth-mode detection, credential file writing (content/md5/permissions/atomicity), AP option rendering, mount-option stripping, publish/republish flows, unstage cleanup, and skip-detach behavior.
- `go build`, `go vet`, `gofmt`, and `golangci-lint` all clean.

## Notes

- WIP: pending E2E validation on a test cluster (tcp/vsc AP mount, STS rotation, multi-AP single-pod).
- The short-term detach strategy is skip-detach for shared handles; a standard per-reference detach via an enhanced external-attacher is planned as a follow-up.
