### PR TITLE
bump EFC to 2.4-20260817 and alinas-utils to 2.4-20260813

### DIFF
--- a/VERSIONS
+++ b/VERSIONS
@@ -25,10 +25,10 @@ OSSFS2_IMAGE_TAG=v2.0.9.ack.2-4094fc0
 # - build/mount-proxy/Dockerfile (ALINAS_UTILS_VERSION, EFC_VERSION, ALINAS_RPM_BASE_URL ARG defaults)
 
 # Base URL for ALINAS/EFC RPM packages (includes version path)
-ALINAS_RPM_BASE_URL=https://aliyun-alinas-eac-cn-shanghai.oss-cn-shanghai.aliyuncs.com/efc-release/2.4
+ALINAS_RPM_BASE_URL=https://aliyun-alinas-eac.oss-cn-beijing.aliyuncs.com/efc-release/2.4/
 
 # ALINAS Utils version (used in Dockerfile for yum install)
-ALINAS_UTILS_VERSION=2.4-0.20260727152320.aa12f6.generic
+ALINAS_UTILS_VERSION=2.4-0.20260813143608.fcc94d.generic
 
 # EFC version (used in Dockerfile for yum install)
-EFC_VERSION=2.4-20260727143717.f5a663.096fb99.release
+EFC_VERSION=2.4-20260817135527.cb17f4.5b35e56.release

--- a/build/mount-proxy/Dockerfile
+++ b/build/mount-proxy/Dockerfile
@@ -107,9 +107,9 @@ ENTRYPOINT ["csi-mount-proxy-server", "--driver=ossfs2"]
 FROM alinux-install AS alinas
 
 ARG TARGETPLATFORM
-ARG ALINAS_UTILS_VERSION=2.4-0.20260727152320.aa12f6.generic
-ARG EFC_VERSION=2.4-20260727143717.f5a663.096fb99.release
-ARG ALINAS_RPM_BASE_URL=https://aliyun-alinas-eac-cn-shanghai.oss-cn-shanghai.aliyuncs.com/efc-release/2.4
+ARG ALINAS_UTILS_VERSION=2.4-0.20260813143608.fcc94d.generic
+ARG EFC_VERSION=2.4-20260817135527.cb17f4.5b35e56.release
+ARG ALINAS_RPM_BASE_URL=https://aliyun-alinas-eac.oss-cn-beijing.aliyuncs.com/efc-release/2.4
 
 RUN --mount=type=bind,from=rpm-builder,source=/root/rpmbuild/RPMS/noarch,target=/tmp/rpms \
     echo 'install_weak_deps=False' >> /etc/yum.conf; \
@@ -146,9 +146,9 @@ ARG OSSFS_VERSION=v1.91.12.ack.2
 ARG OSSFS2_VERSION=v2.0.9.ack.2
 ARG OSSFS_RPM_URL
 ARG OSSFS2_RPM_URL
-ARG ALINAS_UTILS_VERSION=2.4-0.20260727152320.aa12f6.generic
-ARG EFC_VERSION=2.4-20260727143717.f5a663.096fb99.release
-ARG ALINAS_RPM_BASE_URL=https://aliyun-alinas-eac-cn-shanghai.oss-cn-shanghai.aliyuncs.com/efc-release/2.4
+ARG ALINAS_UTILS_VERSION=2.4-0.20260813143608.fcc94d.generic
+ARG EFC_VERSION=2.4-20260817135527.cb17f4.5b35e56.release
+ARG ALINAS_RPM_BASE_URL=https://aliyun-alinas-eac.oss-cn-beijing.aliyuncs.com/efc-release/2.4
 
 RUN --mount=type=bind,from=rpm-builder,source=/root/rpmbuild/RPMS/noarch,target=/tmp/rpms \
     echo 'install_weak_deps=False' >> /etc/yum.conf; \


### PR DESCRIPTION
Update VERSIONS and build/mount-proxy/Dockerfile:
    - EFC_VERSION: 2.4-20260727143717.f5a663.096fb99.release -> 2.4-20260817135527.cb17f4.5b35e56.release
    - ALINAS_UTILS_VERSION: 2.4-0.20260727152320.aa12f6.generic -> 2.4-0.20260813143608.fcc94d.generic

#### What type of PR is this?

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

