### PR TITLE
feat(oss): support AgenticBucket/BucketSpace mounting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,5 @@ build/Dockerfile
 /alibaba-cloud-csi-driver
 .devcontainer/
 .agents/skills/debug-csi/.local/
+.omo/
 bin

--- a/pkg/mounter/fuse_pod_manager/oss/oss_fuse_pod_manager.go
+++ b/pkg/mounter/fuse_pod_manager/oss/oss_fuse_pod_manager.go
@@ -72,9 +72,15 @@ type Options struct {
 	CNFSName       string
 
 	// oss options
+	// normal bucket
 	Bucket string `json:"bucket"`
-	URL    string `json:"url"`
-	Path   string `json:"path"`
+	// agentic bucket
+	AgenticBucket     string `json:"agenticBucket"`
+	BucketSpace       string `json:"bucketSpace"`
+	BucketSpacePrefix string `json:"bucketSpacePrefix"`
+
+	URL  string `json:"url"`
+	Path string `json:"path"`
 
 	// authorization options
 	// accesskey
@@ -114,4 +120,16 @@ type Options struct {
 
 	// pod template
 	DnsPolicy corev1.DNSPolicy `json:"dnsPolicy"`
+}
+
+// MountBucket returns the effective bucket name for mounting.
+// BucketSpace and Bucket are mutually exclusive (enforced by validation).
+// In AgenticBucket mode, BucketSpace is used; otherwise Bucket.
+// If BucketSpacePrefix was specified, it has already been resolved into BucketSpace
+// by resolveBucketSpacePrefix before this method is called.
+func (o *Options) MountBucket() string {
+	if o.BucketSpace != "" {
+		return o.BucketSpace
+	}
+	return o.Bucket
 }

--- a/pkg/mounter/fuse_pod_manager/oss/ossfs/manager.go
+++ b/pkg/mounter/fuse_pod_manager/oss/ossfs/manager.go
@@ -155,7 +155,7 @@ func (f *fuseOssfs) MakeAuthConfig(o *ossfpm.Options, m metadata.MetadataProvide
 		// fixed credentials
 		if o.AkID != "" && o.AkSecret != "" {
 			authCfg.Secrets = map[string]string{
-				mounterutils.GetPasswdFileName(f.Name()): fmt.Sprintf("%s:%s:%s", o.Bucket, o.AkID, o.AkSecret),
+				mounterutils.GetPasswdFileName(f.Name()): fmt.Sprintf("%s:%s:%s", o.MountBucket(), o.AkID, o.AkSecret),
 			}
 			return authCfg, nil
 		}
@@ -313,6 +313,14 @@ func (f *fuseOssfs) MakeMountOptions(o *ossfpm.Options, m metadata.MetadataProvi
 		}
 		mountOptions = append(mountOptions, "sigv4")
 		mountOptions = append(mountOptions, fmt.Sprintf("region=%s", region))
+	}
+
+	// AgenticBucket / BucketSpace support
+	if o.AgenticBucket != "" {
+		mountOptions = append(mountOptions,
+			"auto_create_bucket",
+			fmt.Sprintf("agentic_bucket=%s", o.AgenticBucket),
+		)
 	}
 
 	authOptions := f.getAuthOptions(o, region)

--- a/pkg/mounter/fuse_pod_manager/oss/ossfs/manager_test.go
+++ b/pkg/mounter/fuse_pod_manager/oss/ossfs/manager_test.go
@@ -744,6 +744,29 @@ func TestMakeMountOptions_ossfs(t *testing.T) {
 			},
 		},
 		{
+			name: "AgenticBucket",
+			setupEnv: func(t *testing.T) {
+				t.Setenv("AGENT_IDENTITY_ENDPOINT", "https://credential-provider.ack-agent-identity.svc:8443/")
+				t.Setenv("AGENT_IDENTITY_TOKEN_DIR", "/var/opt/sandbox/agent-token")
+			},
+			opts: &ossfpm.Options{
+				URL:                     "oss://bucket",
+				AgenticBucket:           "my-agentic-xxx-ab-apsr",
+				BucketSpace:             "my-space-xxx-bs-apsr",
+				AuthType:                ossfpm.AuthTypeAgentIdentity,
+				SandboxId:               "sandbox-123",
+				SandboxCredProviderName: "oss-rw",
+			},
+			expected: []string{
+				"url=oss://bucket",
+				"auto_create_bucket",
+				"agentic_bucket=my-agentic-xxx-ab-apsr",
+				"agent_identity_endpoint=https://credential-provider.ack-agent-identity.svc:8443/",
+				"agent_identity_token_file=/var/opt/sandbox/agent-token/sandbox-123.token",
+				"agent_identity_cred_provider=oss-rw",
+			},
+		},
+		{
 			name: "DefaultAuthType",
 			opts: &ossfpm.Options{
 				URL:       "oss://bucket",

--- a/pkg/mounter/fuse_pod_manager/oss/ossfs2/manager.go
+++ b/pkg/mounter/fuse_pod_manager/oss/ossfs2/manager.go
@@ -141,7 +141,7 @@ func (f *fuseOssfs) MakeAuthConfig(o *ossfpm.Options, m metadata.MetadataProvide
 func (f *fuseOssfs) MakeMountOptions(o *ossfpm.Options, m metadata.MetadataProvider) (mountOptions []string, err error) {
 	mountOptions = append(mountOptions,
 		"oss_endpoint="+o.URL,
-		"oss_bucket="+o.Bucket,
+		"oss_bucket="+o.MountBucket(),
 		"oss_bucket_prefix="+o.Path,
 	)
 
@@ -161,6 +161,14 @@ func (f *fuseOssfs) MakeMountOptions(o *ossfpm.Options, m metadata.MetadataProvi
 			return nil, fmt.Errorf("SigV4 is not supported without region")
 		}
 		mountOptions = append(mountOptions, fmt.Sprintf("oss_region=%s", region))
+	}
+
+	// AgenticBucket / BucketSpace support
+	if o.AgenticBucket != "" {
+		mountOptions = append(mountOptions,
+			"auto_create_bucket=true",
+			fmt.Sprintf("agentic_bucket=%s", o.AgenticBucket),
+		)
 	}
 
 	authOptions := f.getAuthOptions(o, region)

--- a/pkg/mounter/fuse_pod_manager/oss/ossfs2/manager_test.go
+++ b/pkg/mounter/fuse_pod_manager/oss/ossfs2/manager_test.go
@@ -447,6 +447,26 @@ func TestMakeMountOptions_ossfs2(t *testing.T) {
 				"metrics_top=5",
 			},
 		},
+		{
+			name: "agenticBucket with BucketSpace",
+			opts: &ossfpm.Options{
+				AccessKey: ossfpm.AccessKey{
+					AkID:     "test-ak",
+					AkSecret: "test-ak-secret",
+				},
+				AgenticBucket: "my-agentic-xxx-ab-apsr",
+				BucketSpace:   "my-space-xxx-bs-apsr",
+				Path:          "/data",
+				URL:           "oss://test-endpoint/",
+			},
+			expected: []string{
+				"oss_endpoint=oss://test-endpoint/",
+				"oss_bucket=my-space-xxx-bs-apsr",
+				"oss_bucket_prefix=/data",
+				"auto_create_bucket=true",
+				"agentic_bucket=my-agentic-xxx-ab-apsr",
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/oss/coco.go
+++ b/pkg/oss/coco.go
@@ -75,7 +75,7 @@ func (ns *nodeServer) publishDirectVolume(ctx context.Context, req *csi.NodePubl
 		annotationsStr = "{}"
 	}
 	metadata := map[string]string{
-		"bucket":      opt.Bucket,
+		"bucket":      opt.MountBucket(),
 		"url":         opt.URL,
 		"otherOpts":   opt.OtherOpts,
 		"path":        opt.Path,

--- a/pkg/oss/controllerserver.go
+++ b/pkg/oss/controllerserver.go
@@ -77,12 +77,10 @@ func (cs *controllerServer) CreateVolume(ctx context.Context, req *csi.CreateVol
 		return nil, status.Errorf(codes.InvalidArgument, "ReclaimPolicy must be Retain. The current reclaimPolicy is %q", reclaimPolicy)
 	}
 
-	path := parsePathOptions(req.Parameters, req.GetName())
-	volumeContext := req.GetParameters()
-	if volumeContext == nil {
-		volumeContext = map[string]string{}
+	volumeContext, err := buildVolumeContext(req.Parameters, req.GetName())
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
-	volumeContext["path"] = path
 	volSizeBytes := int64(req.GetCapacityRange().GetRequiredBytes())
 	csiTargetVolume := &csi.Volume{
 		VolumeId:      req.Name,
@@ -169,6 +167,10 @@ func (cs *controllerServer) ControllerPublishVolume(ctx context.Context, req *cs
 	// ensure fuseType is not empty
 	opts, err := parseOptions(ctx, cs.cnfsGetter, req.GetVolumeContext(), req.GetSecrets(), []*csi.VolumeCapability{req.GetVolumeCapability()}, req.GetReadonly(), "", false, cs.metadata)
 	if err != nil {
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
+	// resolve agenticBucket/bucketSpace options
+	if err := resolveAgenticBucketOptions(opts, cs.metadata); err != nil {
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
 

--- a/pkg/oss/nodeserver.go
+++ b/pkg/oss/nodeserver.go
@@ -132,6 +132,10 @@ func (ns *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 	if err != nil {
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
+	// resolve agenticBucket/bucketSpace options
+	if err := resolveAgenticBucketOptions(opts, ns.metadata); err != nil {
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
 
 	socketPath := req.PublishContext[mountProxySocket]
 
@@ -180,7 +184,7 @@ func (ns *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 		}
 	}
 
-	mountSource := fmt.Sprintf("%s:%s", opts.Bucket, opts.Path)
+	mountSource := fmt.Sprintf("%s:%s", opts.MountBucket(), opts.Path)
 	needRotateToken := needRotateToken(opts.FuseType, authCfg.Secrets)
 
 	// The mount request must be sent when the target is not mounted, when a token needs
@@ -267,7 +271,7 @@ func (ns *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 		var metricsPath string
 		if notMntTarget {
 			// new mounts
-			metricsPath = utils.WriteMetricsInfo(metricsPathPrefix, req, opts.MetricsTop, opts.FuseType, "oss", opts.Bucket)
+			metricsPath = utils.WriteMetricsInfo(metricsPathPrefix, req, opts.MetricsTop, opts.FuseType, "oss", opts.MountBucket())
 		}
 		err := ossfsMounter.ExtendedMount(ctx, &mounter.MountOperation{
 			Source:      mountSource,
@@ -303,7 +307,7 @@ func (ns *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 		var metricsPath string
 		if notMntAttach {
 			// new mounts
-			metricsPath = utils.WriteSharedMetricsInfo(metricsPathPrefix, req, opts.FuseType, "oss", opts.Bucket, attachPath)
+			metricsPath = utils.WriteSharedMetricsInfo(metricsPathPrefix, req, opts.FuseType, "oss", opts.MountBucket(), attachPath)
 		}
 		err = ossfsMounter.ExtendedMount(ctx, &mounter.MountOperation{
 			Source:      mountSource,

--- a/pkg/oss/utils.go
+++ b/pkg/oss/utils.go
@@ -40,7 +40,8 @@ import (
 	"k8s.io/klog/v2"
 )
 
-// VolumeAs determines the mounting target path in OSS
+// VolumeAs determines the mounting target path in OSS.
+// Values are lowercase because callers normalize input with strings.ToLower before comparison.
 type VolumeAsType string
 
 const (
@@ -50,6 +51,8 @@ const (
 	VolumeAsSharePath VolumeAsType = "sharepath"
 	// VolumeAsSubpath means mount on the subpath of `path` which is automatically generated
 	VolumeAsSubpath VolumeAsType = "subpath"
+	// VolumeAsBucketSpace means use volumeId as BucketSpace name (for AgenticBucket mode)
+	VolumeAsBucketSpace VolumeAsType = "bucketspace"
 )
 
 const (
@@ -57,6 +60,13 @@ const (
 	// For compatibility with standard naming conventions, we also support customers configuring `accessKeyID` and `accessKeySecret`
 	AkID     = "akId"
 	AkSecret = "akSecret"
+)
+
+// volumeAttribute / StorageClass parameter keys for AgenticBucket
+const (
+	volKeyAgenticBucket = "agenticBucket"
+	volKeyBucketSpace   = "bucketSpace"
+	volKeyPath          = "path"
 )
 
 // parseCredentialsFromSecret retrieves credentials from the `Secret` field in request.
@@ -154,9 +164,10 @@ func parseOptions(ctx context.Context, cnfsGetter cnfsv1beta1.CNFSGetter, volOpt
 
 	// credentials
 	accessKey, tokenSecret := parseCredentialsFromSecret(secrets)
+	parsedPath, _ := parseVolumeAsOptions(volOptions, reqName)
 	opts := &ossfpm.Options{
 		UseSharedPath: true,
-		Path:          parsePathOptions(volOptions, reqName),
+		Path:          parsedPath,
 		AccessKey:     accessKey,
 		TokenSecret:   tokenSecret,
 	}
@@ -171,6 +182,12 @@ func parseOptions(ctx context.Context, cnfsGetter cnfsv1beta1.CNFSGetter, volOpt
 		switch key {
 		case "bucket":
 			opts.Bucket = value
+		case "agenticbucket":
+			opts.AgenticBucket = value
+		case "bucketspace":
+			opts.BucketSpace = value
+		case "bucketspaceprefix":
+			opts.BucketSpacePrefix = value
 		case "url":
 			opts.URL = value
 		case "otheropts":
@@ -323,13 +340,18 @@ func parseOptions(ctx context.Context, cnfsGetter cnfsv1beta1.CNFSGetter, volOpt
 	return opts, nil
 }
 
-// parsePathOptions parses path-related options from volOptions.
-// It only handles:
+// parseVolumeAsOptions parses volumeAs-related options from volOptions.
+// It handles:
 // - path: base OSS path (default "/")
 // - volumeAs=subpath: append reqName to base path (for CreateVolume)
-func parsePathOptions(volOptions map[string]string, reqName string) string {
+// - volumeAs=bucketspace: use reqName as BucketSpace name (for CreateVolume)
+//
+// Returns (parsedPath, parsedBucketSpace).
+// parsedBucketSpace is non-empty only when volumeAs=bucketspace.
+func parseVolumeAsOptions(volOptions map[string]string, reqName string) (string, string) {
 	parsedPath := "/"
-	var volumeAsSubpath bool
+	var parsedBucketSpace string
+	var volumeAsSubpath, volumeAsBucketSpace bool
 	for k, v := range volOptions {
 		key := strings.TrimSpace(strings.ToLower(k))
 		value := strings.TrimSpace(v)
@@ -345,15 +367,48 @@ func parsePathOptions(volOptions map[string]string, reqName string) string {
 				// do nothing
 			case VolumeAsSubpath:
 				volumeAsSubpath = true
+			case VolumeAsBucketSpace:
+				volumeAsBucketSpace = true
 			default:
-				klog.Warning(WrapOssError(ParamError, "the value(%q) of %q is invalid, only support direct and subpath", v, k).Error())
+				klog.Warning(WrapOssError(ParamError, "the value(%q) of %q is invalid, only support direct, subpath, and bucketspace", v, k).Error())
 			}
 		}
 	}
 	if volumeAsSubpath {
 		parsedPath = path.Join(parsedPath, reqName)
 	}
-	return parsedPath
+	if volumeAsBucketSpace {
+		parsedBucketSpace = reqName
+	}
+	return parsedPath, parsedBucketSpace
+}
+
+// buildVolumeContext processes StorageClass parameters for CreateVolume:
+//   - resolves path and volumeAs (subpath / bucketspace)
+//   - validates agenticBucket / bucketSpace field consistency
+func buildVolumeContext(params map[string]string, reqName string) (map[string]string, error) {
+	parsedPath, parsedBucketSpace := parseVolumeAsOptions(params, reqName)
+
+	// TODO: volumeAs=bucketspace is not yet supported because the CSI external-provisioner
+	// generates volumeId in UUID format (e.g. pvc-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx)
+	// which exceeds the BucketSpace naming length limit (63 chars) when used as a prefix.
+	// Remove this block once OSS relaxes the naming length constraint, and implement
+	// the prefix-to-full-name resolution here (requires accountId + region).
+	if parsedBucketSpace != "" {
+		return nil, fmt.Errorf("volumeAs=bucketspace is not yet supported for dynamic provisioning (BucketSpace naming length constraint)")
+	}
+
+	// Validate sharepath/subpath mode with agenticBucket
+	if params[volKeyAgenticBucket] != "" && params[volKeyBucketSpace] == "" {
+		return nil, fmt.Errorf("%s is required when %s is specified in StorageClass parameters", volKeyBucketSpace, volKeyAgenticBucket)
+	}
+
+	volumeContext := make(map[string]string, len(params)+2)
+	for k, v := range params {
+		volumeContext[k] = v
+	}
+	volumeContext[volKeyPath] = parsedPath
+	return volumeContext, nil
 }
 
 func setCNFSOptions(ctx context.Context, cnfsGetter cnfsv1beta1.CNFSGetter, opts *ossfpm.Options, m metadata.MetadataProvider) error {
@@ -496,17 +551,70 @@ func setFsType(vc map[string]string) {
 	}
 }
 
+// resolveAgenticBucketOptions validates and resolves AgenticBucket/BucketSpace options.
+// It must be called after parseOptions and before using opts.MountBucket().
+func resolveAgenticBucketOptions(opts *ossfpm.Options, m metadata.MetadataProvider) error {
+	if err := validateAgenticBucketOptions(opts); err != nil {
+		return err
+	}
+	if opts.BucketSpacePrefix != "" {
+		resolved, err := resolveBucketSpacePrefix(opts, m)
+		if err != nil {
+			return err
+		}
+		opts.BucketSpace = resolved
+	}
+	return nil
+}
+
+// validateAgenticBucketOptions validates the mutual exclusion and required-field
+// rules for AgenticBucket/BucketSpace vs Bucket.
+func validateAgenticBucketOptions(opts *ossfpm.Options) error {
+	if (opts.AgenticBucket != "" || opts.BucketSpace != "" || opts.BucketSpacePrefix != "") && opts.Bucket != "" {
+		return WrapOssError(ParamError, "agenticBucket/bucketSpace/bucketSpacePrefix and bucket are mutually exclusive")
+	}
+	if opts.BucketSpace != "" && opts.BucketSpacePrefix != "" {
+		return WrapOssError(ParamError, "bucketSpace and bucketSpacePrefix are mutually exclusive")
+	}
+	if opts.AgenticBucket != "" && opts.BucketSpace == "" && opts.BucketSpacePrefix == "" {
+		return WrapOssError(ParamError, "bucketSpace or bucketSpacePrefix is required when agenticBucket is specified")
+	}
+	if (opts.BucketSpace != "" || opts.BucketSpacePrefix != "") && opts.AgenticBucket == "" {
+		return WrapOssError(ParamError, "agenticBucket is required when bucketSpace or bucketSpacePrefix is specified")
+	}
+	return nil
+}
+
+// resolveBucketSpacePrefix resolves a BucketSpace prefix into the full BucketSpace name
+// by appending accountId, region, and the -bs-apsr suffix.
+// Format: {prefix}-{accountId}-{region}-bs-apsr
+func resolveBucketSpacePrefix(opts *ossfpm.Options, m metadata.MetadataProvider) (string, error) {
+	accountId, err := m.Get(metadata.AccountID)
+	if err != nil || accountId == "" {
+		return "", WrapOssError(ParamError, "cannot resolve bucketSpacePrefix: accountId unavailable (set ALIBABA_CLOUD_ACCOUNT_ID env or ensure IMDS/ack-cluster-profile is accessible)")
+	}
+
+	region := ossfpm.ResolveRegion(opts, m)
+	if region == "" {
+		return "", WrapOssError(ParamError, "cannot resolve bucketSpacePrefix: region unavailable (set region in volumeAttributes or REGION_ID env)")
+	}
+
+	fullName := fmt.Sprintf("%s-%s-%s-bs-apsr", opts.BucketSpacePrefix, accountId, region)
+	klog.V(2).Infof("Resolved bucketSpacePrefix %q to full BucketSpace name %q", opts.BucketSpacePrefix, fullName)
+	return fullName, nil
+}
+
 // Check oss options
 func checkOssOptions(opt *ossfpm.Options, fpm *ossfpm.OSSFusePodManager) error {
 	if fpm == nil {
 		return WrapOssError(ParamError, "Unsupported fuseType %s", opt.FuseType)
 	}
-	// common
-	if opt.URL == "" || opt.Bucket == "" {
+	// common: either Bucket or BucketSpace must be set
+	if opt.URL == "" || opt.MountBucket() == "" {
 		return WrapOssError(ParamError, "Url/Bucket empty")
 	}
 
-	err := validateEndpoint(opt.URL, opt.Bucket)
+	err := validateEndpoint(opt.URL, opt.MountBucket())
 	if err != nil {
 		return WrapOssError(UrlError, "url is invalid, %v", err)
 	}

--- a/pkg/oss/utils_test.go
+++ b/pkg/oss/utils_test.go
@@ -584,12 +584,13 @@ func Test_parseOtherOpts(t *testing.T) {
 	}
 }
 
-func Test_parsePathOptions(t *testing.T) {
+func Test_parseVolumeAsOptions(t *testing.T) {
 	tests := []struct {
-		name       string
-		volOptions map[string]string
-		reqName    string
-		wantPath   string
+		name            string
+		volOptions      map[string]string
+		reqName         string
+		wantPath        string
+		wantBucketSpace string
 	}{
 		{
 			name:       "default path",
@@ -623,12 +624,400 @@ func Test_parsePathOptions(t *testing.T) {
 			reqName:  "",
 			wantPath: "/base",
 		},
+		{
+			name: "bucketspace uses reqName as BucketSpace",
+			volOptions: map[string]string{
+				"volumeAs": "bucketspace",
+			},
+			reqName:         "pvc-12345",
+			wantPath:        "/",
+			wantBucketSpace: "pvc-12345",
+		},
+		{
+			name: "bucketspace with explicit path",
+			volOptions: map[string]string{
+				"path":     "/data",
+				"volumeAs": "bucketspace",
+			},
+			reqName:         "pvc-12345",
+			wantPath:        "/data",
+			wantBucketSpace: "pvc-12345",
+		},
+		{
+			name: "bucketspace with empty reqName",
+			volOptions: map[string]string{
+				"volumeAs": "bucketspace",
+			},
+			reqName:         "",
+			wantPath:        "/",
+			wantBucketSpace: "",
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotPath := parsePathOptions(tt.volOptions, tt.reqName)
+			gotPath, gotBucketSpace := parseVolumeAsOptions(tt.volOptions, tt.reqName)
 			assert.Equal(t, tt.wantPath, gotPath)
+			assert.Equal(t, tt.wantBucketSpace, gotBucketSpace)
+		})
+	}
+}
+
+func Test_validateAgenticBucketOptions(t *testing.T) {
+	tests := []struct {
+		name    string
+		opts    *ossfpm.Options
+		wantErr string
+	}{
+		{
+			name:    "all empty - valid",
+			opts:    &ossfpm.Options{},
+			wantErr: "",
+		},
+		{
+			name: "only bucket - valid",
+			opts: &ossfpm.Options{
+				Bucket: "my-bucket",
+			},
+			wantErr: "",
+		},
+		{
+			name: "agenticBucket + bucketSpace - valid",
+			opts: &ossfpm.Options{
+				AgenticBucket: "my-ab",
+				BucketSpace:   "my-bs",
+			},
+			wantErr: "",
+		},
+		{
+			name: "agenticBucket + bucketSpace + bucket - mutually exclusive",
+			opts: &ossfpm.Options{
+				AgenticBucket: "my-ab",
+				BucketSpace:   "my-bs",
+				Bucket:        "my-bucket",
+			},
+			wantErr: "mutually exclusive",
+		},
+		{
+			name: "bucketSpace + bucket - mutually exclusive",
+			opts: &ossfpm.Options{
+				BucketSpace: "my-bs",
+				Bucket:      "my-bucket",
+			},
+			wantErr: "mutually exclusive",
+		},
+		{
+			name: "agenticBucket without bucketSpace or prefix - invalid",
+			opts: &ossfpm.Options{
+				AgenticBucket: "my-ab",
+			},
+			wantErr: "bucketSpace or bucketSpacePrefix is required",
+		},
+		{
+			name: "bucketSpace without agenticBucket - invalid",
+			opts: &ossfpm.Options{
+				BucketSpace: "my-bs",
+			},
+			wantErr: "agenticBucket is required",
+		},
+		{
+			name: "agenticBucket + bucketSpacePrefix - valid",
+			opts: &ossfpm.Options{
+				AgenticBucket:     "my-ab",
+				BucketSpacePrefix: "sandbox-a",
+			},
+			wantErr: "",
+		},
+		{
+			name: "bucketSpace + bucketSpacePrefix - mutually exclusive",
+			opts: &ossfpm.Options{
+				AgenticBucket:     "my-ab",
+				BucketSpace:       "my-bs",
+				BucketSpacePrefix: "sandbox-a",
+			},
+			wantErr: "mutually exclusive",
+		},
+		{
+			name: "bucketSpacePrefix + bucket - mutually exclusive",
+			opts: &ossfpm.Options{
+				AgenticBucket:     "my-ab",
+				BucketSpacePrefix: "sandbox-a",
+				Bucket:            "my-bucket",
+			},
+			wantErr: "mutually exclusive",
+		},
+		{
+			name: "bucketSpacePrefix without agenticBucket - invalid",
+			opts: &ossfpm.Options{
+				BucketSpacePrefix: "sandbox-a",
+			},
+			wantErr: "agenticBucket is required",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateAgenticBucketOptions(tt.opts)
+			if tt.wantErr == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.ErrorContains(t, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func Test_parseOptions_agenticBucket(t *testing.T) {
+	t.Setenv("ALIBABA_CLOUD_NETWORK_TYPE", "vpc")
+
+	// Test parsing agenticBucket and bucketSpace from volumeAttributes
+	opts := mustParseOptions(t, map[string]string{
+		"agenticBucket": "my-agentic-xxx-ab-apsr",
+		"bucketSpace":   "my-space-xxx-bs-apsr",
+		"url":           "oss-cn-hangzhou-internal.aliyuncs.com",
+		"authType":      "agent-identity",
+	}, nil, nil, false, "", false, m)
+
+	assert.Equal(t, "my-agentic-xxx-ab-apsr", opts.AgenticBucket)
+	assert.Equal(t, "my-space-xxx-bs-apsr", opts.BucketSpace)
+	assert.Equal(t, "", opts.Bucket)
+	assert.Equal(t, "my-space-xxx-bs-apsr", opts.MountBucket())
+
+	// Test mutual exclusion: agenticBucket + bucket should fail at resolve time
+	opts2, err := parseOptions(context.Background(), nil, map[string]string{
+		"agenticBucket": "my-ab",
+		"bucketSpace":   "my-bs",
+		"bucket":        "my-bucket",
+		"url":           "oss-cn-hangzhou-internal.aliyuncs.com",
+	}, nil, nil, false, "", false, m)
+	require.NoError(t, err) // parseOptions itself should succeed
+	err = resolveAgenticBucketOptions(opts2, m)
+	assert.ErrorContains(t, err, "mutually exclusive")
+
+	// Test agenticBucket without bucketSpace or prefix should fail at resolve time
+	opts3, err := parseOptions(context.Background(), nil, map[string]string{
+		"agenticBucket": "my-ab",
+		"url":           "oss-cn-hangzhou-internal.aliyuncs.com",
+	}, nil, nil, false, "", false, m)
+	require.NoError(t, err)
+	err = resolveAgenticBucketOptions(opts3, m)
+	assert.ErrorContains(t, err, "bucketSpace or bucketSpacePrefix is required")
+}
+
+func Test_resolveAgenticBucketOptions_prefix(t *testing.T) {
+	t.Setenv("ALIBABA_CLOUD_NETWORK_TYPE", "vpc")
+	t.Setenv("ALIBABA_CLOUD_ACCOUNT_ID", "1301557714835034")
+	t.Setenv("REGION_ID", "cn-hangzhou")
+
+	prefixMeta := metadata.NewMetadata()
+
+	// bucketSpacePrefix should be resolved into full BucketSpace name
+	opts := mustParseOptions(t, map[string]string{
+		"agenticBucket":     "my-agentic-xxx-ab-apsr",
+		"bucketSpacePrefix": "sandbox-a",
+		"url":               "oss-cn-hangzhou-internal.aliyuncs.com",
+		"authType":          "agent-identity",
+	}, nil, nil, false, "", false, prefixMeta)
+	require.NoError(t, resolveAgenticBucketOptions(opts, prefixMeta))
+
+	assert.Equal(t, "sandbox-a-1301557714835034-cn-hangzhou-bs-apsr", opts.BucketSpace)
+	assert.Equal(t, "sandbox-a-1301557714835034-cn-hangzhou-bs-apsr", opts.MountBucket())
+	assert.Equal(t, "sandbox-a", opts.BucketSpacePrefix)
+
+	// bucketSpacePrefix without accountId env should fail
+	t.Setenv("ALIBABA_CLOUD_ACCOUNT_ID", "")
+	noAccountMeta := metadata.NewMetadata()
+	opts2, err := parseOptions(context.Background(), nil, map[string]string{
+		"agenticBucket":     "my-ab",
+		"bucketSpacePrefix": "sandbox-a",
+		"url":               "oss-cn-hangzhou-internal.aliyuncs.com",
+	}, nil, nil, false, "", false, noAccountMeta)
+	require.NoError(t, err)
+	err = resolveAgenticBucketOptions(opts2, noAccountMeta)
+	assert.ErrorContains(t, err, "accountId unavailable")
+}
+
+// Note: volumeAs=bucketspace is tested in Test_parseVolumeAsOptions (parsing)
+// and Test_buildVolumeContext (CreateVolume validation, currently blocked).
+// It is not tested via parseOptions because parseOptions discards the
+// parsedBucketSpace return value from parseVolumeAsOptions — that value
+// is only used by buildVolumeContext in the CreateVolume path.
+
+func Test_checkOssOptions_agenticBucket(t *testing.T) {
+	// BucketSpace should satisfy the "bucket not empty" check
+	err := checkOssOptions(&ossfpm.Options{
+		URL:           "http://oss-cn-hangzhou-internal.aliyuncs.com",
+		BucketSpace:   "my-bs",
+		AgenticBucket: "my-ab",
+		Path:          "/",
+		FuseType:      "ossfs",
+	}, nil)
+	// fpm is nil, but the error should be about fuseType, not bucket
+	assert.ErrorContains(t, err, "Unsupported fuseType")
+}
+
+func Test_buildVolumeContext(t *testing.T) {
+	tests := []struct {
+		name            string
+		params          map[string]string
+		reqName         string
+		wantPath        string
+		wantBucketSpace string
+		wantErr         string
+	}{
+		{
+			name: "basic sharepath",
+			params: map[string]string{
+				"bucket": "my-bucket",
+				"url":    "oss-cn-hangzhou-internal.aliyuncs.com",
+			},
+			reqName:  "pvc-123",
+			wantPath: "/",
+		},
+		{
+			name: "subpath appends reqName",
+			params: map[string]string{
+				"bucket":   "my-bucket",
+				"path":     "/base",
+				"volumeAs": "subpath",
+			},
+			reqName:  "pvc-123",
+			wantPath: "/base/pvc-123",
+		},
+		{
+			name: "bucketspace is not yet supported",
+			params: map[string]string{
+				"agenticBucket": "my-ab",
+				"volumeAs":      "bucketspace",
+			},
+			reqName: "pvc-123",
+			wantErr: "volumeAs=bucketspace is not yet supported",
+		},
+		{
+			name: "sharepath with agenticBucket requires bucketSpace",
+			params: map[string]string{
+				"agenticBucket": "my-ab",
+			},
+			reqName: "pvc-123",
+			wantErr: "bucketSpace is required",
+		},
+		{
+			name: "sharepath with agenticBucket + bucketSpace is valid",
+			params: map[string]string{
+				"agenticBucket": "my-ab",
+				"bucketSpace":   "my-bs",
+			},
+			reqName:         "pvc-123",
+			wantPath:        "/",
+			wantBucketSpace: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, err := buildVolumeContext(tt.params, tt.reqName)
+			if tt.wantErr != "" {
+				assert.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantPath, ctx[volKeyPath])
+			if tt.wantBucketSpace != "" {
+				assert.Equal(t, tt.wantBucketSpace, ctx[volKeyBucketSpace])
+			}
+		})
+	}
+}
+
+func TestCreateVolume(t *testing.T) {
+	cs := &controllerServer{}
+
+	tests := []struct {
+		name       string
+		req        *csi.CreateVolumeRequest
+		wantErr    bool
+		wantErrMsg string
+		wantPath   string
+		wantBucket string // expected volumeContext["bucketSpace"]
+	}{
+		{
+			name: "basic bucket volume",
+			req: &csi.CreateVolumeRequest{
+				Name: "pvc-123",
+				Parameters: map[string]string{
+					"bucket": "my-bucket",
+					"url":    "oss-cn-hangzhou-internal.aliyuncs.com",
+				},
+				CapacityRange: &csi.CapacityRange{RequiredBytes: 10 * 1024 * 1024 * 1024},
+			},
+			wantPath: "/",
+		},
+		{
+			name: "volumeAs=bucketspace is not yet supported",
+			req: &csi.CreateVolumeRequest{
+				Name: "pvc-456",
+				Parameters: map[string]string{
+					"agenticBucket": "my-ab",
+					"url":           "oss-cn-hangzhou-internal.aliyuncs.com",
+					"volumeAs":      "bucketspace",
+				},
+				CapacityRange: &csi.CapacityRange{RequiredBytes: 50 * 1024 * 1024 * 1024},
+			},
+			wantErr:    true,
+			wantErrMsg: "volumeAs=bucketspace is not yet supported",
+		},
+		{
+			name: "volumeAs=subpath with agenticBucket + bucketSpace",
+			req: &csi.CreateVolumeRequest{
+				Name: "pvc-789",
+				Parameters: map[string]string{
+					"agenticBucket": "my-ab",
+					"bucketSpace":   "my-bs",
+					"path":          "/data",
+					"volumeAs":      "subpath",
+				},
+				CapacityRange: &csi.CapacityRange{RequiredBytes: 10 * 1024 * 1024 * 1024},
+			},
+			wantPath: "/data/pvc-789",
+		},
+		{
+			name: "agenticBucket without bucketSpace fails",
+			req: &csi.CreateVolumeRequest{
+				Name: "pvc-err",
+				Parameters: map[string]string{
+					"agenticBucket": "my-ab",
+				},
+			},
+			wantErr:    true,
+			wantErrMsg: "bucketSpace is required when agenticBucket is specified",
+		},
+		{
+			name: "non-Retain reclaimPolicy fails",
+			req: &csi.CreateVolumeRequest{
+				Name: "pvc-err2",
+				Parameters: map[string]string{
+					"csi.alibabacloud.com/reclaimPolicy": "Delete",
+				},
+			},
+			wantErr:    true,
+			wantErrMsg: "ReclaimPolicy must be Retain",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp, err := cs.CreateVolume(context.Background(), tt.req)
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErrMsg)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.req.Name, resp.Volume.VolumeId)
+			assert.Equal(t, tt.wantPath, resp.Volume.VolumeContext[volKeyPath])
+			if tt.wantBucket != "" {
+				assert.Equal(t, tt.wantBucket, resp.Volume.VolumeContext[volKeyBucketSpace])
+			}
 		})
 	}
 }


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature
#### What this PR does / why we need it:
## feat(oss): support AgenticBucket/BucketSpace mounting

### Summary

Add CSI support for OSS AgenticBucket two-layer architecture, enabling per-sandbox isolated storage via BucketSpace.

### Changes

- **New volumeAttributes**: `agenticBucket`, `bucketSpace`, `bucketSpacePrefix`
- **MountBucket()**: resolves effective bucket (BucketSpace or legacy Bucket)
- **resolveBucketSpacePrefix**: composes full BucketSpace name from prefix + accountId + region
- **Mutual exclusion validation**: agenticBucket/bucketSpace and bucket cannot coexist
- **ossfs/ossfs2 mount options**: `auto_create_bucket` + `agentic_bucket=<name>`
- **volumeAs=bucketspace**: dynamic provisioning blocked (63-char naming limit)

### How it works

1. PV declares `agenticBucket` (the parent AgenticBucket name) and `authType: agent-identity`
2. SandboxClaim dynamically injects `bucketSpace` (full name) or `bucketSpacePrefix` (resolved at mount time)
3. CSI NodePublish passes `auto_create_bucket` and `agentic_bucket=<name>` to ossfs
4. ossfs creates BucketSpace if not exists (PutBucket with AgenticBucketName header), then mounts it

### Testing

E2E verified in sandbox environment (cluster `c8bc78a08095d4d8bbf8e723468333b6a`, cn-shanghai):

| Case | Result |
|------|--------|
| name mode (bucketSpace=full name) | ✅ mount + read/write |
| prefix mode (bucketSpacePrefix) | ✅ resolves full name, mount + read/write |
| prefix + region | ✅ |
| name + subPath | ✅ mount to subdirectory, read/write |
| prefix + subPath | ✅ |
| pause/resume (hibernate/wake) | ✅ data persists |
| remount (BucketSpace already exists) | ✅ |

### Dependencies

- ossfs `ack/feat/agentic-bucket` branch (commit `a1229db`): adds `auto_create_bucket` + `agentic_bucket` mount options
- sandbox-controller `feat/agentic-bucket` branch: enricher injects `bucketSpace`/`bucketSpacePrefix` into volumeAttributes and storage-auth annotation

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
