### PR TITLE
disk: report actual disk capacity in ControllerExpandVolume

### DIFF
--- a/pkg/disk/controllerserver.go
+++ b/pkg/disk/controllerserver.go
@@ -643,8 +643,9 @@ func (cs *controllerServer) ControllerExpandVolume(ctx context.Context, req *csi
 	klog.Infof("ControllerExpandVolume:: Starting expand disk with: %v", req)
 
 	// check resize conditions
-	volSizeBytes := int64(req.GetCapacityRange().GetRequiredBytes())
-	requestGB := int((volSizeBytes + 1024*1024*1024 - 1) / (1024 * 1024 * 1024))
+	volSizeBytes := req.GetCapacityRange().GetRequiredBytes()
+	const gi = 1 << 30
+	requestGB := int((volSizeBytes-1)/gi + 1)
 	diskID := req.VolumeId
 
 	disk, err := findDiskByID(diskID, cs.ecs)
@@ -658,11 +659,11 @@ func (cs *controllerServer) ControllerExpandVolume(ctx context.Context, req *csi
 	}
 	if requestGB == disk.Size {
 		klog.Infof("ControllerExpandVolume:: expect size is same with current: %s, size: %dGi", req.VolumeId, requestGB)
-		return &csi.ControllerExpandVolumeResponse{CapacityBytes: volSizeBytes, NodeExpansionRequired: true}, nil
+		return &csi.ControllerExpandVolumeResponse{CapacityBytes: int64(disk.Size) * gi, NodeExpansionRequired: true}, nil
 	}
 	if requestGB < disk.Size {
 		klog.Infof("ControllerExpandVolume:: expect size is less than current: %d, expected: %d, disk: %s", disk.Size, requestGB, req.VolumeId)
-		return &csi.ControllerExpandVolumeResponse{CapacityBytes: volSizeBytes, NodeExpansionRequired: true}, nil
+		return &csi.ControllerExpandVolumeResponse{CapacityBytes: int64(disk.Size) * gi, NodeExpansionRequired: true}, nil
 	}
 
 	// do resize
@@ -684,13 +685,13 @@ func (cs *controllerServer) ControllerExpandVolume(ctx context.Context, req *csi
 		klog.Infof("ControllerExpandVolume:: find disk failed with error: %+v", err)
 		return nil, status.Errorf(codes.Internal, "ControllerExpandVolume:: find disk failed with error: %+v", err)
 	}
-	if requestGB != checkDisk.Size {
+	if checkDisk.Size < requestGB {
 		klog.Infof("ControllerExpandVolume:: resize disk err with excepted size: %vGB, actual size: %vGB", requestGB, checkDisk.Size)
 		return nil, status.Errorf(codes.Internal, "resize disk err with excepted size: %vGB, actual size: %vGB", requestGB, checkDisk.Size)
 	}
 
 	klog.Infof("ControllerExpandVolume:: Success to resize volume: %s from %dG to %dG, RequestID: %s", req.VolumeId, disk.Size, requestGB, response.RequestId)
-	return &csi.ControllerExpandVolumeResponse{CapacityBytes: volSizeBytes, NodeExpansionRequired: true}, nil
+	return &csi.ControllerExpandVolumeResponse{CapacityBytes: int64(checkDisk.Size) * gi, NodeExpansionRequired: true}, nil
 }
 
 func newListSnapshotsResponse(snapshots []ecs.Snapshot, nextToken string) (*csi.ListSnapshotsResponse, error) {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

`ControllerExpandVolume` previously returned the raw requested bytes (`volSizeBytes`) as `CapacityBytes`, even though ECS disks are always sized in whole GiB. The CO therefore received a sub-GiB value that does not match the real provisioned capacity, which can confuse node-side filesystem expansion.

This PR reports the true disk size from the ECS API in every return path: `disk.Size` for the no-op (equal/shrink) paths and `checkDisk.Size` after a resize. It also relaxes the post-resize verification to only fail when the actual size is *smaller* than requested (`checkDisk.Size < requestGB`); ECS may round up beyond the requested size, and a larger disk still satisfies the CSI capacity contract. The GiB ceiling computation is also simplified with a named const.

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

The shrink path (`requestGB < disk.Size`) is a no-op — the disk is never actually shrunk — so reporting `disk.Size` (the real, larger capacity) is correct rather than the smaller requested value.

#### Does this PR introduce a user-facing change?

```release-note
disk: ControllerExpandVolume now reports the actual provisioned disk capacity (in whole GiB) instead of the raw requested bytes, and only fails the post-resize check when the disk is smaller than requested.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
```