### PR TITLE
bmcpfs: skip forcing g_lease_Enable=false for nas2 file systems

### DIFF
--- a/pkg/bmcpfs/nodeserver.go
+++ b/pkg/bmcpfs/nodeserver.go
@@ -131,16 +131,17 @@ func (ns *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 	if source == "" {
 		return nil, status.Error(codes.InvalidArgument, "mountTarget is empty")
 	}
+
+	// Default g_lease_Enable=false unless user explicitly specified it
+	// it turns on write caching for both data and metadata (backend support required), reducing read/write latency for small files. The risk is that it may increase the possibility of abnormal data loss in extreme cases.
+	if !isNas2MountTarget(source) && !hasMountOption(mountOptions, "g_lease_Enable") {
+		mountOptions = append(mountOptions, "g_lease_Enable=false")
+	}
+
 	if path := req.VolumeContext[_path]; path != "" {
 		source = fmt.Sprintf("%s:%s", source, path)
 	}
 	klog.InfoS("Mounting mount target", "targetPath", req.TargetPath, "source", source)
-
-	// Default g_lease_Enable=false unless user explicitly specified it
-	// it turns on write caching for both data and metadata (backend support required), reducing read/write latency for small files. The risk is that it may increase the possibility of abnormal data loss in extreme cases.
-	if !hasMountOption(mountOptions, "g_lease_Enable") {
-		mountOptions = append(mountOptions, "g_lease_Enable=false")
-	}
 
 	mountOptions = append(mountOptions, "efc,protocol=efc,fstype=cpfs")
 	err = ns.mounter.Mount(source, req.TargetPath, "alinas", mountOptions)
@@ -174,4 +175,32 @@ func hasMountOption(options []string, key string) bool {
 	return slices.ContainsFunc(options, func(opt string) bool {
 		return opt == key || strings.HasPrefix(opt, prefix)
 	})
+}
+
+// length of a BMCPFS V2 file system ID: region(2) + arch(2) + random(17)
+const bmcpfsV2FSIDLength = 21
+
+// isNas2MountTarget reports whether the mount target belongs to a nas2 (self-developed new
+// architecture) file system, judged by the arch mark encoded in its file system ID.
+//
+// Supported mount target formats:
+//
+//	cpfs-<fsid>-<suffix>.<region>.cpfs.aliyuncs.com   (unified)
+//	bmcpfs-<fsid>-<suffix>.<region>.cpfs.aliyuncs.com (BMCPFS original)
+//	dcpfs-<fsid>-<suffix>.<region>.cpfs.aliyuncs.com  (dedicated CPFS)
+//
+// The arch mark is the 3rd and 4th character of the file system ID: 00 for GPFS, 01 for nas2.
+// Only BMCPFS V2 file system IDs are 21 characters long, so the others (GPFS 19, NAS 10-16)
+// never match here.
+func isNas2MountTarget(mountTarget string) bool {
+	host, _, _ := strings.Cut(mountTarget, ".")
+	parts := strings.Split(host, "-")
+	if len(parts) < 3 {
+		return false
+	}
+	fsid := parts[1]
+	if len(fsid) != bmcpfsV2FSIDLength {
+		return false
+	}
+	return fsid[2:4] == "01"
 }

--- a/pkg/bmcpfs/nodeserver_test.go
+++ b/pkg/bmcpfs/nodeserver_test.go
@@ -87,26 +87,130 @@ func TestHasMountOption(t *testing.T) {
 	}
 }
 
