### PR TITLE
Fix/nas unmount via broker by target

### DIFF
--- a/pkg/mounter/mounter.go
+++ b/pkg/mounter/mounter.go
@@ -19,6 +19,24 @@ type Mounter interface {
 	ExtendedMount(ctx context.Context, op *MountOperation) error
 }
 
+// ProxyUnmounter is implemented by mounters that can unmount through the mount
+// broker (mount-proxy-server) instead of unmounting locally. This is required
+// for NAS AccessPoint mounts: the broker runs in cgroup 0, the only cgroup
+// allowed to reach the mount broker port (tcp 12049) under the csi_mount_proxy
+// nftables rule. A local umount from a container cgroup would be dropped.
+//
+// ExtendedUnmount returns ErrTargetNotManagedByBroker when the broker has no
+// record of target (it was not mounted through the broker), so the caller can
+// fall back to a local unmount.
+type ProxyUnmounter interface {
+	ExtendedUnmount(ctx context.Context, target string) error
+}
+
+// ErrTargetNotManagedByBroker is returned by ProxyUnmounter.ExtendedUnmount when
+// the mount broker reports it does not own the target (proxy.ErrTargetNotManaged)
+// or when the broker predates the unmount RPC. Callers fall back to local unmount.
+var ErrTargetNotManagedByBroker = errors.New("target not managed by mount broker")
+
 type MountOperation struct {
 	Source      string
 	Target      string

--- a/pkg/mounter/proxy/client/client.go
+++ b/pkg/mounter/proxy/client/client.go
@@ -101,6 +101,15 @@ func (c *client) Mount(ctx context.Context, req *proxy.MountRequest) (*proxy.Res
 	})
 }
 
