### PR TITLE
fix(nas): chmod 0777 for auto-created subpath when AGENT_SANDBOX is enabled

### DIFF
--- a/pkg/nas/utils.go
+++ b/pkg/nas/utils.go
@@ -193,8 +193,8 @@ func doMount(m mounter.Mounter, opt *Options, targetPath, volumeId, podUid strin
 		return err
 	}
 	// MkdirAll honors the process umask, so the created subpath would typically
-	// end up as 0755. Explicitly chmod to 0777 for agent mode (rootless containers are required)
-	if agentMode {
+	// end up as 0755. Explicitly chmod to 0777 for OpenKruise sandbox (rootless containers are required)
+	if os.Getenv("AGENT_SANDBOX") == "true" {
 		if err := os.Chmod(subDir, 0o777); err != nil {
 			return err
 		}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

When the NAS driver auto-creates a missing subpath during mount, `os.MkdirAll` honors the process umask, so the directory typically ends up as `0755`. In the OpenKruise sandbox scenario, workloads run as rootless containers and need write access to the auto-created subpath.

This PR explicitly chmods the auto-created subpath to `0777` when the `AGENT_SANDBOX=true` environment variable is set, restricting the permissive mode to the sandbox scenario only.

#### Which issue(s) this PR fixes:

NONE

#### Special notes for your reviewer:

The chmod is gated by the `AGENT_SANDBOX` env var rather than agent mode in general, so non-sandbox agent-mode mounts keep the default umask-derived permissions.

#### Does this PR introduce a user-facing change?

```release-note
NAS: auto-created subpaths are chmod'ed to 0777 when the node plugin runs with AGENT_SANDBOX=true, enabling rootless containers in OpenKruise sandboxes to write to them.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```