### PR TITLE
fix(disk): remove duplicate partition guard and wrap detach error as gRPC status

### DIFF
--- a/pkg/disk/device_manager.go
+++ b/pkg/disk/device_manager.go
@@ -125,9 +125,6 @@ func (m *DeviceManager) adaptDevicePartition(rootDevicePath string) (string, err
 	if !m.EnableDiskPartition {
 		return rootDevicePath, nil
 	}
-	if !m.EnableDiskPartition {
-		return rootDevicePath, nil
-	}
 	devName, err := m.deviceName(rootDevicePath)
 	if err != nil {
 		return "", fmt.Errorf("get device name for %s failed: %w", rootDevicePath, err)

--- a/pkg/disk/nodeserver.go
+++ b/pkg/disk/nodeserver.go
@@ -821,7 +821,7 @@ func (ns *nodeServer) NodeUnstageVolume(ctx context.Context, req *csi.NodeUnstag
 	err = ns.ad.detachDisk(ctx, ecsClient, req.VolumeId, ns.NodeID, true)
 	if err != nil {
 		logger.Error(err, "Detach failed")
-		return nil, err
+		return nil, status.Errorf(codes.Internal, "detach disk %s from node %s: %v", req.VolumeId, ns.NodeID, err)
 	}
 	ns.ad.repo.DeleteAttached(req.VolumeId)
 


### PR DESCRIPTION
## What this PR does

Two small correctness fixes in the disk driver, both in the node-side path.

### 1. `pkg/disk/device_manager.go`: remove duplicate `EnableDiskPartition` guard

`adaptDevicePartition` had the identical early-return check twice in a row:

```go
if !m.EnableDiskPartition {
    return rootDevicePath, nil
}
if !m.EnableDiskPartition {   // dead code — never reachable
    return rootDevicePath, nil
}
```

The second copy is dead code: it can never execute because the first one already returned. Removed.

### 2. `pkg/disk/nodeserver.go`: wrap `NodeUnstageVolume` detach error as `codes.Internal`

The node-side detach path in `NodeUnstageVolume` returned a bare `error`:

```go
err = ns.ad.detachDisk(ctx, ecsClient, req.VolumeId, ns.NodeID, true)
if err != nil {
    logger.Error(err, "Detach failed")
    return nil, err   // bare error → CO receives codes.Unknown
}
```

Every other error site in `NodeUnstageVolume` wraps the error with `status.Errorf`
so the container orchestrator (external-attacher / kubelet) can classify the
response correctly. This one inconsistent path surfaced as `codes.Unknown`, which
some COs treat differently from `codes.Internal` (e.g. may not retry).

Fixed to match the rest of the function:

```go
return nil, status.Errorf(codes.Internal, "detach disk %s from node %s: %v", req.VolumeId, ns.NodeID, err)
```

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Testing

- `GOOS=linux GOARCH=amd64 go build ./pkg/disk/...` — passes
- `GOOS=linux GOARCH=amd64 go vet ./pkg/disk/...` — passes