+func TestIsNas2MountTarget(t *testing.T) {
+	tests := []struct {
+		name        string
+		mountTarget string
+		expected    bool
+	}{
+		// nas2 (arch=01)
+		{
+			name:        "unified format",
+			mountTarget: "cpfs-290113jifsm2nj4dg3rrx-000001.cn-wulanchabu.cpfs.aliyuncs.com",
+			expected:    true,
+		},
+		{
+			name:        "unified format in another region",
+			mountTarget: "cpfs-01010s1l10qqde4ru3krh-000001.cn-shanghai.cpfs.aliyuncs.com",
+			expected:    true,
+		},
+		{
+			name:        "BMCPFS original format",
+			mountTarget: "bmcpfs-37012i9aty1zmsd5a6pvc-009000.cn-wulanchabu.cpfs.aliyuncs.com",
+			expected:    true,
+		},
+		{
+			name:        "BMCPFS original format with non-digit suffix",
+			mountTarget: "bmcpfs-29011rcxzav3omorigltw-abcdefghij.cn-wulanchabu.cpfs.aliyuncs.com",
+			expected:    true,
+		},
+		{
+			name:        "dedicated CPFS format",
+			mountTarget: "dcpfs-03011yei5ad2qec9oa2fm-000001.cn-beijing.cpfs.aliyuncs.com",
+			expected:    true,
+		},
+		// GPFS (arch=00)
+		{
+			name:        "unified format of GPFS",
+			mountTarget: "cpfs-29001f0goqyg298uaugux-000001.cn-wulanchabu.cpfs.aliyuncs.com",
+			expected:    false,
+		},
+		{
+			name:        "BMCPFS original format of GPFS",
+			mountTarget: "bmcpfs-37002i9aty1zmsd5a6pvc-009000.cn-wulanchabu.cpfs.aliyuncs.com",
+			expected:    false,
+		},
+		// file system IDs that are not 21 characters long
+		{
+			name:        "GPFS old format with 19-character file system ID",
+			mountTarget: "cpfs-290zufboa90tn5cikkm-000001.cn-wulanchabu.cpfs.aliyuncs.com",
+			expected:    false,
+		},
+		{
+			name:        "CPFS old format with short file system ID",
+			mountTarget: "cpfs-2901abcdef-000001.cn-wulanchabu.cpfs.aliyuncs.com",
+			expected:    false,
+		},
+		// other domains
+		{
+			name:        "OSS bucket domain",
+			mountTarget: "cyx-wulanchabu-data.oss-cn-wulanchabu-internal.aliyuncs.com",
+			expected:    false,
+		},
+		{
+			name:        "NAS domain",
+			mountTarget: "xxx.nas.aliyuncs.com",
+			expected:    false,
+		},
+		{
+			name:        "host has less than 3 dash-separated parts",
+			mountTarget: "cpfs-290113jifsm2nj4dg3rrx.cn-wulanchabu.cpfs.aliyuncs.com",
+			expected:    false,
+		},
+		{
+			name:        "empty mount target",
+			mountTarget: "",
+			expected:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, isNas2MountTarget(tt.mountTarget))
+		})
+	}
+}
+
 func TestNodePublishVolume_GLeaseEnable(t *testing.T) {
+	const (
+		gpfsMountTarget = "cpfs-29001f0goqyg298uaugux-000001.cn-wulanchabu.cpfs.aliyuncs.com"
+		nas2MountTarget = "cpfs-290113jifsm2nj4dg3rrx-000001.cn-wulanchabu.cpfs.aliyuncs.com"
+	)
 	tests := []struct {
 		name               string
+		mountTarget        string
 		mountFlags         []string
 		expectLeaseInMount bool // whether g_lease_Enable=false appears in mount args
 	}{
 		{
 			name:               "default: g_lease_Enable=false injected",
+			mountTarget:        gpfsMountTarget,
 			mountFlags:         nil,
 			expectLeaseInMount: true,
 		},
 		{
 			name:               "user specified g_lease_Enable=true, not injected",
+			mountTarget:        gpfsMountTarget,
 			mountFlags:         []string{"g_lease_Enable=true"},
 			expectLeaseInMount: false,
 		},
 		{
 			name:               "user specified g_lease_Enable=false explicitly",
+			mountTarget:        gpfsMountTarget,
 			mountFlags:         []string{"g_lease_Enable=false"},
-			expectLeaseInMount: false, // already present, we don't double-add
+			expectLeaseInMount: true, // specified by user, we don't double-add
+		},
+		{
+			name:               "nas2 file system: not injected",
+			mountTarget:        nas2MountTarget,
+			mountFlags:         nil,
+			expectLeaseInMount: false,
+		},
+		{
+			name:               "nas2 file system: user specified g_lease_Enable=false",
+			mountTarget:        nas2MountTarget,
+			mountFlags:         []string{"g_lease_Enable=false"},
+			expectLeaseInMount: true,
 		},
 	}
 
@@ -131,7 +235,7 @@ func TestNodePublishVolume_GLeaseEnable(t *testing.T) {
 				},
 				PublishContext: map[string]string{
 					_networkType:    networkTypeVPC,
-					_vpcMountTarget: "10.0.0.1:/",
+					_vpcMountTarget: tt.mountTarget,
 				},
 				VolumeContext: map[string]string{},
 			}
@@ -144,19 +248,20 @@ func TestNodePublishVolume_GLeaseEnable(t *testing.T) {
 			assert.Len(t, mounter.MountPoints, 1)
 			opts := mounter.MountPoints[0].Opts
 
-			if tt.expectLeaseInMount {
-				assert.Contains(t, opts, "g_lease_Enable=false",
-					"expected g_lease_Enable=false to be injected, got opts: %v", opts)
-			} else {
-				// When user already specified it, we should not find a duplicate
-				count := 0
-				for _, opt := range opts {
-					if opt == "g_lease_Enable=false" || opt == "g_lease_Enable=true" {
-						count++
-					}
+			count := 0
+			for _, opt := range opts {
+				if opt == "g_lease_Enable=false" || opt == "g_lease_Enable=true" {
+					count++
 				}
+			}
+			if tt.expectLeaseInMount {
 				assert.Equal(t, 1, count,
 					"expected exactly one g_lease_Enable option, got opts: %v", opts)
+				assert.Contains(t, opts, "g_lease_Enable=false",
+					"expected g_lease_Enable=false, got opts: %v", opts)
+			} else {
+				assert.NotContains(t, opts, "g_lease_Enable=false",
+					"expected no g_lease_Enable=false, got opts: %v", opts)
 			}
 		})
 	}


### PR DESCRIPTION
nas2 (the self-developed new architecture) file systems are expected to handle the lease properly, so keep their backend default instead of always turning g_lease off. Whether a mount target belongs to nas2 is judged by the arch mark encoded in its file system ID, which is a port of is_nas2_fsid() in the EFC entrypoint.

The mount target domain is now kept in a dedicated variable, because the sub path is appended to source before the check.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
