### PR TITLE
disk: auto-tag and scope LingJun disks by node topology

### DIFF
--- a/pkg/cloud/metadata/eflo.go
+++ b/pkg/cloud/metadata/eflo.go
@@ -10,12 +10,15 @@ import (
 
 type efloNodeMetadata struct {
 	nodeType string // empty string means "no nodeType" (some LingJun instances)
+	hpnZone  string
 }
 
 func (m *efloNodeMetadata) GetAny(_ *mcontext, key MetadataKey) (any, error) {
 	switch key {
 	case LingjunNodeType:
 		return m.nodeType, nil
+	case LingjunHpnZone:
+		return m.hpnZone, nil
 	case machineKind:
 		return MachineKindLingjun, nil
 	}
@@ -32,7 +35,7 @@ func (f *EfloNodeFetcher) ID() fetcherID { return efloNodeFetcherID }
 
 func (f *EfloNodeFetcher) FetchFor(ctx *mcontext, key MetadataKey) (middleware, error) {
 	switch key {
-	case LingjunNodeType, machineKind:
+	case LingjunNodeType, LingjunHpnZone, machineKind:
 	default:
 		return nil, ErrUnknownMetadataKey
 	}
@@ -57,9 +60,10 @@ func (f *EfloNodeFetcher) FetchFor(ctx *mcontext, key MetadataKey) (middleware, 
 		return nil, fmt.Errorf("DescribeNode returned nil response, resp: %v", resp)
 	}
 	nodeType := ptr.Deref(resp.Body.NodeType, "")
-	ctx.logger.V(1).Info("EFLO DescribeNode", "nodeType", nodeType, "requestID", ptr.Deref(resp.Body.RequestId, ""))
+	hpnZone := ptr.Deref(resp.Body.HpnZone, "")
+	ctx.logger.V(1).Info("EFLO DescribeNode", "nodeType", nodeType, "hpnZone", hpnZone, "requestID", ptr.Deref(resp.Body.RequestId, ""))
 
-	return newImmutable(&efloNodeMetadata{nodeType: nodeType}, "EFLO-Node"), nil
+	return newImmutable(&efloNodeMetadata{nodeType: nodeType, hpnZone: hpnZone}, "EFLO-Node"), nil
 }
 
 type efloNodeTypeMetadata struct {

--- a/pkg/cloud/metadata/eflo_test.go
+++ b/pkg/cloud/metadata/eflo_test.go
@@ -95,6 +95,10 @@ func TestGetEFLO(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, MachineKindLingjun, kind)
 
+	hpnZone, err := m.Get(LingjunHpnZone)
+	assert.NoError(t, err)
+	assert.Equal(t, "A4", hpnZone)
+
 	_, err = m.Get(999)
 	assert.ErrorIs(t, err, ErrUnknownMetadataKey)
 }

--- a/pkg/cloud/metadata/k8s.go
+++ b/pkg/cloud/metadata/k8s.go
@@ -53,11 +53,12 @@ var (
 const instanceTypeInfoAnnotation = "alibabacloud.com/instance-type-info"
 
 var MetadataLabels = map[MetadataKey][]string{
-	RegionID:     RegionIDLabels,
-	ZoneID:       ZoneIDLabels,
-	InstanceType: InstanceTypeLabels,
-	InstanceID:   InstanceIdLabels,
-	VmocType:     VmocLabels,
+	RegionID:       RegionIDLabels,
+	ZoneID:         ZoneIDLabels,
+	InstanceType:   InstanceTypeLabels,
+	InstanceID:     InstanceIdLabels,
+	VmocType:       VmocLabels,
+	LingjunHpnZone: {LingjunHpnZoneLabel},
 }
 
 func init() {
@@ -70,6 +71,9 @@ func init() {
 
 // LingjunWorkerLabel is the label key used to identify Lingjun nodes.
 const LingjunWorkerLabel = "alibabacloud.com/lingjun-worker"
+
+// LingjunHpnZoneLabel is the label key carrying a Lingjun node's HPN zone (e.g. "A3").
+const LingjunHpnZoneLabel = "alibabacloud.com/lingjun-hpnzone"
 
 // VirtualKubeletTypeLabel is the label key whose value "virtual-kubelet"
 // identifies virtual-kubelet nodes (no real instance behind them).

--- a/pkg/cloud/metadata/metadata.go
+++ b/pkg/cloud/metadata/metadata.go
@@ -33,6 +33,7 @@ const (
 	RRSATokenFile
 	IsVscEnable
 	LingjunNodeType
+	LingjunHpnZone
 
 	// non-string metadata, not public, can only access with corresponding methods
 	machineKind
@@ -69,6 +70,8 @@ func (k MetadataKey) String() string {
 		return "RRSATokenFile"
 	case LingjunNodeType:
 		return "LingjunNodeType"
+	case LingjunHpnZone:
+		return "LingjunHpnZone"
 	case machineKind:
 		return "MachineKind"
 	case diskQuantity:

--- a/pkg/disk/constants.go
+++ b/pkg/disk/constants.go
@@ -23,6 +23,25 @@ const (
 	BURSTING_ENABLED_KEY   = "burstingEnabled"
 	DISK_TAG_PREFIX        = "diskTags/"
 	REMOVE_DISK_TAG_PREFIX = "-diskTags/"
+	RESTRICT_TO_HPN_ZONE   = "restrictToHpnZone"
+)
+
+// Disk tags with special meaning for LingJun (灵骏) nodes.
+const (
+	// DiskTagCreatedByProduct, when set to DiskTagCreatedByProductEflo at disk
+	// creation (irreversible), makes the disk attachable only to LingJun instances.
+	DiskTagCreatedByProduct     = "createdByProduct"
+	DiskTagCreatedByProductEflo = "eflo"
+	// DiskTagAttachToHpnZone restricts the disk to a single HPN zone (e.g. "A3").
+	DiskTagAttachToHpnZone = "attachToHpnZone"
+)
+
+// RestrictToHpnZone is the value of the restrictToHpnZone SC parameter.
+type RestrictToHpnZone string
+
+const (
+	RestrictToHpnZoneNever  RestrictToHpnZone = "never"
+	RestrictToHpnZoneAlways RestrictToHpnZone = "always"
 )
 
 // keys used in CreateSnapshotRequest.Parameters

--- a/pkg/disk/controllerserver.go
+++ b/pkg/disk/controllerserver.go
@@ -87,6 +87,9 @@ type diskVolumeArgs struct {
 	BurstingEnabled  bool
 	RequestGB        int64
 	DataCache        datacache.Opts
+
+	// ExtraTopology is extra PV nodeAffinity resolved in getDiskVolumeOptions.
+	ExtraTopology map[string]string
 }
 
 var delVolumeSnap sync.Map
@@ -245,7 +248,7 @@ func (cs *controllerServer) CreateVolume(ctx context.Context, req *csi.CreateVol
 
 	klog.Infof("CreateVolume: Successfully created Disk %s: id[%s], zone[%s], disktype[%s], snapshotID[%s]", req.GetName(), diskID, diskVol.ZoneID, attempt, snapshotID)
 
-	tmpVol := volumeCreate(attempt, diskID, utils.Gi2Bytes(int64(diskVol.RequestGB)), volumeContext, diskVol.ZoneID, volumeContentSource(snapshotID))
+	tmpVol := volumeCreate(attempt, diskID, utils.Gi2Bytes(int64(diskVol.RequestGB)), volumeContext, diskVol.ZoneID, diskVol.ExtraTopology, volumeContentSource(snapshotID))
 
 	return &csi.CreateVolumeResponse{Volume: tmpVol}, nil
 }

--- a/pkg/disk/nodeserver.go
+++ b/pkg/disk/nodeserver.go
@@ -953,6 +953,21 @@ func (ns *nodeServer) NodeGetInfo(ctx context.Context, req *csi.NodeGetInfoReque
 		segments[v1.LabelTopologyZone] = zoneID
 	}
 
+	kind, err := m.MachineKind()
+	if err != nil && !errors.Is(err, metadata.ErrUnknownMetadataKey) {
+		return nil, status.Errorf(codes.Internal, "cannot determine current machine kind: %v", err)
+	}
+	if kind == metadata.MachineKindLingjun {
+		hpnZone, err := m.Get(metadata.LingjunHpnZone)
+		if err != nil {
+			return nil, status.Errorf(codes.Internal, "failed to get LingJun HPN zone: %v", err)
+		}
+		segments[metadata.LingjunWorkerLabel] = "true"
+		if hpnZone != "" {
+			segments[metadata.LingjunHpnZoneLabel] = hpnZone
+		}
+	}
+
 	// disable disk allocation when maxVolumesNum is 0
 	// events:
 	// Warning  ProvisioningFailed  diskplugin.csi.alibabacloud.com_csi-provisioner

--- a/pkg/disk/utils.go
+++ b/pkg/disk/utils.go
@@ -40,6 +40,9 @@ import (
 	aliyunep "github.com/aliyun/alibaba-cloud-sdk-go/sdk/endpoints"
 	"github.com/aliyun/alibaba-cloud-sdk-go/services/ecs"
 	"github.com/container-storage-interface/spec/lib/go/csi"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
 	volumeSnapshotV1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
 	snapClientset "github.com/kubernetes-csi/external-snapshotter/client/v8/clientset/versioned"
 	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/cloud"
@@ -303,6 +306,18 @@ func iterZone(requirement *csi.TopologyRequirement) iter.Seq[string] {
 	}
 }
 
+// injectTag sets tags[key]=value unless the user already set the same key to a
+// different value, in which case it errors instead of overwriting — the driver
+// must not adjudicate a user's tag value.
+func injectTag(tags map[string]string, key, value string) error {
+	if existing, ok := tags[key]; ok && existing != value {
+		return status.Errorf(codes.InvalidArgument,
+			"disk tag %q conflicts: driver requires %q but %q was requested", key, value, existing)
+	}
+	tags[key] = value
+	return nil
+}
+
 func parseTags(params map[string]string) (map[string]string, error) {
 	// Note that we cannot assume the iteration order of the map, we must ensure consistent output.
 	seenTags := map[string]string{}
@@ -509,6 +524,71 @@ func getDiskVolumeOptions(
 	diskVolArgs.DiskTags, err = parseTags(volOptions)
 	if err != nil {
 		return nil, err
+	}
+
+	// restrictToHpnZone SC parameter
+	restrictToHpnZone := RestrictToHpnZone(volOptions[RESTRICT_TO_HPN_ZONE])
+	switch restrictToHpnZone {
+	case "", RestrictToHpnZoneNever: // default, nothing to check
+	case RestrictToHpnZoneAlways:
+		// always means the driver owns attachToHpnZone per-disk; a static manual value
+		// contradicts that. Rejected from SC params alone (not gated on the selected
+		// target) so the verdict is deterministic rather than depending on which node a
+		// given PV happens to land on.
+		if _, ok := diskVolArgs.DiskTags[DiskTagAttachToHpnZone]; ok {
+			return nil, status.Errorf(codes.InvalidArgument,
+				"disk tag %q must not be set manually when %s=%s", DiskTagAttachToHpnZone, RESTRICT_TO_HPN_ZONE, RestrictToHpnZoneAlways)
+		}
+	default:
+		return nil, fmt.Errorf("invalid %s %q, must be %q or %q", RESTRICT_TO_HPN_ZONE, restrictToHpnZone, RestrictToHpnZoneNever, RestrictToHpnZoneAlways)
+	}
+
+	access := req.AccessibilityRequirements
+	segs := access.GetPreferred()
+	if segs == nil {
+		segs = access.GetRequisite()
+	}
+
+	eflo := false
+	switch diskVolArgs.DiskTags[DiskTagCreatedByProduct] {
+	case DiskTagCreatedByProductEflo:
+		eflo = true
+	default:
+		if len(segs) > 0 && !slices.ContainsFunc(segs, func(seg *csi.Topology) bool {
+			return seg.GetSegments()[metadata.LingjunWorkerLabel] != "true"
+		}) {
+			// All target is LingJun, WaitForFirstConsumer selected LingJun node, or Immediate but all nodes in cluster is LingJun.
+			// auto-inject createdByProduct:eflo
+			// (create-time only, irreversible — makes the disk attachable and only attachable to LingJun)
+			if err := injectTag(diskVolArgs.DiskTags, DiskTagCreatedByProduct, DiskTagCreatedByProductEflo); err != nil {
+				return nil, err
+			}
+			eflo = true
+		}
+	}
+
+	// A disk carrying createdByProduct:eflo — whether we injected it for a LingJun target
+	// or the user set it manually — attaches ONLY to LingJun.
+	// Derived from the resolved SC tags (not the final DiskTags),
+	// so ExtraTopology stays unaffected by MutableParameters.
+	if eflo {
+		diskVolArgs.ExtraTopology = map[string]string{metadata.LingjunWorkerLabel: "true"}
+		if restrictToHpnZone == RestrictToHpnZoneAlways {
+			var hpnZone string // find first LingJun worker HPN zone
+			for _, seg := range segs {
+				seg := seg.GetSegments()
+				if seg[metadata.LingjunWorkerLabel] == "true" {
+					hpnZone = seg[metadata.LingjunHpnZoneLabel]
+					break
+				}
+			}
+			if hpnZone == "" {
+				return nil, status.Errorf(codes.InvalidArgument,
+					"%s=%s but no HPN zone in topology; use volumeBindingMode: WaitForFirstConsumer", RESTRICT_TO_HPN_ZONE, RestrictToHpnZoneAlways)
+			}
+			diskVolArgs.DiskTags[DiskTagAttachToHpnZone] = hpnZone
+			diskVolArgs.ExtraTopology[metadata.LingjunHpnZoneLabel] = hpnZone
+		}
 	}
 
 	// kmsKeyId
@@ -843,7 +923,7 @@ func patchForNode(node *v1.Node, maxVolumesNum int, diskTypes []string) []byte {
 	return BuildNodePatch(node, maxVolumesNum, diskTypes, NodeDiskCountAnnotation)
 }
 
-func volumeCreate(attempt createAttempt, diskID string, volSizeBytes int64, volumeContext map[string]string, zoneID string, contextSource *csi.VolumeContentSource) *csi.Volume {
+func volumeCreate(attempt createAttempt, diskID string, volSizeBytes int64, volumeContext map[string]string, zoneID string, extraTopology map[string]string, contextSource *csi.VolumeContentSource) *csi.Volume {
 	segments := map[string]string{}
 	cateDesc := AllCategories[attempt.Category]
 	volumeContext[labelAppendPrefix+TopologyRegionKey] = GlobalConfigVar.Region
@@ -856,6 +936,7 @@ func volumeCreate(attempt createAttempt, diskID string, volSizeBytes int64, volu
 	if attempt.Instance != "" {
 		segments[common.ECSInstanceIDTopologyKey] = attempt.Instance
 	}
+	maps.Copy(segments, extraTopology)
 
 	accessibleTopology := []*csi.Topology{{Segments: segments}}
 	if attempt.Category != "" {
@@ -967,7 +1048,7 @@ func staticVolumeCreate(req *csi.CreateVolumeRequest) (*csi.Volume, error) {
 		Category(disk.Category), PerformanceLevel(disk.PerformanceLevel),
 		"", // no instanceID for virtual-kubelet.
 	}
-	return volumeCreate(attempt, diskID, volSizeBytes, volumeContext, disk.ZoneId, volumeContentSource(snapshotID)), nil
+	return volumeCreate(attempt, diskID, volSizeBytes, volumeContext, disk.ZoneId, nil, volumeContentSource(snapshotID)), nil
 }
 
 // updateVolumeContext remove unnecessary volume context

--- a/pkg/disk/utils_test.go
+++ b/pkg/disk/utils_test.go
@@ -19,6 +19,7 @@ import (
 	"cmp"
 	"context"
 	"fmt"
+	"maps"
 	"os"
 	"testing"
 
@@ -516,6 +517,170 @@ func TestGetDiskVolumeOptions(t *testing.T) {
 	assert.Equal(t, map[string]string{"a": "b"}, opts.DiskTags)
 	assert.Equal(t, int64(20), opts.RequestGB)
 	assert.Equal(t, int64(10<<30), opts.DataCache.Size.Value())
+}
+
+func lingjunTopoReq(worker, hpnZone string) *csi.TopologyRequirement {
+	seg := map[string]string{}
+	if worker != "" {
+		seg[metadata.LingjunWorkerLabel] = worker
+	}
+	if hpnZone != "" {
+		seg[metadata.LingjunHpnZoneLabel] = hpnZone
+	}
+	return &csi.TopologyRequirement{Preferred: []*csi.Topology{{Segments: seg}}}
+}
+
+func TestGetDiskVolumeOptionsLingjun(t *testing.T) {
+	cases := []struct {
+		name        string
+		params      map[string]string
+		topo        *csi.TopologyRequirement
+		wantErr     string
+		wantEflo    bool // DiskTags[createdByProduct] == eflo
+		wantHpnZone string
+	}{
+		{
+			name:     "lingjun target auto eflo",
+			topo:     lingjunTopoReq("true", "A3"),
+			wantEflo: true,
+		},
+		{
+			name:        "restrictToHpnZone always with zone",
+			params:      map[string]string{RESTRICT_TO_HPN_ZONE: string(RestrictToHpnZoneAlways)},
+			topo:        lingjunTopoReq("true", "A3"),
+			wantEflo:    true,
+			wantHpnZone: "A3",
+		},
+		{
+			name:    "restrictToHpnZone always lingjun but no hpnzone",
+			params:  map[string]string{RESTRICT_TO_HPN_ZONE: string(RestrictToHpnZoneAlways)},
+			topo:    lingjunTopoReq("true", ""),
+			wantErr: "no HPN zone",
+		},
+		{
+			name:   "restrictToHpnZone always on non-lingjun target no-op",
+			params: map[string]string{RESTRICT_TO_HPN_ZONE: string(RestrictToHpnZoneAlways)},
+			topo:   lingjunTopoReq("", ""),
+		},
+		{
+			name:    "unknown enum value",
+			params:  map[string]string{RESTRICT_TO_HPN_ZONE: "sometimes"},
+			topo:    lingjunTopoReq("true", "A3"),
+			wantErr: "invalid restrictToHpnZone",
+		},
+		{
+			name:     "manual eflo same value deduped",
+			params:   map[string]string{"diskTags/createdByProduct": "eflo"},
+			topo:     lingjunTopoReq("true", "A3"),
+			wantEflo: true,
+		},
+		{
+			name:    "manual eflo different value conflicts",
+			params:  map[string]string{"diskTags/createdByProduct": "other"},
+			topo:    lingjunTopoReq("true", "A3"),
+			wantErr: "conflicts",
+		},
+		{
+			// Core invariant: a manual eflo tag makes the disk LingJun-only even
+			// when the target isn't detected as LingJun, so worker affinity must
+			// still be added (else the Pod may land on ECS and fail to attach).
+			name:     "manual eflo on non-lingjun target still gets worker affinity",
+			params:   map[string]string{"diskTags/createdByProduct": "eflo"},
+			topo:     lingjunTopoReq("", ""),
+			wantEflo: true,
+		},
+		{
+			name:    "manual attachToHpnZone rejected under always",
+			params:  map[string]string{RESTRICT_TO_HPN_ZONE: string(RestrictToHpnZoneAlways), "diskTags/attachToHpnZone": "A3"},
+			topo:    lingjunTopoReq("true", "A3"),
+			wantErr: "must not be set manually",
+		},
+		{
+			// Rejected from SC params alone: deterministic regardless of target.
+			name:    "manual attachToHpnZone rejected under always even on non-lingjun target",
+			params:  map[string]string{RESTRICT_TO_HPN_ZONE: string(RestrictToHpnZoneAlways), "diskTags/attachToHpnZone": "A3"},
+			topo:    lingjunTopoReq("", ""),
+			wantErr: "must not be set manually",
+		},
+		{
+			name:   "manual attachToHpnZone allowed under never",
+			params: map[string]string{"diskTags/attachToHpnZone": "A3"},
+			topo:   lingjunTopoReq("true", "A3"),
+			// eflo still auto-injected on lingjun target
+			wantEflo: true,
+		},
+		{
+			// eflo is auto-injected only when EVERY candidate is LingJun. A single
+			// ECS candidate means the disk could land on ECS, so we must not make it
+			// LingJun-only, even though another candidate is LingJun.
+			name: "any ECS candidate suppresses auto eflo",
+			topo: &csi.TopologyRequirement{Requisite: []*csi.Topology{
+				{Segments: map[string]string{TopologyZoneKey: "cn-beijing-i"}},
+				{Segments: map[string]string{metadata.LingjunWorkerLabel: "true", metadata.LingjunHpnZoneLabel: "A3"}},
+			}},
+			wantEflo: false,
+		},
+		{
+			// All candidates LingJun (e.g. Immediate in an all-LingJun cluster, or
+			// allowedTopologies pinned to worker) → auto eflo.
+			name: "all candidates lingjun auto eflo",
+			topo: &csi.TopologyRequirement{Requisite: []*csi.Topology{
+				{Segments: map[string]string{metadata.LingjunWorkerLabel: "true", metadata.LingjunHpnZoneLabel: "A3"}},
+				{Segments: map[string]string{metadata.LingjunWorkerLabel: "true", metadata.LingjunHpnZoneLabel: "A5"}},
+			}},
+			wantEflo: true,
+		},
+		{
+			// No topology at all (Topology feature off / non-topology caller) must NOT
+			// vacuously auto-inject eflo — that would make a plain ECS disk LingJun-only.
+			name:     "nil topology no auto eflo",
+			topo:     nil,
+			wantEflo: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			params := map[string]string{"zoneId": "cn-beijing-i"}
+			maps.Copy(params, tc.params)
+			req := &csi.CreateVolumeRequest{
+				CapacityRange:             &csi.CapacityRange{RequiredBytes: 20 * GBSIZE},
+				Parameters:                params,
+				AccessibilityRequirements: tc.topo,
+			}
+			opts, err := getDiskVolumeOptions(req, testMetadata, &record.FakeRecorder{}, "")
+			if tc.wantErr != "" {
+				assert.ErrorContains(t, err, tc.wantErr)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, tc.wantEflo, opts.DiskTags[DiskTagCreatedByProduct] == DiskTagCreatedByProductEflo)
+			// Eflo disks always carry the lingjun-worker affinity; non-eflo disks none.
+			assert.Equal(t, tc.wantEflo, opts.ExtraTopology[metadata.LingjunWorkerLabel] == "true")
+			assert.Equal(t, tc.wantHpnZone, opts.ExtraTopology[metadata.LingjunHpnZoneLabel])
+			if tc.wantHpnZone != "" {
+				assert.Equal(t, tc.wantHpnZone, opts.DiskTags[DiskTagAttachToHpnZone])
+			}
+		})
+	}
+}
+
+func TestVolumeCreateExtraTopology(t *testing.T) {
+	attempt := createAttempt{Category: DiskSSD}
+	extra := map[string]string{
+		metadata.LingjunWorkerLabel:  "true",
+		metadata.LingjunHpnZoneLabel: "A3",
+	}
+	vol := volumeCreate(attempt, "d-123", 20*GBSIZE, map[string]string{}, "cn-beijing-i", extra, nil)
+	segs := vol.AccessibleTopology[0].Segments
+	assert.Equal(t, "true", segs[metadata.LingjunWorkerLabel])
+	assert.Equal(t, "A3", segs[metadata.LingjunHpnZoneLabel])
+	assert.Equal(t, "cn-beijing-i", segs[ZonalDiskTopologyKey])
+
+	// nil extra leaves the base segments untouched (regression guard)
+	vol = volumeCreate(attempt, "d-123", 20*GBSIZE, map[string]string{}, "cn-beijing-i", nil, nil)
+	segs = vol.AccessibleTopology[0].Segments
+	_, hasWorker := segs[metadata.LingjunWorkerLabel]
+	assert.False(t, hasWorker)
 }
 
 func TestGetDiskVolumeOptionsWithSnapshotID(t *testing.T) {


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/kind api-change

#### What this PR does / why we need it:

On LingJun (灵骏) nodes a cloud disk must carry the `createdByProduct:eflo` tag at create time (irreversible) to be attachable, and in some HPN zones must be further pinned with `attachToHpnZone:<X>`. An eflo disk attaches ONLY to LingJun instances, so if its PV isn't scheduling-constrained to LingJun, the scheduler can place the pod on an ECS node where attach fails with a confusing platform error. Today users must hand-craft this via static `diskTags`, which cannot express a per-replica HPN zone for a workload spread across zones.

This makes dynamic provisioning on LingJun nodes work out of the box:

- `NodeGetInfo` advertises the existing LingJun node labels (`alibabacloud.com/lingjun-worker`, `alibabacloud.com/lingjun-hpnzone`) as CSI topology segments, so detection and scheduling both flow through native CSI topology (no apiserver Node fetch).
- The provisioner auto-injects `createdByProduct:eflo` when every candidate node is LingJun, and generates a matching PV `nodeAffinity` (`lingjun-worker=true`) so an eflo disk is only scheduled to LingJun nodes. The affinity is derived from the disk's resolved eflo tag (whether auto-injected or set manually by the user), keeping the tag and affinity in lockstep.
- A new `restrictToHpnZone` StorageClass parameter (enum `never`|`always`, default `never`) gates the per-disk `attachToHpnZone:<X>` tag + `lingjun-hpnzone=<X>` affinity, resolved from the selected node's real HPN zone. This is what lets a single shared SC serve a StatefulSet whose replicas land in different HPN zones.

Design: `restrictToHpnZone` is a no-op on non-LingJun targets, so it is safe on a StorageClass shared with ECS nodes; eflo is only auto-injected when ALL candidates are LingJun, so an Immediate mixed cluster that lands disks on ECS is unaffected (no regression). Setting `attachToHpnZone` manually under `always` is rejected deterministically from the SC parameters alone.

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:

Verified end-to-end on a real LingJun cluster: NodeGetInfo topology registration (LingJun-only), `restrictToHpnZone: always` + WFC (PV affinity `worker ∧ hpnzone=A2`, disk tagged `createdByProduct=eflo` + `attachToHpnZone=A2`, attach OK), default `never` (eflo + worker affinity, no hpnzone pin), and the manual-`attachToHpnZone`-under-`always` rejection.

The other half of the invariant — "a non-eflo disk must not attach to LingJun" — is a known pre-existing gap left out of scope (the LingJun `node-role.alibabacloud.com/lingjun:NoSchedule` taint mitigates it); the design doc discusses the tradeoffs.

Requires the CSI role to have `eflo:DescribeNode` / `eflo:DescribeNodeType` for the node plugin's disk-quantity path on LingJun nodes.

#### Does this PR introduce a user-facing change?
```release-note
Disk: on LingJun (灵骏) nodes, dynamically provisioned disks are now automatically tagged `createdByProduct:eflo` and given a matching node affinity so they only schedule to LingJun nodes. A new `restrictToHpnZone` StorageClass parameter (`never`|`always`, default `never`) additionally pins each disk to its target HPN zone via the `attachToHpnZone` tag and a `lingjun-hpnzone` node affinity.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```
