### PR TITLE
chore(chart): raise bmcpfs external-attacher kube API QPS

### DIFF
--- a/deploy/charts/alibaba-cloud-csi-driver/templates/controller.yaml
+++ b/deploy/charts/alibaba-cloud-csi-driver/templates/controller.yaml
@@ -535,8 +535,8 @@ spec:
             - --csi-address=/csi/csi.sock
             - --http-endpoint=:8121
             - --leader-election=true
-            - --kube-api-qps=50
-            - --kube-api-burst=100
+            - --kube-api-qps=500
+            - --kube-api-burst=1000
             - --worker-threads=256
             - --timeout=30s
           ports:


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

388bb43ee raised `--worker-threads` for the `external-bmcpfs-attacher` sidecar from 32 to 256, but its kube API rate limits stayed at `--kube-api-qps=50` / `--kube-api-burst=100`, so the client-side limiter — not the workers — now caps attach throughput.

Every attach costs 2 write calls: one patch to add the attacher finalizer to the VolumeAttachment, then one patch of `status.attached=true`. Detach costs another 2 (remove finalizer, then `status.attached=false`). So 256 in-flight attaches need ~512 API calls just to each make one step of progress; at 50 QPS that is over 10s spent purely waiting on the rate limiter, and the extra worker threads mostly queue behind it.

This raises the limits to `--kube-api-qps=500` / `--kube-api-burst=1000`, i.e. ~2 calls/s per worker thread sustained, with a burst that covers one full wave of 256 attaches. The 1:2 qps:burst ratio matches every other sidecar in the chart.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

Chart-only change; no code paths touched. The disk attacher already runs at 1000/2000 with 1200 worker threads, so these values stay well within what the API server is expected to absorb for this component.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
