### PR TITLE
helm: keep fuse namespace and SA on uninstall

### DIFF
--- a/deploy/charts/alibaba-cloud-csi-driver/templates/fuse.yaml
+++ b/deploy/charts/alibaba-cloud-csi-driver/templates/fuse.yaml
@@ -5,6 +5,10 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: {{ .Values.deploy.fuseNamespace }}
+  annotations:
+    # Keep on uninstall: this namespace hosts on-demand fuse pods that may be
+    # serving live mounts; deleting it would tear them down.
+    helm.sh/resource-policy: keep
 
 ---
 apiVersion: v1
@@ -12,6 +16,8 @@ kind: ServiceAccount
 metadata:
   name: csi-fuse-ossfs
   namespace: {{ .Values.deploy.fuseNamespace }}
+  annotations:
+    helm.sh/resource-policy: keep
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

The fuse namespace (`ack-csi-fuse` by default) hosts on-demand ossfs fuse pods that back OSS volume mounts for workloads across the cluster. On `helm uninstall`, Helm deletes the namespace, which cascades to those fuse pods and tears down live mounts — even though the CSI driver is only being upgraded/reinstalled. The `csi-fuse-ossfs` ServiceAccount is the RRSA identity those fuse pods run as, so it is on the same critical path.

This annotates both the fuse `Namespace` and the `csi-fuse-ossfs` `ServiceAccount` with `helm.sh/resource-policy: keep` so `helm uninstall` leaves them (and the running fuse pods) in place. The `alicloud-csi-provisioner` Role/RoleBinding are intentionally not annotated: they back no running pod and are cheap to recreate, so normal Helm lifecycle for them is fine.

Note for existing installs: Helm reads `resource-policy` from the release manifest stored at uninstall time, so a release created before this change needs a `helm upgrade` first to persist the annotation.

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
helm: the fuse namespace and its ServiceAccount are now retained on `helm uninstall` to avoid tearing down live OSS mounts served by fuse pods.
```
