### PR TITLE
Bump up golang to v1.26.6

### DIFF
--- a/build/csi-agent/Dockerfile
+++ b/build/csi-agent/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM registry-cn-hangzhou.ack.aliyuncs.com/dev/golang:1.26.5 AS builder
+FROM --platform=$BUILDPLATFORM registry-cn-hangzhou.ack.aliyuncs.com/dev/golang:1.26.6 AS builder
 WORKDIR /src
 ARG TARGETARCH
 ARG TARGETOS

--- a/build/mount-proxy/Dockerfile
+++ b/build/mount-proxy/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM registry-cn-hangzhou.ack.aliyuncs.com/dev/golang:1.26.5 AS builder
+FROM --platform=$BUILDPLATFORM registry-cn-hangzhou.ack.aliyuncs.com/dev/golang:1.26.6 AS builder
 WORKDIR /src
 ARG TARGETARCH
 ARG TARGETOS

--- a/build/multi/Dockerfile.multi
+++ b/build/multi/Dockerfile.multi
@@ -1,5 +1,5 @@
 # syntax=registry-cn-hangzhou.ack.aliyuncs.com/dev/dockerfile:1.6
-FROM --platform=$BUILDPLATFORM registry-cn-hangzhou.ack.aliyuncs.com/dev/golang:1.26.5 as build
+FROM --platform=$BUILDPLATFORM registry-cn-hangzhou.ack.aliyuncs.com/dev/golang:1.26.6 as build
 WORKDIR /go/src/github.com/kubernetes-sigs/alibaba-cloud-csi-driver
 ARG TARGETARCH
 ARG TARGETOS

--- a/build/multi/Dockerfile.multi.asi
+++ b/build/multi/Dockerfile.multi.asi
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.4
-FROM --platform=$BUILDPLATFORM golang:1.26.5 as build
+FROM --platform=$BUILDPLATFORM golang:1.26.6 as build
 WORKDIR /go/src/github.com/kubernetes-sigs/alibaba-cloud-csi-driver
 COPY . .
 ARG TARGETARCH


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Routine toolchain bump: the builder images move from `golang:1.26.5` to `golang:1.26.6`, the latest 1.26 patch release. Covers all four build files — `build/multi/Dockerfile.multi`, `build/multi/Dockerfile.multi.asi`, `build/csi-agent/Dockerfile` and `build/mount-proxy/Dockerfile` — so every image is built with the same toolchain.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

Verified `golang:1.26.6` exists both on Docker Hub (used by `Dockerfile.multi.asi`) and in `registry-cn-hangzhou.ack.aliyuncs.com/dev` (used by the other three), and that 1.26.6 is the newest 1.26 patch — 1.26.7 is not published yet. The `go` directive in `go.mod` stays at 1.26.0; this only changes which toolchain builds the binaries.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