+func (c *client) Unmount(ctx context.Context, req *proxy.UnmountRequest) (*proxy.Response, error) {
+	return c.doRequest(ctx, &proxy.Request{
+		Header: proxy.Header{
+			Method: proxy.Unmount,
+		},
+		Body: req,
+	})
+}
+
 func (c *client) Ping(ctx context.Context) (*proxy.Response, error) {
 	return c.doRequest(ctx, &proxy.Request{
 		Header: proxy.Header{

--- a/pkg/mounter/proxy/protocol.go
+++ b/pkg/mounter/proxy/protocol.go
@@ -17,9 +17,17 @@ const (
 type Method string
 
 const (
-	Mount Method = "mount"
-	Ping  Method = "ping"
+	Mount   Method = "mount"
+	Unmount Method = "unmount"
+	Ping    Method = "ping"
 )
+
+// ErrTargetNotManaged is the error string returned by mount-proxy-server when an
+// Unmount request targets a mount point that was NOT mounted through the broker
+// (i.e. the broker has no record of it). The client uses this sentinel to fall
+// back to a local unmount. It is intentionally matched by string because the
+// error crosses the proxy socket as plain text (see Response.Error).
+const ErrTargetNotManaged = "target not managed by mount broker"
 
 type Header struct {
 	Method Method `json:"method,omitempty"`
@@ -57,6 +65,22 @@ type MountRequest struct {
 	// exposes the merged view at Target.
 	// Forward-compatible: old mount-proxy-server versions ignore unknown JSON fields.
 	Overlay bool `json:"overlay,omitempty"`
+}
+
+// UnmountRequest asks mount-proxy-server to unmount a mount point that was
+// mounted through the broker. It is executed inside the mount-proxy-server
+// process (cgroup 0), so the resulting umount.nfs traffic to the local mount
+// broker (tcp 12049) is not blocked by the csi_mount_proxy nftables rule (which
+// drops dport 12049 from cgroup != 0).
+//
+// Unlike MountRequest, it carries NO fstype: routing is decided by which driver
+// actually owns the target (tracked at mount time), not by the kernel fstype.
+// This avoids the alinas-vs-nfs mismatch (alinas AccessPoint mounts are recorded
+// as fstype "nfs" in the kernel mount table, so fstype-based routing would miss
+// them). If no driver owns the target, the broker returns ErrTargetNotManaged
+// and the caller falls back to a local unmount.
+type UnmountRequest struct {
+	Target string `json:"target,omitempty"`
 }
 
 func ReadMsg(r io.Reader, msg any) error {

--- a/pkg/mounter/proxy/server/alinas/driver.go
+++ b/pkg/mounter/proxy/server/alinas/driver.go
@@ -56,6 +56,29 @@ func (h *Driver) Fstypes() []string {
 	return []string{fstypeAlinas, fstypeCpfsNfs}
 }
 
+var _ server.Unmounter = (*Driver)(nil)
+
+// Unmount implements server.Unmounter. It unmounts target only if this driver
+// mounted it (tracked in h.targets at mount time), returning owned=false when it
+// has no record of target so the dispatcher can fall back appropriately.
+//
+// Routing by ownership (not by kernel fstype) is required: alinas AccessPoint
+// mounts are performed with fstype "alinas" but appear as "nfs" in the kernel
+// mount table, so any fstype-based decision would fail to route their unmounts
+// through the broker and the umount.nfs RPC to tcp 12049 would be dropped by the
+// csi_mount_proxy nftables rule (cgroup != 0), blocking ~3s.
+func (h *Driver) Unmount(target string) (owned bool, err error) {
+	if _, ok := h.targets.Load(target); !ok {
+		return false, nil
+	}
+	// h.Mounter is the extendedMounter, whose Unmount also deletes the target
+	// from h.targets and stops the jwtauth refresher on success.
+	if err := h.Mounter.Unmount(target); err != nil {
+		return true, err
+	}
+	return true, nil
+}
+
 func (h *Driver) Mount(ctx context.Context, req *proxy.MountRequest) error {
 	return h.ExtendedMount(ctx, &mounter.MountOperation{
 		Source:      req.Source,
@@ -101,7 +124,7 @@ func (h *Driver) Terminate() {
 	h.targets.Range(func(key, _ any) bool {
 		target := key.(string)
 		klog.InfoS("Unmounting NAS mount point on exit", "target", target)
-		if err := h.Unmount(target); err != nil {
+		if _, err := h.Unmount(target); err != nil {
 			klog.ErrorS(err, "Failed to unmount NAS mount point", "target", target)
 		}
 		return true

--- a/pkg/mounter/proxy/server/driver.go
+++ b/pkg/mounter/proxy/server/driver.go
@@ -16,6 +16,24 @@ type Driver interface {
 	ApplyOptionDefaults(options []string) []string
 }
 
+// Unmounter is an optional interface a Driver may implement to handle unmount
+// requests coming over the proxy socket. Handling unmount inside the
+// mount-proxy-server process (cgroup 0) is required for NAS AccessPoint mounts,
+// because the csi_mount_proxy nftables rule drops mount-broker traffic (dport
+// 12049) from any process in cgroup != 0.
+//
+// Routing is by ownership, not by fstype: a driver returns owned=true only if it
+// actually mounted this target (tracked at mount time). This avoids relying on
+// the kernel fstype, which for alinas AccessPoint mounts is reported as "nfs"
+// rather than "alinas". When owned=false, the target was not mounted by this
+// driver and the caller should try another driver or fall back to local unmount.
+type Unmounter interface {
+	// Unmount unmounts target if this driver owns it. It returns owned=false
+	// (with nil err) when the driver has no record of target, so the dispatcher
+	// can try other drivers / signal the client to unmount locally.
+	Unmount(target string) (owned bool, err error)
+}
+
 var (
 	fstypeToDriver = map[string]Driver{}
 	nameToDriver   = map[string]Driver{}
@@ -31,4 +49,28 @@ func handleMountRequest(ctx context.Context, req *proxy.MountRequest) error {
 		return fmt.Errorf("fstype %q not supported", req.Fstype)
 	}
 	return h.Mount(ctx, req)
+}
+
+// handleUnmountRequest routes an unmount to whichever registered driver owns the
+// target (tracked at mount time). It does not use fstype. If no driver owns the
+// target, it returns an error whose message is proxy.ErrTargetNotManaged, which
+// the client detects to fall back to a local unmount.
+func handleUnmountRequest(_ context.Context, req *proxy.UnmountRequest) error {
+	if req.Target == "" {
+		return fmt.Errorf("empty unmount target")
+	}
+	for _, d := range nameToDriver {
+		u, ok := d.(Unmounter)
+		if !ok {
+			continue
+		}
+		owned, err := u.Unmount(req.Target)
+		if err != nil {
+			return fmt.Errorf("driver %q unmount %q: %w", d.Name(), req.Target, err)
+		}
+		if owned {
+			return nil
+		}
+	}
+	return fmt.Errorf("%s: %s", proxy.ErrTargetNotManaged, req.Target)
 }

--- a/pkg/mounter/proxy/server/handler.go
+++ b/pkg/mounter/proxy/server/handler.go
@@ -100,6 +100,20 @@ func handle(ctx context.Context, req *rawRequest) proxy.Response {
 				Error: err.Error(),
 			}
 		}
+	case proxy.Unmount:
+		var unmountReq proxy.UnmountRequest
+		err := json.Unmarshal(req.Body, &unmountReq)
+		if err != nil {
+			return proxy.Response{
+				Error: err.Error(),
+			}
+		}
+		err = handleUnmountRequest(ctx, &unmountReq)
+		if err != nil {
+			return proxy.Response{
+				Error: err.Error(),
+			}
+		}
 	case proxy.Ping:
 		return proxy.Response{}
 	default:

--- a/pkg/mounter/proxy/server/unmount_test.go
+++ b/pkg/mounter/proxy/server/unmount_test.go
@@ -1,0 +1,122 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/mounter/proxy"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeUnmountDriver is a minimal Driver that optionally implements Unmounter.
+type fakeUnmountDriver struct {
+	name      string
+	owns      map[string]bool // targets this driver claims to own
+	unmounted []string
+	err       error
+}
+
+func (d *fakeUnmountDriver) Name() string                                     { return d.name }
+func (d *fakeUnmountDriver) Fstypes() []string                                { return nil }
+func (d *fakeUnmountDriver) Init()                                            {}
+func (d *fakeUnmountDriver) Terminate()                                       {}
+func (d *fakeUnmountDriver) Mount(context.Context, *proxy.MountRequest) error { return nil }
+func (d *fakeUnmountDriver) ApplyOptionDefaults(o []string) []string          { return o }
+
+func (d *fakeUnmountDriver) Unmount(target string) (bool, error) {
+	if d.err != nil {
+		return d.owns[target], d.err
+	}
+	if !d.owns[target] {
+		return false, nil
+	}
+	d.unmounted = append(d.unmounted, target)
+	return true, nil
+}
+
+// withRegisteredDriver registers d in nameToDriver and restores on cleanup.
+func withRegisteredDriver(t *testing.T, d Driver) {
+	t.Helper()
+	name := d.Name()
+	prev, existed := nameToDriver[name]
+	nameToDriver[name] = d
+	t.Cleanup(func() {
+		if existed {
+			nameToDriver[name] = prev
+		} else {
+			delete(nameToDriver, name)
+		}
+	})
+}
+
+func TestHandleUnmount_RoutesToOwningDriver(t *testing.T) {
+	d := &fakeUnmountDriver{name: "fake-owner", owns: map[string]bool{"/mnt/x": true}}
+	withRegisteredDriver(t, d)
+
+	err := handleUnmountRequest(context.Background(), &proxy.UnmountRequest{Target: "/mnt/x"})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"/mnt/x"}, d.unmounted)
+}
+
+func TestHandleUnmount_NotOwned_ReturnsSentinel(t *testing.T) {
+	d := &fakeUnmountDriver{name: "fake-owner", owns: map[string]bool{}}
+	withRegisteredDriver(t, d)
+
+	err := handleUnmountRequest(context.Background(), &proxy.UnmountRequest{Target: "/mnt/unknown"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), proxy.ErrTargetNotManaged)
+	assert.Empty(t, d.unmounted)
+}
+
+func TestHandleUnmount_EmptyTarget(t *testing.T) {
+	err := handleUnmountRequest(context.Background(), &proxy.UnmountRequest{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "empty unmount target")
+}
+
+func TestHandleUnmount_DriverError(t *testing.T) {
+	d := &fakeUnmountDriver{name: "fake-owner", owns: map[string]bool{"/mnt/x": true}, err: errors.New("boom")}
+	withRegisteredDriver(t, d)
+
+	err := handleUnmountRequest(context.Background(), &proxy.UnmountRequest{Target: "/mnt/x"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "boom")
+}
+
+func TestHandleUnmount_DriverWithoutUnmounterIsSkipped(t *testing.T) {
+	// A driver that does not implement Unmounter must be skipped, not panic.
+	withRegisteredDriver(t, &basicDriver{name: "no-unmounter"})
+
+	err := handleUnmountRequest(context.Background(), &proxy.UnmountRequest{Target: "/mnt/x"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), proxy.ErrTargetNotManaged)
+}
+
+func TestHandleUnmountViaHandle_BadBody(t *testing.T) {
+	resp := handle(context.Background(), &rawRequest{
+		Header: proxy.Header{Method: proxy.Unmount},
+		Body:   json.RawMessage(`{bad`),
+	})
+	assert.NotEmpty(t, resp.Error)
+}
+
+func TestHandleUnmountViaHandle_EmptyTarget(t *testing.T) {
+	resp := handle(context.Background(), &rawRequest{
+		Header: proxy.Header{Method: proxy.Unmount},
+		Body:   json.RawMessage(`{}`),
+	})
+	assert.Contains(t, resp.Error, "empty unmount target")
+}
+
+// basicDriver implements Driver but NOT Unmounter.
+type basicDriver struct{ name string }
+
+func (d *basicDriver) Name() string                                     { return d.name }
+func (d *basicDriver) Fstypes() []string                                { return nil }
+func (d *basicDriver) Init()                                            {}
+func (d *basicDriver) Terminate()                                       {}
+func (d *basicDriver) Mount(context.Context, *proxy.MountRequest) error { return nil }
+func (d *basicDriver) ApplyOptionDefaults(o []string) []string          { return o }

--- a/pkg/mounter/proxy_mounter.go
+++ b/pkg/mounter/proxy_mounter.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/mounter/proxy"
 	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/mounter/proxy/client"
@@ -15,7 +16,10 @@ type ProxyMounter struct {
 	mountutils.Interface
 }
 
-var _ Mounter = &ProxyMounter{}
+var (
+	_ Mounter        = &ProxyMounter{}
+	_ ProxyUnmounter = &ProxyMounter{}
+)
 
 func NewProxyMounter(socketPath string, inner mountutils.Interface) Mounter {
 	return &ProxyMounter{
@@ -63,4 +67,35 @@ func (m *ProxyMounter) Mount(source string, target string, fstype string, option
 		FsType:  fstype,
 		Options: options,
 	})
+}
+
+// ExtendedUnmount unmounts target through the mount broker (mount-proxy-server),
+// so the umount runs in the daemon's cgroup 0. This is required for NAS
+// AccessPoint mounts: the csi_mount_proxy nftables rule drops mount-broker
+// traffic (tcp dport 12049) from any process in cgroup != 0, so a local
+// umount.nfs issued from a container cgroup would have its RPC to the broker
+// silently dropped (~3s timeout per attempt).
+//
+// The broker decides ownership by target (tracked at mount time), not by fstype.
+// If the broker has no record of target (proxy.ErrTargetNotManaged) or predates
+// the unmount RPC ("invalid method"), ExtendedUnmount returns
+// ErrTargetNotManagedByBroker so the caller can fall back to a local unmount.
+func (m *ProxyMounter) ExtendedUnmount(ctx context.Context, target string) error {
+	dclient := client.NewClient(m.socketPath)
+	resp, err := dclient.Unmount(ctx, &proxy.UnmountRequest{Target: target})
+	if err != nil {
+		return fmt.Errorf("call mounter daemon: %w", err)
+	}
+	if err := resp.ToError(); err != nil {
+		// Old mount-proxy-server that predates the unmount RPC replies
+		// "invalid method"; brokers that do not own the target reply
+		// proxy.ErrTargetNotManaged. In both cases there is nothing for the
+		// broker to unmount, so let the caller fall back to a local unmount.
+		if strings.Contains(err.Error(), "invalid method") ||
+			strings.Contains(err.Error(), proxy.ErrTargetNotManaged) {
+			return ErrTargetNotManagedByBroker
+		}
+		return fmt.Errorf("failed to unmount via mount broker: %w", err)
+	}
+	return nil
 }

--- a/pkg/nas/mounter.go
+++ b/pkg/nas/mounter.go
@@ -84,8 +84,13 @@ func (m *NasMounter) unmount(target string, local func() error) error {
 		// Not a broker-owned mount (plain NFS, or broker too old): unmount locally.
 		return local()
 	default:
-		logger.Error(err, "failed to unmount via mount broker")
-		return err
+		// Broker is unreachable or returned an unexpected error. Do not fail the
+		// unmount: fall back to a local unmount so unmounting never becomes
+		// strictly dependent on broker availability. For broker-owned mounts this
+		// local umount may hit the ~3s utab-fallback path, but that is strictly
+		// better than failing NodeUnpublishVolume.
+		logger.Error(err, "unmount via mount broker failed, falling back to local unmount")
+		return local()
 	}
 }
 

--- a/pkg/nas/mounter.go
+++ b/pkg/nas/mounter.go
@@ -4,6 +4,8 @@ package nas
 
 import (
 	"context"
+	"errors"
+	"time"
 
 	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/mounter"
 	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/mounter/interceptors"
@@ -37,6 +39,54 @@ func (m *NasMounter) ExtendedMount(ctx context.Context, op *mounter.MountOperati
 		logger.Info("mounted successfully")
 	}
 	return err
+}
+
+// Unmount routes the unmount through the mount broker when the broker owns the
+// target (i.e. it was mounted through the broker), and unmounts locally
+// otherwise. Ownership is decided by the broker per target, NOT by the kernel
+// fstype: alinas AccessPoint mounts are performed as fstype "alinas" but show up
+// as "nfs" in the kernel mount table, so an fstype-based decision would route
+// their unmounts locally and the umount.nfs RPC to tcp 12049 would be dropped by
+// the csi_mount_proxy nftables rule (cgroup != 0), blocking ~3s.
+func (m *NasMounter) Unmount(target string) error {
+	return m.unmount(target, func() error { return m.Interface.Unmount(target) })
+}
+
+// UnmountWithForce is called by mount-utils CleanupMountWithForce. NasMounter
+// satisfies mountutils.MounterForceUnmounter through its embedded Interface, so
+// this override is required to keep broker-owned unmounts on the broker path;
+// otherwise the forced local umount would still be dropped by the nftables rule.
+func (m *NasMounter) UnmountWithForce(target string, umountTimeout time.Duration) error {
+	return m.unmount(target, func() error {
+		if fu, ok := m.Interface.(mountutils.MounterForceUnmounter); ok {
+			return fu.UnmountWithForce(target, umountTimeout)
+		}
+		return m.Interface.Unmount(target)
+	})
+}
+
+// unmount tries the mount broker first (when the alinas mounter supports it) and
+// falls back to the provided local unmount when the broker does not own the
+// target (or predates the unmount RPC). It never inspects the kernel fstype.
+func (m *NasMounter) unmount(target string, local func() error) error {
+	pu, ok := m.alinasMounter.(mounter.ProxyUnmounter)
+	if !ok {
+		// Not using the proxy mounter (agent/connector mode): unmount locally.
+		return local()
+	}
+	logger := klog.Background().WithValues("target", target)
+	err := pu.ExtendedUnmount(context.Background(), target)
+	switch {
+	case err == nil:
+		logger.Info("unmounted successfully via mount broker")
+		return nil
+	case errors.Is(err, mounter.ErrTargetNotManagedByBroker):
+		// Not a broker-owned mount (plain NFS, or broker too old): unmount locally.
+		return local()
+	default:
+		logger.Error(err, "failed to unmount via mount broker")
+		return err
+	}
 }
 
 func newNasMounter(agentMode bool, socketPath string) mounter.Mounter {

--- a/pkg/nas/mounter_test.go
+++ b/pkg/nas/mounter_test.go
@@ -123,3 +123,23 @@ func TestNasMounter_Unmount_NonProxyModeIsLocal(t *testing.T) {
 	}
 	assert.True(t, unmounted, "non-proxy mode must unmount locally")
 }
+
+func TestNasMounter_Unmount_BrokerErrorFallsBackToLocal(t *testing.T) {
+	fake := &mountutils.FakeMounter{
+		MountPoints: []mountutils.MountPoint{{Path: "/mnt/alinas", Type: "nfs"}},
+	}
+	// Broker returns an unexpected (non-sentinel) error, e.g. socket unreachable.
+	pu := &fakeProxyUnmounter{Mounter: mounter.NewAdaptorMounter(fake), extendedErr: errors.New("call mounter daemon: dial unix: connection refused")}
+	nasMounter := &NasMounter{Interface: fake, alinasMounter: pu}
+
+	err := nasMounter.Unmount("/mnt/alinas")
+	assert.NoError(t, err, "broker error must not fail the unmount")
+	assert.Equal(t, []string{"/mnt/alinas"}, pu.calls, "broker is tried first")
+	var unmounted bool
+	for _, a := range fake.GetLog() {
+		if a.Action == mountutils.FakeActionUnmount {
+			unmounted = true
+		}
+	}
+	assert.True(t, unmounted, "must fall back to local unmount when the broker errors")
+}

--- a/pkg/nas/mounter_test.go
+++ b/pkg/nas/mounter_test.go
@@ -52,3 +52,74 @@ func TestNasMounter_FuseMountError(t *testing.T) {
 	})
 	assert.Error(t, err)
 }
+
+// fakeProxyUnmounter implements mounter.Mounter (via embedded AdaptorMounter)
+// and mounter.ProxyUnmounter. It records ExtendedUnmount targets and can be
+// configured to report a target as not managed by the broker.
+type fakeProxyUnmounter struct {
+	mounter.Mounter
+	calls       []string
+	notManaged  bool // return ErrTargetNotManagedByBroker
+	extendedErr error
+}
+
+func (f *fakeProxyUnmounter) ExtendedUnmount(_ context.Context, target string) error {
+	f.calls = append(f.calls, target)
+	if f.notManaged {
+		return mounter.ErrTargetNotManagedByBroker
+	}
+	return f.extendedErr
+}
+
+func TestNasMounter_Unmount_BrokerOwnedRoutesToBroker(t *testing.T) {
+	fake := &mountutils.FakeMounter{}
+	pu := &fakeProxyUnmounter{Mounter: mounter.NewAdaptorMounter(fake)}
+	nasMounter := &NasMounter{Interface: fake, alinasMounter: pu}
+
+	err := nasMounter.Unmount("/mnt/alinas")
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"/mnt/alinas"}, pu.calls)
+	// Broker handled it; no local unmount action recorded.
+	for _, a := range fake.GetLog() {
+		assert.NotEqual(t, mountutils.FakeActionUnmount, a.Action, "must not unmount locally")
+	}
+}
+
+func TestNasMounter_Unmount_NotManagedFallsBackToLocal(t *testing.T) {
+	fake := &mountutils.FakeMounter{
+		MountPoints: []mountutils.MountPoint{{Path: "/mnt/plain-nfs", Type: "nfs"}},
+	}
+	pu := &fakeProxyUnmounter{Mounter: mounter.NewAdaptorMounter(fake), notManaged: true}
+	nasMounter := &NasMounter{Interface: fake, alinasMounter: pu}
+
+	err := nasMounter.Unmount("/mnt/plain-nfs")
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"/mnt/plain-nfs"}, pu.calls, "broker is tried first")
+	// Fell back to a local unmount.
+	var unmounted bool
+	for _, a := range fake.GetLog() {
+		if a.Action == mountutils.FakeActionUnmount {
+			unmounted = true
+		}
+	}
+	assert.True(t, unmounted, "must fall back to local unmount when broker does not own the target")
+}
+
+// nonProxyMounter implements only mounter.Mounter (no ProxyUnmounter), modeling
+// agent/connector mode where unmounts must always be local.
+func TestNasMounter_Unmount_NonProxyModeIsLocal(t *testing.T) {
+	fake := &mountutils.FakeMounter{
+		MountPoints: []mountutils.MountPoint{{Path: "/mnt/x", Type: "nfs"}},
+	}
+	nasMounter := &NasMounter{Interface: fake, alinasMounter: mounter.NewAdaptorMounter(fake)}
+
+	err := nasMounter.Unmount("/mnt/x")
+	assert.NoError(t, err)
+	var unmounted bool
+	for _, a := range fake.GetLog() {
+		if a.Action == mountutils.FakeActionUnmount {
+			unmounted = true
+		}
+	}
+	assert.True(t, unmounted, "non-proxy mode must unmount locally")
+}

--- a/pkg/nas/utils.go
+++ b/pkg/nas/utils.go
@@ -188,7 +188,15 @@ func doMount(m mounter.Mounter, opt *Options, targetPath, volumeId, podUid strin
 	}); err != nil {
 		return err
 	}
-	if err := os.MkdirAll(filepath.Join(tmpPath, relPath), os.ModePerm); err != nil {
+	subDir := filepath.Join(tmpPath, relPath)
+	if err := os.MkdirAll(subDir, os.ModePerm); err != nil {
+		return err
+	}
+	// MkdirAll honors the process umask, so the created subpath would typically
+	// end up as 0755. Explicitly chmod to 0777 (umask is not applied to chmod)
+	// so the auto-created subpath is world-writable by default, matching the
+	// behavior expected by workloads that run as arbitrary UIDs.
+	if err := os.Chmod(subDir, 0o777); err != nil {
 		return err
 	}
 	if err := cleanupMountpoint(m, tmpPath); err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

##### Commit 1 — route alinas unmount through mount broker by ownership
Why NAS umount takes ~3 seconds (root cause)
NAS AccessPoint volumes are NFSv3-over-TLS. At mount time mount.alinas runs mount.nfs, and nfs-utils/libmount records the mount in the userspace mount table /run/mount/utab. That entry stores the info the kernel mount table does not keep but that umount.nfs needs to send the NFSv3 UMNT RPC to mountd — notably addr, port=xxxx, mountport, proto, clientaddr.

Crucially:
- /run/mount/utab is per-mount-namespace (each container has its own /run tmpfs); it is not shared across namespaces.
- Mount is delegated to the broker (mount-proxy-server): NasMounter.ExtendedMount sends the mount over the proxy socket, so mount.nfs runs inside the broker's mount namespace, and the utab entry is written there.
- The old unmount ran locally in the csi-plugin container's mount namespace (NasMounter inherited the embedded mount-utils Unmount). That namespace's /run/mount/utab never had the entry (it didn't perform the mount, and utab isn't shared).

So umount.nfs finds no utab record, falls back to contacting mountd on 127.0.1.x:xxx to send the UMNT RPC. The socket is opened non-blocking; the connect returns EINPROGRESS and umount.nfs waits in select() for the socket to become writable. The RPC gets no usable response, so select() returns only on its built-in 3×1s timeout ≈ 3.0s (the kernel umount(2) itself is microseconds; sendto is never even reached).

This isolates the cause to utab, independent of any network/nftables factor.
Note on the csi_mount_proxy nftables rule (oif lo tcp dport xxxx meta cgroup != 0 drop): in cgroup-v2 deployments where the plugin container is in a non-root cgroup, that rule also drops the fallback UMNT RPC and produces the same 3s stall. But it is a secondary amplifier, not the primary cause — the utab-namespace mismatch alone reproduces the 3s even when the rule does not match (e.g. root cgroup).

Compatibility / fallback
- Old mount-proxy-server (no unmount RPC): replies invalid method → local unmount (no regression).
- Plain NFS / non-broker mounts: broker has no record → ErrTargetNotManaged → local unmount (correct).
- Agent/connector mode (no ProxyUnmounter): always local.
- Broker restart (in-memory targets lost): affected old mounts fall back to local unmount; acceptable edge case.
Validation
- End-to-end: NodePublishVolume's subpath-creation cleanup now logs unmounted successfully via mount broker and completes in ~9ms (was ~3010ms via the local path).
- Unit tests added for broker-side routing (owned / not-owned / error / empty target / driver-without-Unmounter) and NasMounter routing (broker success / fallback-to-local / non-proxy mode).

##### Commit 2 — chmod auto-created subpath to 0777
The subpath directory auto-created during NodePublishVolume (via the temporary subpath-creation mount) was made with os.MkdirAll(..., os.ModePerm), which is subject to the process umask and therefore usually ended up as 0755. Workloads running as arbitrary/non-root UIDs then could not write into their own subpath.
Fix: after MkdirAll, explicitly os.Chmod(subDir, 0o777) (chmod is not affected by umask) so the auto-created subpath is world-writable by default.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NAS: fix NodeUnpublishVolume taking ~3s per alinas/AccessPoint mount by routing the unmount through the mount broker (the namespace that performed the mount and holds the libmount utab entry); falls back to a local unmount when the broker does not own the target or is unavailable.

Action required / behavior change: the directory auto-created for a NAS subpath volume is now chmod'd to 0777 (previously it was created with MkdirAll under the process umask and typically ended up 0755). Only newly auto-created subpath directories are affected; existing directories are not modified.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

