### PR TITLE
feat(pov): serve kvcsplugin.csi.alibabacloud.com alongside povplugin

### DIFF
--- a/main.go
+++ b/main.go
@@ -268,7 +268,20 @@ func main() {
 			case ExtenderAgent:
 				klog.Fatalf("rund-csi protocol 1.0 is no longer supported.")
 			case TypePluginPOV:
-				driver = pov.NewServers(meta, endpoint, serviceType)
+				// The POV driver serves two CSI driver names (povplugin and
+				// kvcsplugin), each on its own endpoint.
+				for _, s := range pov.NewServers(meta, endpoint, serviceType) {
+					driverType := strings.TrimSuffix(s.DriverName, TypePluginSuffix)
+					server := common.NewCSIServer(driverType, s.Servers)
+					wg.Go(func() {
+						common.Serve(server, s.Endpoint)
+					})
+					wg.Go(func() {
+						<-ctx.Done()
+						server.Stop()
+					})
+				}
+				continue
 			case TypePluginBMCPFS:
 				driver = bmcpfs.NewServers(meta, endpoint, serviceType)
 			default:

--- a/pkg/common/start.go
+++ b/pkg/common/start.go
@@ -22,6 +22,14 @@ type Servers struct {
 	GroupControllerServer csi.GroupControllerServer
 }
 
+// NamedServer binds a CSI server implementation to a driver name and an
+// endpoint, so that one driver can serve multiple CSI driver names.
+type NamedServer struct {
+	DriverName string
+	Endpoint   string
+	Servers    *Servers
+}
+
 func ParseEndpoint(ep string) (string, string, error) {
 	if strings.HasPrefix(strings.ToLower(ep), "unix://") || strings.HasPrefix(strings.ToLower(ep), "tcp://") {
 		s := strings.SplitN(ep, "://", 2)

--- a/pkg/pov/identity.go
+++ b/pkg/pov/identity.go
@@ -11,10 +11,10 @@ type identityServer struct {
 	common.GenericIdentityServer
 }
 
-func newIdentityServer() *identityServer {
+func newIdentityServer(driverName string) *identityServer {
 	return &identityServer{
 		GenericIdentityServer: common.GenericIdentityServer{
-			Name: DriverName,
+			Name: driverName,
 		},
 	}
 }

--- a/pkg/pov/pov.go
+++ b/pkg/pov/pov.go
@@ -3,6 +3,8 @@
 package pov
 
 import (
+	"strings"
+
 	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/cloud/metadata"
 	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/common"
 	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/options"
@@ -13,16 +15,41 @@ import (
 
 const (
 	DriverName = "povplugin.csi.alibabacloud.com"
+	// kvcsDriverName is served by the POV driver as well, until a dedicated
+	// KVCS plugin exists.
+	kvcsDriverName = "kvcsplugin.csi.alibabacloud.com"
 )
 
 var GlobalConfigVar GlobalConfig
 
-// Pangu Over Virtio
-func NewServers(meta *metadata.Metadata, endpoint string, serviceType utils.ServiceType) *common.Servers {
+// NewServers returns the CSI servers of the POV driver (Pangu Over Virtio):
+// the same POV services are served under both the povplugin and the
+// kvcsplugin driver names, each on its own endpoint. The kvcs endpoint is
+// derived by replacing the pov driver name in the given endpoint.
+func NewServers(meta *metadata.Metadata, endpoint string, serviceType utils.ServiceType) []common.NamedServer {
 	newGlobalConfig(meta, serviceType)
 
+	servers := []common.NamedServer{{
+		DriverName: DriverName,
+		Endpoint:   endpoint,
+		Servers:    newDriverServers(meta, serviceType, DriverName),
+	}}
+
+	if !strings.Contains(endpoint, DriverName) {
+		klog.Warningf("NewServers: endpoint %s does not contain %s, skip serving %s", endpoint, DriverName, kvcsDriverName)
+		return servers
+	}
+	kvcsEndpoint := strings.ReplaceAll(endpoint, DriverName, kvcsDriverName)
+	return append(servers, common.NamedServer{
+		DriverName: kvcsDriverName,
+		Endpoint:   kvcsEndpoint,
+		Servers:    newDriverServers(meta, serviceType, kvcsDriverName),
+	})
+}
+
+func newDriverServers(meta *metadata.Metadata, serviceType utils.ServiceType, driverName string) *common.Servers {
 	var servers common.Servers
-	servers.IdentityServer = newIdentityServer()
+	servers.IdentityServer = newIdentityServer(driverName)
 	if serviceType&utils.Controller != 0 {
 		cs := newControllerService()
 		servers.ControllerServer = &cs

--- a/pkg/pov/pov_windows.go
+++ b/pkg/pov/pov_windows.go
@@ -10,6 +10,6 @@ const (
 	DriverName = "povplugin.csi.alibabacloud.com"
 )
 
-func NewServers(meta *metadata.Metadata, endpoint string, serviceType utils.ServiceType) *common.Servers {
+func NewServers(_ *metadata.Metadata, _ string, _ utils.ServiceType) []common.NamedServer {
 	panic("POV driver is not supported on Windows")
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

When the POV driver is declared, it now registers two CSI driver names:
`povplugin.csi.alibabacloud.com` and `kvcsplugin.csi.alibabacloud.com`,
without any deployment configuration change and without `main.go` knowing
about kvcs. The alias server is created inside the pov package: the alias
endpoint is derived by replacing the pov driver name in the given endpoint,
and the same POV controller/node services are served under the KVCS
identity, until a dedicated KVCS plugin exists.

#### Which issue(s) this PR fixes:

NONE

#### Special notes for your reviewer:

- The driver name only affects the identity server (`GetPluginInfo`); POV
  controller/node logic is name-agnostic.
- If the endpoint does not contain the pov driver name (e.g. the default
  `unix://tmp/csi.sock`), the alias server is skipped with a warning.
- Deployment side (one registrar per socket, `CSIDriver` object,
  provisioner/attacher sidecars and RBAC scoped to the new name) is out of
  scope for this PR.

#### Does this PR introduce a user-facing change?

```release-note
When the POV driver is enabled, it now also serves `kvcsplugin.csi.alibabacloud.com` alongside `povplugin.csi.alibabacloud.com`.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```
