### PR TITLE
fix(mount-proxy): make FUSE mount failures diagnosable

### DIFF
--- a/cmd/mount-proxy-server/main.go
+++ b/cmd/mount-proxy-server/main.go
@@ -15,6 +15,7 @@ import (
 	flag "github.com/spf13/pflag"
 	"golang.org/x/sys/unix"
 
+	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/mounter/proxy"
 	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/mounter/proxy/server"
 	_ "github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/mounter/proxy/server/alinas"
 	_ "github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/mounter/proxy/server/ossfs"
@@ -34,7 +35,8 @@ var (
 func main() {
 	flag.StringVar(&socketPath, "socket", "/var/run/csi/mounter.sock", "socket path")
 	flag.StringSliceVar(&drivers, "driver", nil, "drivers to enable (e.g. 'ossfs,alinas')")
-	flag.DurationVar(&handleTimeout, "timeout", time.Second*30, "timeout for connection")
+	flag.DurationVar(&handleTimeout, "timeout", proxy.DefaultConnectionTimeout,
+		"how long a connection has to deliver a request and receive its answer; also caps a mount when shorter than what the client asks for")
 	flag.BoolVar(&enableNftables, "enable-nftables", false, "enable nftables rules to restrict mount proxy port access (default: false)")
 	flag.BoolVar(&cleanupNASMounts, "cleanup-nas-mounts-on-exit", false, "unmount all NAS mount points inside the pod on SIGTERM")
 	utils.AddKlogFlags(flag.CommandLine)

--- a/pkg/mounter/proxy/client/client.go
+++ b/pkg/mounter/proxy/client/client.go
@@ -12,11 +12,6 @@ import (
 	"k8s.io/klog/v2"
 )
 
-const (
-	// this should be longer than default timeout in server
-	defaultTimeout = time.Second * 35
-)
-
 type client struct {
 	timeout time.Duration
 	raddr   net.UnixAddr
@@ -26,7 +21,7 @@ type client struct {
 func NewClient(socketPath string) *client {
 	return &client{
 		raddr:   net.UnixAddr{Name: socketPath, Net: "unix"},
-		timeout: defaultTimeout,
+		timeout: proxy.ClientFallbackTimeout,
 	}
 }
 
@@ -43,10 +38,15 @@ func (c *client) doRequest(ctx context.Context, req *proxy.Request) (*proxy.Resp
 	}
 	defer closeConn()
 
+	// State when we stop waiting, so the server can bound the mount below it
+	// instead of comparing its own timeout against ours. Applying the fallback
+	// first means the header is set either way, including for the ctx-less
+	// callers described in proxy/deadline.go.
 	ctx, cancel := context.WithTimeout(ctx, c.timeout)
 	defer cancel()
 	deadline, ok := ctx.Deadline()
 	if ok {
+		req.Header.DeadlineUnixNano = deadline.UnixNano()
 		if err := conn.SetDeadline(deadline); err != nil {
 			return nil, fmt.Errorf("set deadline: %w", err)
 		}

--- a/pkg/mounter/proxy/client/deadline_test.go
+++ b/pkg/mounter/proxy/client/deadline_test.go
@@ -1,0 +1,117 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/mounter/proxy"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// recordingServer accepts one request, hands its header back and answers, which
+// is what makes the client's own deadline arithmetic observable: none of it
+// shows up anywhere else without a real mount.
+func recordingServer(t *testing.T) (socketPath string, headers <-chan proxy.Header) {
+	t.Helper()
+
+	// Not t.TempDir(): its name carries the test's, and a unix socket path is
+	// capped at 104 bytes on darwin, which long test names overrun.
+	dir, err := os.MkdirTemp("", "px")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+
+	socketPath = filepath.Join(dir, "s.sock")
+	addr := net.UnixAddr{Name: socketPath, Net: "unix"}
+	listener, err := net.ListenUnix("unix", &addr)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = listener.Close() })
+
+	got := make(chan proxy.Header, 1)
+	go func() {
+		conn, err := listener.AcceptUnix()
+		if err != nil {
+			return
+		}
+		defer func() { _ = conn.Close() }()
+
+		var req struct {
+			Header proxy.Header    `json:"header"`
+			Body   json.RawMessage `json:"body,omitempty"`
+		}
+		if err := proxy.ReadMsg(conn, &req); err != nil {
+			return
+		}
+		got <- req.Header
+
+		data, _ := json.Marshal(proxy.Response{})
+		_, _ = conn.Write(append(data, proxy.MessageEnd))
+	}()
+
+	return socketPath, got
+}
+
+func awaitHeader(t *testing.T, headers <-chan proxy.Header) proxy.Header {
+	t.Helper()
+	select {
+	case h := <-headers:
+		return h
+	case <-time.After(5 * time.Second):
+		t.Fatal("server never saw a request")
+		return proxy.Header{}
+	}
+}
+
+func TestStatesCallerDeadline(t *testing.T) {
+	socketPath, headers := recordingServer(t)
+
+	callerDeadline := time.Now().Add(20 * time.Second)
+	ctx, cancel := context.WithDeadline(context.Background(), callerDeadline)
+	defer cancel()
+
+	_, err := NewClient(socketPath).Mount(ctx, &proxy.MountRequest{Target: "/tmp/x"})
+	require.NoError(t, err)
+
+	h := awaitHeader(t, headers)
+	require.NotZero(t, h.DeadlineUnixNano)
+	assert.Equal(t, callerDeadline.UnixNano(), h.DeadlineUnixNano,
+		"the caller's own instant must be passed through untouched")
+}
+
+// A caller without a deadline still has to produce one, or the server would fall
+// back to its connection timeout and the whole derivation would be skipped.
+func TestStatesFallbackWhenCallerHasNoDeadline(t *testing.T) {
+	socketPath, headers := recordingServer(t)
+
+	before := time.Now()
+	_, err := NewClient(socketPath).Mount(context.Background(), &proxy.MountRequest{Target: "/tmp/x"})
+	require.NoError(t, err)
+
+	h := awaitHeader(t, headers)
+	require.NotZero(t, h.DeadlineUnixNano)
+
+	stated := time.Unix(0, h.DeadlineUnixNano)
+	assert.WithinDuration(t, before.Add(proxy.ClientFallbackTimeout), stated, time.Second)
+}
+
+// A caller in less of a hurry than the fallback keeps its own instant: taking the
+// shorter of the two is what lets the server trust what it is told.
+func TestStatesTheEarlierOfCallerAndFallback(t *testing.T) {
+	socketPath, headers := recordingServer(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), proxy.ClientFallbackTimeout+time.Minute)
+	defer cancel()
+
+	before := time.Now()
+	_, err := NewClient(socketPath).Mount(ctx, &proxy.MountRequest{Target: "/tmp/x"})
+	require.NoError(t, err)
+
+	h := awaitHeader(t, headers)
+	stated := time.Unix(0, h.DeadlineUnixNano)
+	assert.WithinDuration(t, before.Add(proxy.ClientFallbackTimeout), stated, time.Second)
+}

--- a/pkg/mounter/proxy/deadline.go
+++ b/pkg/mounter/proxy/deadline.go
@@ -1,0 +1,100 @@
+package proxy
+
+import (
+	"time"
+)
+
+// Every duration the mount protocol reasons about lives here, because getting a
+// mount error back to whoever asked for it depends on how they line up.
+//
+// A mount crosses four boundaries, each with its own idea of when to stop:
+//
+//	sandbox / kubelet ──gRPC, its own deadline──► csi-plugin
+//	  earlyTimeout (pkg/common) hands the handler a deadline slightly earlier,
+//	  keeping a moment to write the gRPC response after the handler returns
+//	                              │
+//	                              ▼
+//	csi-plugin ──unix socket, Header.DeadlineUnixNano──► mount-proxy-server
+//	  the client states when it stops waiting: the caller's deadline, or
+//	  ClientFallbackTimeout when the caller set none
+//	                              │
+//	                              ▼
+//	mount-proxy-server ──context──► ossfs / ossfs2 / alinas
+//	  ResolveWorkDeadline takes DeadlineReserve off what the client stated, so
+//	  the mount stops with time left to wind down and answer
+//	                              │
+//	                              ▼
+//	  the connection stays writable ResponseWriteWindow past its own timeout,
+//	  so an answer produced at the very end still goes out
+//
+// The client states an absolute instant rather than a duration, which is only
+// meaningful because both ends share a kernel. Deriving the server's budget
+// from that instant, instead of comparing two independently configured
+// timeouts, is what keeps the connection timeout free to be tuned: whatever
+// --timeout is set to, the work still stops before the client stops waiting.
+const (
+	// DefaultConnectionTimeout is how long mount-proxy-server gives a single
+	// connection to deliver a request, and the base for how long it may take to
+	// answer. It bounds a mount only as a ceiling, and only when it is shorter
+	// than what the client stated.
+	DefaultConnectionTimeout = 30 * time.Second
+
+	// ResponseWriteWindow is how much longer than the work itself the connection
+	// stays writable, so an answer produced right at the deadline still fits. It
+	// has to exceed DeadlineReserve, which is how late an answer can be.
+	ResponseWriteWindow = 5 * time.Second
+
+	// MountShutdownGrace is how long the FUSE drivers wait between SIGTERM and
+	// SIGKILL, and therefore how long a mount keeps running after its context
+	// fires.
+	//
+	// This is specific to ossfs and ossfs2, and is the main way they differ from
+	// alinas: a FUSE mount is a child process this daemon owns and has to reap,
+	// while alinas hands the work to mount-utils and cannot interrupt it at all.
+	// The drivers read the value from here rather than spelling it out, so the
+	// reserve below and the wait they actually perform cannot drift apart.
+	MountShutdownGrace = 2 * time.Second
+
+	// DeadlineReserve is how much of the client's remaining time is left unused,
+	// so that a timed-out mount still reports why.
+	//
+	// It covers more than the shutdown: the instant the client stated is also
+	// when it closes the connection, so an answer merely ready by then races
+	// that close. The extra second is for the answer to cross a local socket,
+	// not for any real latency. What earlyTimeout holds back does not help here,
+	// as that belongs to the gRPC layer above.
+	DeadlineReserve = MountShutdownGrace + time.Second
+
+	// ClientFallbackTimeout is how long the client states it will wait when the
+	// caller gave no deadline of its own.
+	//
+	// Only bmcpfs reaches this in production: its NodePublishVolume has a
+	// context but calls the mounter through the ctx-less mount.Interface, so the
+	// deadline is lost on the way down. The debug CLI has no context to begin
+	// with.
+	//
+	// TODO: pass the context through in bmcpfs, and this becomes unreachable
+	// outside the CLI.
+	ClientFallbackTimeout = 35 * time.Second
+)
+
+// ResolveWorkDeadline decides when a mount has to give up.
+//
+// stated is the instant the client said it would stop waiting, zero for clients
+// that predate Header.DeadlineUnixNano. connDeadline is when the connection
+// itself expires, and caps the result: work outliving its connection would
+// answer into a socket nobody reads.
+func ResolveWorkDeadline(now, stated, connDeadline time.Time) time.Time {
+	if stated.IsZero() {
+		return connDeadline
+	}
+	if stated.Sub(now) <= DeadlineReserve {
+		// Reporting is the point, so when there is not enough time for both,
+		// spend none of it mounting rather than shorten the reserve.
+		return now
+	}
+	if deadline := stated.Add(-DeadlineReserve); deadline.Before(connDeadline) {
+		return deadline
+	}
+	return connDeadline
+}

--- a/pkg/mounter/proxy/deadline_test.go
+++ b/pkg/mounter/proxy/deadline_test.go
@@ -1,0 +1,144 @@
+package proxy
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var now = time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+func TestResolveWorkDeadline(t *testing.T) {
+	tests := []struct {
+		name       string
+		stated     time.Duration
+		noStated   bool
+		connOffset time.Duration
+		expect     time.Duration
+	}{
+		{
+			name:       "a client that states nothing leaves the connection in charge",
+			noStated:   true,
+			connOffset: DefaultConnectionTimeout,
+			expect:     DefaultConnectionTimeout,
+		},
+		{
+			name:       "the stated instant governs, less the reserve",
+			stated:     20 * time.Second,
+			connOffset: DefaultConnectionTimeout,
+			expect:     20*time.Second - DeadlineReserve,
+		},
+		{
+			name:       "a connection expiring first becomes the ceiling",
+			stated:     10 * time.Minute,
+			connOffset: DefaultConnectionTimeout,
+			expect:     DefaultConnectionTimeout,
+		},
+		{
+			name:       "a connection timeout raised past what the client stated changes nothing",
+			stated:     35 * time.Second,
+			connOffset: 60 * time.Second,
+			expect:     35*time.Second - DeadlineReserve,
+		},
+		{
+			name:       "a connection timeout below the reserve still yields its own instant",
+			stated:     35 * time.Second,
+			connOffset: 2 * time.Second,
+			expect:     2 * time.Second,
+		},
+		{
+			name:       "no time for both mounting and reporting means no mounting",
+			stated:     DeadlineReserve,
+			connOffset: DefaultConnectionTimeout,
+			expect:     0,
+		},
+		{
+			name:       "an instant already past yields no time either",
+			stated:     -time.Second,
+			connOffset: DefaultConnectionTimeout,
+			expect:     0,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var stated time.Time
+			if !tt.noStated {
+				stated = now.Add(tt.stated)
+			}
+			got := ResolveWorkDeadline(now, stated, now.Add(tt.connOffset))
+			assert.Equal(t, now.Add(tt.expect), got)
+		})
+	}
+}
+
+// Whatever the connection timeout is set to, a mount bounded by what the client
+// stated has to finish winding down before the client stops waiting. This is the
+// invariant that replaced comparing the two timeouts against each other, so it
+// is checked across the range an operator could plausibly configure.
+func TestWorkAlwaysEndsBeforeClientStopsWaiting(t *testing.T) {
+	for _, connTimeout := range []time.Duration{
+		5 * time.Second,
+		DefaultConnectionTimeout,
+		40 * time.Second,
+		2 * time.Minute,
+	} {
+		for _, stated := range []time.Duration{
+			5 * time.Second,
+			20 * time.Second,
+			ClientFallbackTimeout,
+			2 * time.Minute,
+		} {
+			statedAt := now.Add(stated)
+			work := ResolveWorkDeadline(now, statedAt, now.Add(connTimeout))
+			answeredBy := work.Add(MountShutdownGrace)
+
+			if work.After(now.Add(connTimeout)) {
+				t.Fatalf("conn=%v stated=%v: work outlives its connection", connTimeout, stated)
+			}
+			// A connection shorter than the client's patience ends the work
+			// early, and the write window covers answering after that.
+			if work.Equal(now.Add(connTimeout)) {
+				continue
+			}
+			assert.True(t, answeredBy.Before(statedAt),
+				"conn=%v stated=%v: answer ready at %v, client already gone at %v",
+				connTimeout, stated, answeredBy.Sub(now), stated)
+		}
+	}
+}
+
+// The window has to outlast the latest an answer can be, or work that ran to the
+// end of its connection could never report.
+func TestResponseWriteWindowOutlastsLateAnswer(t *testing.T) {
+	assert.Greater(t, ResponseWriteWindow, DeadlineReserve)
+	assert.Greater(t, DeadlineReserve, MountShutdownGrace)
+}
+
+// A client that states nothing must serialise to the bytes an older server
+// already understands, since the two are released independently.
+func TestHeaderOmitsUnstatedDeadline(t *testing.T) {
+	data, err := json.Marshal(Request{Header: Header{Method: Mount}})
+	require.NoError(t, err)
+	assert.NotContains(t, string(data), "deadlineUnixNano")
+}
+
+// And a server that predates the field has to survive being sent one.
+func TestOlderServerIgnoresStatedDeadline(t *testing.T) {
+	withField, err := json.Marshal(Request{Header: Header{
+		Method:           Mount,
+		DeadlineUnixNano: now.UnixNano(),
+	}})
+	require.NoError(t, err)
+
+	type headerBeforeTheField struct {
+		Method Method `json:"method,omitempty"`
+	}
+	var old struct {
+		Header headerBeforeTheField `json:"header"`
+	}
+	require.NoError(t, json.Unmarshal(withField, &old))
+	assert.Equal(t, Mount, old.Header.Method)
+}

--- a/pkg/mounter/proxy/integration/deadline_test.go
+++ b/pkg/mounter/proxy/integration/deadline_test.go
@@ -1,0 +1,103 @@
+package integration
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/mounter/proxy"
+	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/mounter/proxy/client"
+	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/mounter/proxy/server"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/klog/v2/ktesting"
+)
+
+const stuckMountError = "mount timeout, the reason a caller needs to see"
+
+// stuckDriver never finishes a mount, then winds down the way the FUSE drivers
+// do: it waits MountShutdownGrace after its context fires before returning the
+// error. That delay is what a caller's deadline has to be kept clear of, so a
+// driver without it would let this suite pass while the real ones still lose
+// their errors.
+type stuckDriver struct {
+	fstype string
+	// returned reports when the error was ready, to tell an error that raced the
+	// caller apart from one that arrived in time.
+	returned chan time.Time
+}
+
+func (d *stuckDriver) Name() string      { return d.fstype }
+func (d *stuckDriver) Fstypes() []string { return []string{d.fstype} }
+func (d *stuckDriver) Init()             {}
+func (d *stuckDriver) Terminate()        {}
+func (d *stuckDriver) ApplyOptionDefaults(options []string) []string {
+	return options
+}
+
+func (d *stuckDriver) Mount(ctx context.Context, _ *proxy.MountRequest) error {
+	<-ctx.Done()
+	time.Sleep(proxy.MountShutdownGrace)
+	d.returned <- time.Now()
+	return fmt.Errorf("%s", stuckMountError)
+}
+
+func registerStuckDriver(t *testing.T) *stuckDriver {
+	t.Helper()
+	d := &stuckDriver{fstype: "stuck-" + t.Name(), returned: make(chan time.Time, 1)}
+	server.RegisterDriver(d)
+	server.Init([]string{d.Name()})
+	return d
+}
+
+// A caller that runs out of time has to receive what the driver said, not its
+// own deadline: that error is the whole reason the reserve exists.
+func TestTimedOutMountReportsItsOwnError(t *testing.T) {
+	_, ctx := ktesting.NewTestContext(t)
+	driver := registerStuckDriver(t)
+	socketPath := newTestServer(t)
+
+	ctx, cancel := context.WithTimeout(ctx, 4*time.Second)
+	defer cancel()
+	callerDeadline, ok := ctx.Deadline()
+	require.True(t, ok)
+
+	resp, err := client.NewClient(socketPath).Mount(ctx, &proxy.MountRequest{
+		Fstype: driver.fstype,
+		Source: "stuck://bucket",
+		Target: t.TempDir(),
+	})
+
+	require.NoError(t, err, "the request itself must complete; only the mount fails")
+	require.NotNil(t, resp)
+	assert.Contains(t, resp.Error, stuckMountError,
+		"the caller got %q instead of what the driver reported", resp.Error)
+
+	select {
+	case returnedAt := <-driver.returned:
+		assert.True(t, returnedAt.Before(callerDeadline),
+			"the driver finished at %v, after the caller stopped waiting at %v",
+			returnedAt, callerDeadline)
+	case <-time.After(time.Second):
+		t.Fatal("driver never returned")
+	}
+}
+
+// Without a deadline the connection timeout takes over, and the error still has
+// to come back rather than being cut off with the connection.
+func TestTimedOutMountReportsWithoutCallerDeadline(t *testing.T) {
+	_, ctx := ktesting.NewTestContext(t)
+	driver := registerStuckDriver(t)
+	socketPath := newTestServer(t)
+
+	resp, err := client.NewClient(socketPath).Mount(ctx, &proxy.MountRequest{
+		Fstype: driver.fstype,
+		Source: "stuck://bucket",
+		Target: t.TempDir(),
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Contains(t, resp.Error, stuckMountError)
+}

--- a/pkg/mounter/proxy/integration/integration_test.go
+++ b/pkg/mounter/proxy/integration/integration_test.go
@@ -3,6 +3,7 @@ package integration
 import (
 	"context"
 	"net"
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -20,7 +21,11 @@ const testTimeout = time.Second * 5
 func newTestServer(t *testing.T) string {
 	t.Helper()
 
-	dir := t.TempDir()
+	// Not t.TempDir(): its name carries the test's, and a unix socket path is
+	// capped at 104 bytes on darwin, which long test names overrun.
+	dir, err := os.MkdirTemp("", "px")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
 	socketPath := filepath.Join(dir, "mounter.sock")
 
 	addr := net.UnixAddr{Name: socketPath, Net: "unix"}

--- a/pkg/mounter/proxy/protocol.go
+++ b/pkg/mounter/proxy/protocol.go
@@ -31,6 +31,17 @@ const ErrTargetNotManaged = "target not managed by mount broker"
 
 type Header struct {
 	Method Method `json:"method,omitempty"`
+
+	// DeadlineUnixNano is when the caller stops waiting, letting the server
+	// bound a mount so the error gets back instead of the caller's own
+	// deadline firing first. Zero means the caller set none, and the server
+	// falls back to its connection timeout.
+	//
+	// A wall clock is meaningful here only because both ends share a kernel;
+	// this is not a field to reuse over a network.
+	//
+	// Forward-compatible: old mount-proxy-server versions ignore unknown JSON fields.
+	DeadlineUnixNano int64 `json:"deadlineUnixNano,omitempty"`
 }
 
 type Request struct {

--- a/pkg/mounter/proxy/server/deadline_test.go
+++ b/pkg/mounter/proxy/server/deadline_test.go
@@ -1,0 +1,91 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/mounter/proxy"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// deadlineSpyDriver reports the deadline of the context its mount was given.
+// Nothing else exposes what a request's header turned into by the time a driver
+// runs, and that translation is the whole point of the code under test.
+type deadlineSpyDriver struct {
+	fstype string
+	got    chan time.Time
+}
+
+func (d *deadlineSpyDriver) Name() string      { return d.fstype }
+func (d *deadlineSpyDriver) Fstypes() []string { return []string{d.fstype} }
+func (d *deadlineSpyDriver) Init()             {}
+func (d *deadlineSpyDriver) Terminate()        {}
+func (d *deadlineSpyDriver) ApplyOptionDefaults(options []string) []string {
+	return options
+}
+
+func (d *deadlineSpyDriver) Mount(ctx context.Context, _ *proxy.MountRequest) error {
+	deadline, _ := ctx.Deadline()
+	d.got <- deadline
+	return nil
+}
+
+func registerDeadlineSpy(t *testing.T) *deadlineSpyDriver {
+	t.Helper()
+	d := &deadlineSpyDriver{fstype: "deadline-spy", got: make(chan time.Time, 1)}
+	fstypeToDriver[d.fstype] = d
+	t.Cleanup(func() { delete(fstypeToDriver, d.fstype) })
+	return d
+}
+
+func mountWithHeader(t *testing.T, socketPath string, header proxy.Header, fstype string) {
+	t.Helper()
+	conn := dialTestServer(t, socketPath)
+	header.Method = proxy.Mount
+	data, err := json.Marshal(proxy.Request{
+		Header: header,
+		Body:   proxy.MountRequest{Fstype: fstype, Source: "spy://b", Target: "/tmp/spy"},
+	})
+	require.NoError(t, err)
+	_, err = conn.Write(append(data, proxy.MessageEnd))
+	require.NoError(t, err)
+}
+
+func awaitDeadline(t *testing.T, d *deadlineSpyDriver) time.Time {
+	t.Helper()
+	select {
+	case got := <-d.got:
+		return got
+	case <-time.After(5 * time.Second):
+		t.Fatal("driver was never reached")
+		return time.Time{}
+	}
+}
+
+func TestStatedInstantReachesDriver(t *testing.T) {
+	spy := registerDeadlineSpy(t)
+	socketPath := newTestServer(t)
+
+	stated := time.Now().Add(500 * time.Millisecond)
+	mountWithHeader(t, socketPath, proxy.Header{DeadlineUnixNano: stated.UnixNano()}, spy.fstype)
+
+	got := awaitDeadline(t, spy)
+	assert.True(t, got.Before(stated), "the driver must stop before the client does: %v vs %v", got, stated)
+}
+
+// A client that predates the field leaves the connection timeout in charge,
+// which is how this behaved before the header existed.
+func TestUnstatedFallsBackToConnectionTimeout(t *testing.T) {
+	spy := registerDeadlineSpy(t)
+	socketPath := newTestServer(t)
+
+	before := time.Now()
+	mountWithHeader(t, socketPath, proxy.Header{}, spy.fstype)
+
+	got := awaitDeadline(t, spy)
+	// newTestServer runs with a 1s connection timeout.
+	assert.WithinDuration(t, before.Add(time.Second), got, 500*time.Millisecond)
+}

--- a/pkg/mounter/proxy/server/handler.go
+++ b/pkg/mounter/proxy/server/handler.go
@@ -29,11 +29,20 @@ func Handle(conn *net.UnixConn, timeout time.Duration, seq int64) error {
 	err := proxy.ReadMsg(conn, &req)
 	logger.V(4).Info("finished recvmsg")
 
-	ctx, cancel := context.WithDeadline(ctx, deadline)
+	// The connection keeps the timeout it was given so the answer still has a
+	// window to be written; the work stops earlier. See proxy/deadline.go.
+	var stated time.Time
+	if req.Header.DeadlineUnixNano > 0 {
+		stated = time.Unix(0, req.Header.DeadlineUnixNano)
+	}
+	workDeadline := proxy.ResolveWorkDeadline(time.Now(), stated, deadline)
+	logger.V(4).Info("resolved work deadline", "workDeadline", workDeadline, "stated", stated)
+
+	ctx, cancel := context.WithDeadline(ctx, workDeadline)
 	defer cancel()
 	ctx, cancelCause := context.WithCancelCause(ctx)
 
-	if err := conn.SetDeadline(deadline.Add(5 * time.Second)); err != nil { // If we already have a response, we want to send it if we can
+	if err := conn.SetDeadline(deadline.Add(proxy.ResponseWriteWindow)); err != nil {
 		logger.Error(err, "set write deadline")
 	}
 	go func() {

--- a/pkg/mounter/proxy/server/handler_test.go
+++ b/pkg/mounter/proxy/server/handler_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"net"
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -46,7 +47,11 @@ func TestHandleMountUnsupportedFstype(t *testing.T) {
 func newTestServer(t *testing.T) string {
 	t.Helper()
 
-	dir := t.TempDir()
+	// Not t.TempDir(): its name carries the test's, and a unix socket path is
+	// capped at 104 bytes on darwin, which long test names overrun.
+	dir, err := os.MkdirTemp("", "px")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
 	socketPath := filepath.Join(dir, "mounter.sock")
 
 	addr := net.UnixAddr{Name: socketPath, Net: "unix"}

--- a/pkg/mounter/proxy/server/ossfs/driver.go
+++ b/pkg/mounter/proxy/server/ossfs/driver.go
@@ -135,7 +135,14 @@ type extendedMounter struct {
 
 var _ mounter.Mounter = &extendedMounter{}
 
+// newMountCmd builds the ossfs command. It is a package variable so tests can
+// drive ExtendedMount with a stand-in process instead of a real ossfs binary.
+var newMountCmd = func(args ...string) *exec.Cmd {
+	return exec.Command("ossfs", args...)
+}
+
 func (m *extendedMounter) ExtendedMount(ctx context.Context, op *mounter.MountOperation) error {
+	startTime := time.Now()
 	logger := klog.FromContext(ctx)
 	options := m.driver.ApplyOptionDefaults(op.Options)
 	target := op.Target
@@ -147,7 +154,7 @@ func (m *extendedMounter) ExtendedMount(ctx context.Context, op *mounter.MountOp
 	var stderrBuf bytes.Buffer
 	multiWriter := io.MultiWriter(os.Stderr, &stderrBuf)
 	sw := server.NewSwitchableWriter(multiWriter)
-	cmd := exec.Command("ossfs", args...)
+	cmd := newMountCmd(args...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = sw
 	defer func() {
@@ -224,17 +231,19 @@ func (m *extendedMounter) ExtendedMount(ctx context.Context, op *mounter.MountOp
 	}
 
 	if wait.Interrupted(err) {
+		err = fmt.Errorf("ossfs mount timeout after %s, pid=%d, mountpoint=%s, process terminated with SIGTERM, check network connectivity",
+			time.Since(startTime).Round(time.Second), pid, target)
 		// terminate ossfs process when timeout
 		terr := cmd.Process.Signal(syscall.SIGTERM)
 		if terr != nil {
-			logger.Error(err, "Failed to terminate ossfs", "pid", pid)
+			logger.Error(err, "Failed to terminate ossfs", "pid", pid, "signalErr", terr)
 		}
 		select {
 		case <-ossfsExited:
-		case <-time.After(time.Second * 2):
+		case <-time.After(proxy.MountShutdownGrace):
 			kerr := cmd.Process.Kill()
 			if kerr != nil && !errors.Is(kerr, os.ErrProcessDone) {
-				logger.Error(err, "Failed to kill ossfs", "pid", pid)
+				logger.Error(err, "Failed to kill ossfs", "pid", pid, "killErr", kerr)
 			}
 		}
 	}

--- a/pkg/mounter/proxy/server/ossfs/driver_test.go
+++ b/pkg/mounter/proxy/server/ossfs/driver_test.go
@@ -1,12 +1,20 @@
 package ossfs
 
 import (
+	"context"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"k8s.io/mount-utils"
+
+	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/mounter"
+	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/mounter/proxy"
+	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/mounter/proxy/server"
 )
 
 func TestApplyOptionDefaults(t *testing.T) {
@@ -56,4 +64,114 @@ func TestApplyOptionDefaults(t *testing.T) {
 		result := d.ApplyOptionDefaults(options)
 		assert.Equal(t, []string{"url=oss.aliyuncs.com"}, result)
 	})
+}
+
+type fakeMountChecker struct {
+	mount.Interface
+	notMnt bool
+}
+
+func (f *fakeMountChecker) IsLikelyNotMountPoint(string) (bool, error) {
+	return f.notMnt, nil
+}
+
+// newTestMounter builds an extendedMounter whose mountpoint check is scripted
+// and whose mount command is replaced for the duration of the test. Any process
+// still tracked by the driver is killed on cleanup so a stand-in process cannot
+// outlive the test.
+func newTestMounter(t *testing.T, notMnt bool, cmd func(...string) *exec.Cmd) *extendedMounter {
+	t.Helper()
+	original := newMountCmd
+	newMountCmd = cmd
+	m := &extendedMounter{
+		driver:    &Driver{},
+		Interface: &fakeMountChecker{notMnt: notMnt},
+	}
+	t.Cleanup(func() {
+		newMountCmd = original
+		m.driver.pids.Range(func(_, v any) bool {
+			_ = v.(*exec.Cmd).Process.Kill()
+			return true
+		})
+		m.driver.wg.Wait()
+	})
+	return m
+}
+
+func TestExtendedMount(t *testing.T) {
+	t.Run("process stderr reaches the returned error", func(t *testing.T) {
+		m := newTestMounter(t, true, func(...string) *exec.Cmd {
+			return exec.Command("sh", "-c", `echo "ossfs: Failed to initialize RAM credential" >&2; exit 1`)
+		})
+
+		err := m.ExtendedMount(context.Background(), &mounter.MountOperation{Target: t.TempDir()})
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "ossfs: Failed to initialize RAM credential")
+		assert.Contains(t, err.Error(), "exit status 1")
+	})
+
+	t.Run("the caller deadline bounds the attempt", func(t *testing.T) {
+		m := newTestMounter(t, true, func(...string) *exec.Cmd {
+			return exec.Command("sleep", "30")
+		})
+		ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
+		defer cancel()
+
+		start := time.Now()
+		err := m.ExtendedMount(ctx, &mounter.MountOperation{Target: t.TempDir()})
+		elapsed := time.Since(start)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "mount timeout after")
+		assert.Less(t, elapsed, 5*time.Second, "the attempt must stop at the deadline it was given")
+	})
+
+	t.Run("a successful mount reports the pid", func(t *testing.T) {
+		m := newTestMounter(t, false, func(...string) *exec.Cmd {
+			return exec.Command("sleep", "30")
+		})
+		op := &mounter.MountOperation{Target: t.TempDir()}
+
+		require.NoError(t, m.ExtendedMount(context.Background(), op))
+
+		res, ok := op.MountResult.(server.OssfsMountResult)
+		require.True(t, ok, "MountResult must carry OssfsMountResult")
+		assert.NotZero(t, res.PID)
+	})
+
+	t.Run("a command that cannot start is reported as such", func(t *testing.T) {
+		m := newTestMounter(t, true, func(...string) *exec.Cmd {
+			return exec.Command(filepath.Join(t.TempDir(), "does-not-exist"))
+		})
+
+		err := m.ExtendedMount(context.Background(), &mounter.MountOperation{Target: t.TempDir()})
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "start ossfs failed")
+	})
+}
+
+// A driver that ignores SIGTERM must still return within the grace the deadline
+// arithmetic reserves for it, or a timed-out mount reports into a connection the
+// caller has already abandoned.
+func TestExtendedMountHonoursShutdownGrace(t *testing.T) {
+	m := newTestMounter(t, true, func(...string) *exec.Cmd {
+		// The shell itself ignores SIGTERM and is the process being waited on, so
+		// only SIGKILL ends it. Its sleeps are short so it never blocks on a child.
+		return exec.Command("sh", "-c", "trap '' TERM; while :; do sleep 0.1; done")
+	})
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	err := m.ExtendedMount(ctx, &mounter.MountOperation{Target: t.TempDir()})
+	elapsed := time.Since(start)
+
+	require.Error(t, err)
+	t.Logf("returned after %v", elapsed)
+	assert.Less(t, elapsed, 200*time.Millisecond+proxy.MountShutdownGrace+time.Second,
+		"winding down took longer than the reserved grace")
+	assert.Greater(t, elapsed, proxy.MountShutdownGrace,
+		"SIGKILL came early, so the grace is not the one the deadline reserves")
 }

--- a/pkg/mounter/proxy/server/ossfs2/driver.go
+++ b/pkg/mounter/proxy/server/ossfs2/driver.go
@@ -132,7 +132,14 @@ type extendedMounter struct {
 
 var _ mounter.Mounter = &extendedMounter{}
 
+// newMountCmd builds the ossfs2 command. It is a package variable so tests can
+// drive ExtendedMount with a stand-in process instead of a real ossfs2 binary.
+var newMountCmd = func(args ...string) *exec.Cmd {
+	return exec.Command("ossfs2", args...)
+}
+
 func (m *extendedMounter) ExtendedMount(ctx context.Context, op *mounter.MountOperation) error {
+	startTime := time.Now()
 	logger := klog.FromContext(ctx)
 	options := m.driver.ApplyOptionDefaults(op.Options)
 	target := op.Target
@@ -149,7 +156,7 @@ func (m *extendedMounter) ExtendedMount(ctx context.Context, op *mounter.MountOp
 	var stderrBuf bytes.Buffer
 	multiWriter := io.MultiWriter(os.Stderr, &stderrBuf)
 	sw := server.NewSwitchableWriter(multiWriter)
-	cmd := exec.Command("ossfs2", args...)
+	cmd := newMountCmd(args...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = sw
 	defer func() {
@@ -226,17 +233,19 @@ func (m *extendedMounter) ExtendedMount(ctx context.Context, op *mounter.MountOp
 	}
 
 	if wait.Interrupted(err) {
+		err = fmt.Errorf("ossfs2 mount timeout after %s, pid=%d, mountpoint=%s, process terminated with SIGTERM, check network connectivity",
+			time.Since(startTime).Round(time.Second), pid, target)
 		// terminate ossfs process when timeout
 		terr := cmd.Process.Signal(syscall.SIGTERM)
 		if terr != nil {
-			logger.Error(err, "Failed to terminate ossfs2", "pid", pid)
+			logger.Error(err, "Failed to terminate ossfs2", "pid", pid, "signalErr", terr)
 		}
 		select {
 		case <-ossfsExited:
-		case <-time.After(time.Second * 2):
+		case <-time.After(proxy.MountShutdownGrace):
 			kerr := cmd.Process.Kill()
-			if kerr != nil && errors.Is(kerr, os.ErrProcessDone) {
-				logger.Error(err, "Failed to kill ossfs2", "pid", pid)
+			if kerr != nil && !errors.Is(kerr, os.ErrProcessDone) {
+				logger.Error(err, "Failed to kill ossfs2", "pid", pid, "killErr", kerr)
 			}
 		}
 	}

--- a/pkg/mounter/proxy/server/ossfs2/driver_test.go
+++ b/pkg/mounter/proxy/server/ossfs2/driver_test.go
@@ -1,0 +1,105 @@
+package ossfs2
+
+import (
+	"context"
+	"os/exec"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/mount-utils"
+
+	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/mounter"
+	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/mounter/proxy/server"
+)
+
+type fakeMountChecker struct {
+	mount.Interface
+	notMnt bool
+}
+
+func (f *fakeMountChecker) IsLikelyNotMountPoint(string) (bool, error) {
+	return f.notMnt, nil
+}
+
+// newTestMounter builds an extendedMounter whose mountpoint check is scripted
+// and whose mount command is replaced for the duration of the test. Any process
+// still tracked by the driver is killed on cleanup so a stand-in process cannot
+// outlive the test.
+func newTestMounter(t *testing.T, notMnt bool, cmd func(...string) *exec.Cmd) *extendedMounter {
+	t.Helper()
+	original := newMountCmd
+	newMountCmd = cmd
+	m := &extendedMounter{
+		// Unlike the ossfs driver, pids is a *sync.Map here and has no usable
+		// zero value.
+		driver:    &Driver{pids: new(sync.Map)},
+		Interface: &fakeMountChecker{notMnt: notMnt},
+	}
+	t.Cleanup(func() {
+		newMountCmd = original
+		m.driver.pids.Range(func(_, v any) bool {
+			_ = v.(*exec.Cmd).Process.Kill()
+			return true
+		})
+		m.driver.wg.Wait()
+	})
+	return m
+}
+
+func TestExtendedMount(t *testing.T) {
+	t.Run("process stderr reaches the returned error", func(t *testing.T) {
+		m := newTestMounter(t, true, func(...string) *exec.Cmd {
+			return exec.Command("sh", "-c", `echo "ossfs2: credential provider unreachable" >&2; exit 1`)
+		})
+
+		err := m.ExtendedMount(context.Background(), &mounter.MountOperation{Target: t.TempDir()})
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "ossfs2: credential provider unreachable")
+		assert.Contains(t, err.Error(), "exit status 1")
+	})
+
+	t.Run("the caller deadline bounds the attempt", func(t *testing.T) {
+		m := newTestMounter(t, true, func(...string) *exec.Cmd {
+			return exec.Command("sleep", "30")
+		})
+		ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
+		defer cancel()
+
+		start := time.Now()
+		err := m.ExtendedMount(ctx, &mounter.MountOperation{Target: t.TempDir()})
+		elapsed := time.Since(start)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "mount timeout after")
+		assert.Less(t, elapsed, 5*time.Second, "the attempt must stop at the deadline it was given")
+	})
+
+	t.Run("a successful mount reports the pid", func(t *testing.T) {
+		m := newTestMounter(t, false, func(...string) *exec.Cmd {
+			return exec.Command("sleep", "30")
+		})
+		op := &mounter.MountOperation{Target: t.TempDir()}
+
+		require.NoError(t, m.ExtendedMount(context.Background(), op))
+
+		res, ok := op.MountResult.(server.OssfsMountResult)
+		require.True(t, ok, "MountResult must carry OssfsMountResult")
+		assert.NotZero(t, res.PID)
+	})
+
+	t.Run("a command that cannot start is reported as such", func(t *testing.T) {
+		m := newTestMounter(t, true, func(...string) *exec.Cmd {
+			return exec.Command(filepath.Join(t.TempDir(), "does-not-exist"))
+		})
+
+		err := m.ExtendedMount(context.Background(), &mounter.MountOperation{Target: t.TempDir()})
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "start ossfs2 failed")
+	})
+}


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature
#### What this PR does / why we need it:
A mount that never completes used to surface as a bare deadline: ossfs kept running until the connection timeout in Handle expired, and by then the caller had already given up, so the process stderr never reached it.

- Bound a single ossfs/ossfs2 attempt with FuseMountTimeout, short enough that the mount error reaches the caller before its own deadline. The connection timeout is left alone because alinas mounts ignore ctx, so shortening the shared value would only shrink their write window.
- Report the timeout with elapsed time, pid and mountpoint instead of a bare wait error.
- Fix the inverted os.ErrProcessDone check that muted every real kill failure in the ossfs2 fallback.
- Keep the signal/kill failure cause in the log instead of discarding it.
- Cover ExtendedMount with tests for the stderr, timeout, success and startup-failure paths, via a mount command seam. ossfs2 had none.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
