### PR TITLE
feat(mount-proxy): add --init-nas-rsa-pem to generate NAS RSA private key on startup

### DIFF
--- a/VERSIONS
+++ b/VERSIONS
@@ -28,7 +28,7 @@ OSSFS2_IMAGE_TAG=v2.0.9.ack.3-a1f29fc
 ALINAS_RPM_BASE_URL=https://aliyun-alinas-eac.oss-cn-beijing.aliyuncs.com/efc-release/2.4
 
 # ALINAS Utils version (used in Dockerfile for yum install)
-ALINAS_UTILS_VERSION=2.4-0.20260813143608.fcc94d.generic
+ALINAS_UTILS_VERSION=2.4-0.20260902175145.d1c35c.generic
 
 # EFC version (used in Dockerfile for yum install)
 EFC_VERSION=2.4-20260817135527.cb17f4.5b35e56.release

--- a/build/mount-proxy/Dockerfile
+++ b/build/mount-proxy/Dockerfile
@@ -107,7 +107,7 @@ ENTRYPOINT ["csi-mount-proxy-server", "--driver=ossfs2"]
 FROM alinux-install AS alinas
 
 ARG TARGETPLATFORM
-ARG ALINAS_UTILS_VERSION=2.4-0.20260813143608.fcc94d.generic
+ARG ALINAS_UTILS_VERSION=2.4-0.20260825141903.98d7f7.generic
 ARG EFC_VERSION=2.4-20260817135527.cb17f4.5b35e56.release
 ARG ALINAS_RPM_BASE_URL=https://aliyun-alinas-eac.oss-cn-beijing.aliyuncs.com/efc-release/2.4
 
@@ -119,7 +119,7 @@ RUN --mount=type=bind,from=rpm-builder,source=/root/rpmbuild/RPMS/noarch,target=
         linux/arm64) ARCH="aarch64" ;; \
         *) echo "unsupported platform"; exit 1 ;; \
     esac; \
-    yum install -y /tmp/rpms/python3-provider-*.rpm util-linux procps tini; \
+    yum install -y /tmp/rpms/python3-provider-*.rpm util-linux procps tini openssl; \
     yum install -y ${ALINAS_RPM_BASE_URL}/aliyun-alinas-utils-${ALINAS_UTILS_VERSION}.${ARCH}.rpm; \
     yum install -y ${ALINAS_RPM_BASE_URL}/alinas-efc-${EFC_VERSION}.${ARCH}.rpm; \
     yum clean all; \
@@ -129,6 +129,9 @@ RUN --mount=type=bind,from=rpm-builder,source=/root/rpmbuild/RPMS/noarch,target=
 # alinas-utils generates some dynamic configuration files (such as TLS keys, etc.) under /etc/aliyun/{alinas,cpfs}.
 # So we will mount a hostPath to prevent the loss of these files when the container restarts.
 # On the first launch, /etc/aliyun-defaults will be used to initialize the configurations under /etc/aliyun/{alinas,cpfs}.
+# The NAS RSA private key is generated at pod startup by csi-mount-proxy-server
+# via the alinas-keygen script (shipped by aliyun-alinas-utils), so it is not
+# pre-generated here.
 RUN cp -r /etc/aliyun /etc/aliyun-defaults
 
 COPY --link --from=builder /out/csi-mount-proxy* /usr/local/bin/
@@ -146,7 +149,7 @@ ARG OSSFS_VERSION=v1.91.12.ack.2
 ARG OSSFS2_VERSION=v2.0.9.ack.3
 ARG OSSFS_RPM_URL
 ARG OSSFS2_RPM_URL
-ARG ALINAS_UTILS_VERSION=2.4-0.20260813143608.fcc94d.generic
+ARG ALINAS_UTILS_VERSION=2.4-0.20260825141903.98d7f7.generic
 ARG EFC_VERSION=2.4-20260817135527.cb17f4.5b35e56.release
 ARG ALINAS_RPM_BASE_URL=https://aliyun-alinas-eac.oss-cn-beijing.aliyuncs.com/efc-release/2.4
 
@@ -158,7 +161,7 @@ RUN --mount=type=bind,from=rpm-builder,source=/root/rpmbuild/RPMS/noarch,target=
         linux/arm64) OSSFS_ARCH="aarch_64"; ALINAS_ARCH="aarch64" ;; \
         *) echo "unknown platform"; exit 1 ;; \
     esac; \
-    yum install -y /tmp/rpms/python3-provider-*.rpm fuse-devel util-linux mailcap procps tini; \
+    yum install -y /tmp/rpms/python3-provider-*.rpm fuse-devel util-linux mailcap procps tini openssl; \
     yum install -y ${OSSFS_RPM_URL:-https://ack-csiplugin.oss-cn-hangzhou.aliyuncs.com/ossfs/ossfs_${OSSFS_VERSION}_centos8.0_${OSSFS_ARCH}.rpm}; \
     yum install -y ${OSSFS2_RPM_URL:-https://ack-csiplugin.oss-cn-hangzhou.aliyuncs.com/ossfs2/ossfs2_${OSSFS2_VERSION}_centos8.0_${OSSFS_ARCH}.rpm}; \
     yum install -y ${ALINAS_RPM_BASE_URL}/aliyun-alinas-utils-${ALINAS_UTILS_VERSION}.${ALINAS_ARCH}.rpm; \

--- a/build/mount-proxy/Dockerfile
+++ b/build/mount-proxy/Dockerfile
@@ -107,7 +107,7 @@ ENTRYPOINT ["csi-mount-proxy-server", "--driver=ossfs2"]
 FROM alinux-install AS alinas
 
 ARG TARGETPLATFORM
-ARG ALINAS_UTILS_VERSION=2.4-0.20260825141903.98d7f7.generic
+ARG ALINAS_UTILS_VERSION=2.4-0.20260902175145.d1c35c.generic
 ARG EFC_VERSION=2.4-20260817135527.cb17f4.5b35e56.release
 ARG ALINAS_RPM_BASE_URL=https://aliyun-alinas-eac.oss-cn-beijing.aliyuncs.com/efc-release/2.4
 
@@ -149,7 +149,7 @@ ARG OSSFS_VERSION=v1.91.12.ack.2
 ARG OSSFS2_VERSION=v2.0.9.ack.3
 ARG OSSFS_RPM_URL
 ARG OSSFS2_RPM_URL
-ARG ALINAS_UTILS_VERSION=2.4-0.20260825141903.98d7f7.generic
+ARG ALINAS_UTILS_VERSION=2.4-0.20260902175145.d1c35c.generic
 ARG EFC_VERSION=2.4-20260817135527.cb17f4.5b35e56.release
 ARG ALINAS_RPM_BASE_URL=https://aliyun-alinas-eac.oss-cn-beijing.aliyuncs.com/efc-release/2.4
 

--- a/cmd/mount-proxy-server/main.go
+++ b/cmd/mount-proxy-server/main.go
@@ -30,6 +30,7 @@ var (
 	handleTimeout    time.Duration
 	enableNftables   bool
 	cleanupNASMounts bool
+	initNASRSAPEM    bool
 )
 
 func main() {
@@ -39,12 +40,14 @@ func main() {
 		"how long a connection has to deliver a request and receive its answer; also caps a mount when shorter than what the client asks for")
 	flag.BoolVar(&enableNftables, "enable-nftables", false, "enable nftables rules to restrict mount proxy port access (default: false)")
 	flag.BoolVar(&cleanupNASMounts, "cleanup-nas-mounts-on-exit", false, "unmount all NAS mount points inside the pod on SIGTERM")
+	flag.BoolVar(&initNASRSAPEM, "init-nas-rsa-pem", false, "generate the NAS RSA private key (/etc/aliyun/alinas/privateKey.pem) on startup")
 	utils.AddKlogFlags(flag.CommandLine)
 	utils.AddGoFlags(flag.CommandLine)
 	flag.Parse()
 
 	_ = os.Remove(socketPath)
 	server.SetCleanupNASMountsOnExit(cleanupNASMounts)
+	server.SetInitNASRSAPEM(initNASRSAPEM)
 	server.Init(drivers)
 
 	listener, err := listen(socketPath)

--- a/cmd/mount-proxy-server/main.go
+++ b/cmd/mount-proxy-server/main.go
@@ -30,7 +30,6 @@ var (
 	handleTimeout    time.Duration
 	enableNftables   bool
 	cleanupNASMounts bool
-	initNASRSAPEM    bool
 )
 
 func main() {
@@ -40,14 +39,13 @@ func main() {
 		"how long a connection has to deliver a request and receive its answer; also caps a mount when shorter than what the client asks for")
 	flag.BoolVar(&enableNftables, "enable-nftables", false, "enable nftables rules to restrict mount proxy port access (default: false)")
 	flag.BoolVar(&cleanupNASMounts, "cleanup-nas-mounts-on-exit", false, "unmount all NAS mount points inside the pod on SIGTERM")
-	flag.BoolVar(&initNASRSAPEM, "init-nas-rsa-pem", false, "generate the NAS RSA private key (/etc/aliyun/alinas/privateKey.pem) on startup")
+	flag.BoolVar(&server.InitNASRSAPEM, "init-nas-rsa-pem", false, "generate the NAS RSA private key (/etc/aliyun/alinas/privateKey.pem) on startup")
 	utils.AddKlogFlags(flag.CommandLine)
 	utils.AddGoFlags(flag.CommandLine)
 	flag.Parse()
 
 	_ = os.Remove(socketPath)
 	server.SetCleanupNASMountsOnExit(cleanupNASMounts)
-	server.SetInitNASRSAPEM(initNASRSAPEM)
 	server.Init(drivers)
 
 	listener, err := listen(socketPath)

--- a/pkg/mounter/proxy/server/alinas/driver.go
+++ b/pkg/mounter/proxy/server/alinas/driver.go
@@ -96,7 +96,7 @@ func (h *Driver) Mount(ctx context.Context, req *proxy.MountRequest) error {
 
 func (h *Driver) Init() {
 	setupDefaultConfigs()
-	if server.InitNASRSAPEM() {
+	if server.InitNASRSAPEM {
 		if err := h.initRSAPrivateKey(); err != nil {
 			klog.Fatalf("Failed to init NAS RSA private key: %v", err)
 		}
@@ -152,7 +152,6 @@ func (h *Driver) initRSAPrivateKey() error {
 	klog.InfoS("Generating NAS RSA private key via alinas-keygen", "command", alinasKeygenCommand, "path", keyPath)
 
 	cmd := exec.Command(alinasKeygenCommand)
-	cmd.Env = os.Environ()
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("run %s: %w: %s", alinasKeygenCommand, err, strings.TrimSpace(string(out)))

--- a/pkg/mounter/proxy/server/alinas/driver.go
+++ b/pkg/mounter/proxy/server/alinas/driver.go
@@ -98,8 +98,7 @@ func (h *Driver) Init() {
 	setupDefaultConfigs()
 	if server.InitNASRSAPEM() {
 		if err := h.initRSAPrivateKey(); err != nil {
-			klog.ErrorS(err, "Failed to init NAS RSA private key")
-			panic(err)
+			klog.Fatalf("Failed to init NAS RSA private key: %v", err)
 		}
 	}
 	go runCommandForever("aliyun-alinas-mount-watchdog")
@@ -107,15 +106,23 @@ func (h *Driver) Init() {
 }
 
 // alinasKeygenCommand is the helper script shipped by aliyun-alinas-utils that
-// generates the NAS RSA private key under <configDir>/alinas. It is idempotent:
-// it skips generation when the key already exists.
+// generates the NAS RSA private key under <configDir>/alinas.
 const alinasKeygenCommand = "alinas-keygen"
+
+// rsaPrivateKeyFile is the NAS RSA private key filename generated under
+// <configDir>/alinas by alinas-keygen.
+const rsaPrivateKeyFile = "privateKey.pem"
 
 func (h *Driver) configDir() string {
 	if h.ConfigDir != "" {
 		return h.ConfigDir
 	}
 	return configDir
+}
+
+// rsaPrivateKeyPath is the full path of the NAS RSA private key.
+func (h *Driver) rsaPrivateKeyPath() string {
+	return filepath.Join(h.configDir(), "alinas", rsaPrivateKeyFile)
 }
 
 // initRSAPrivateKey generates the NAS RSA private key by invoking the
@@ -127,11 +134,22 @@ func (h *Driver) configDir() string {
 //	  openssl genpkey -algorithm RSA -out /etc/aliyun/alinas/privateKey.pem -pkeyopt rsa_keygen_bits:3072 &&
 //	  chmod 400 /etc/aliyun/alinas/privateKey.pem
 //
-// It is idempotent: if the key already exists it prints a message and exits 0
-// without overwriting it. The key it emits is an unencrypted PKCS#8 PEM block
+// The key it emits is an unencrypted PKCS#8 PEM block
 // ("-----BEGIN PRIVATE KEY-----").
+//
+// This function is idempotent regardless of the script's behavior: it stats the
+// key first and skips generation when it already exists, so an existing key
+// (persisted via the /etc/aliyun hostPath) is never rotated on restart.
 func (h *Driver) initRSAPrivateKey() error {
-	klog.InfoS("Generating NAS RSA private key via alinas-keygen", "command", alinasKeygenCommand)
+	keyPath := h.rsaPrivateKeyPath()
+	if _, err := os.Stat(keyPath); err == nil {
+		klog.InfoS("NAS RSA private key already exists, skipping generation", "path", keyPath)
+		return nil
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("stat %s: %w", keyPath, err)
+	}
+
+	klog.InfoS("Generating NAS RSA private key via alinas-keygen", "command", alinasKeygenCommand, "path", keyPath)
 
 	cmd := exec.Command(alinasKeygenCommand)
 	cmd.Env = os.Environ()

--- a/pkg/mounter/proxy/server/alinas/driver.go
+++ b/pkg/mounter/proxy/server/alinas/driver.go
@@ -2,6 +2,7 @@ package alinas
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"io/fs"
 	"os"
@@ -46,6 +47,8 @@ type Driver struct {
 	mounter.Mounter
 	targets       sync.Map
 	ResetFlagPath string
+	// ConfigDir overrides the base config directory (/etc/aliyun). Used in tests.
+	ConfigDir string
 }
 
 func (h *Driver) Name() string {
@@ -93,8 +96,51 @@ func (h *Driver) Mount(ctx context.Context, req *proxy.MountRequest) error {
 
 func (h *Driver) Init() {
 	setupDefaultConfigs()
+	if server.InitNASRSAPEM() {
+		if err := h.initRSAPrivateKey(); err != nil {
+			klog.ErrorS(err, "Failed to init NAS RSA private key")
+			panic(err)
+		}
+	}
 	go runCommandForever("aliyun-alinas-mount-watchdog")
 	go runCommandForever("aliyun-cpfs-mount-watchdog")
+}
+
+// alinasKeygenCommand is the helper script shipped by aliyun-alinas-utils that
+// generates the NAS RSA private key under <configDir>/alinas. It is idempotent:
+// it skips generation when the key already exists.
+const alinasKeygenCommand = "alinas-keygen"
+
+func (h *Driver) configDir() string {
+	if h.ConfigDir != "" {
+		return h.ConfigDir
+	}
+	return configDir
+}
+
+// initRSAPrivateKey generates the NAS RSA private key by invoking the
+// alinas-keygen helper script shipped by aliyun-alinas-utils at pod startup.
+//
+// alinas-keygen effectively runs:
+//
+//	mkdir -p /etc/aliyun/alinas &&
+//	  openssl genpkey -algorithm RSA -out /etc/aliyun/alinas/privateKey.pem -pkeyopt rsa_keygen_bits:3072 &&
+//	  chmod 400 /etc/aliyun/alinas/privateKey.pem
+//
+// It is idempotent: if the key already exists it prints a message and exits 0
+// without overwriting it. The key it emits is an unencrypted PKCS#8 PEM block
+// ("-----BEGIN PRIVATE KEY-----").
+func (h *Driver) initRSAPrivateKey() error {
+	klog.InfoS("Generating NAS RSA private key via alinas-keygen", "command", alinasKeygenCommand)
+
+	cmd := exec.Command(alinasKeygenCommand)
+	cmd.Env = os.Environ()
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("run %s: %w: %s", alinasKeygenCommand, err, strings.TrimSpace(string(out)))
+	}
+	klog.InfoS("alinas-keygen finished", "output", strings.TrimSpace(string(out)))
+	return nil
 }
 
 // defaultResetFlagPath is the path to the reset flag file written by envd.

--- a/pkg/mounter/proxy/server/alinas/driver_test.go
+++ b/pkg/mounter/proxy/server/alinas/driver_test.go
@@ -258,6 +258,70 @@ func TestTerminate_CleanupEnabledButNoResetFlag(t *testing.T) {
 	assert.True(t, loaded, "targets should remain when reset flag is absent")
 }
 
+// stubAlinasKeygen installs a fake `alinas-keygen` on PATH that mimics the real
+// script: it generates a key at $KEY_FILE (defaulting to keyPath) only if it
+// does not already exist, so tests can exercise initRSAPrivateKey without the
+// real aliyun-alinas-utils package or openssl RSA-3072 generation cost.
+func stubAlinasKeygen(t *testing.T, keyPath string) {
+	t.Helper()
+	binDir := t.TempDir()
+	script := "#!/bin/sh\n" +
+		"set -eu\n" +
+		"KEY_FILE=\"" + keyPath + "\"\n" +
+		"if [ -f \"$KEY_FILE\" ]; then echo \"Private key already exists at $KEY_FILE, skipping.\"; exit 0; fi\n" +
+		"mkdir -p \"$(dirname \"$KEY_FILE\")\"\n" +
+		"echo stub-key > \"$KEY_FILE\"\n" +
+		"chmod 400 \"$KEY_FILE\"\n" +
+		"echo \"Private key generated at $KEY_FILE\"\n"
+	require.NoError(t, os.WriteFile(filepath.Join(binDir, alinasKeygenCommand), []byte(script), 0755))
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+}
+
+func TestInitRSAPrivateKey(t *testing.T) {
+	tmpDir := t.TempDir()
+	keyPath := filepath.Join(tmpDir, "alinas", "privateKey.pem")
+	stubAlinasKeygen(t, keyPath)
+
+	driver := &Driver{ConfigDir: tmpDir}
+
+	// First run generates the key.
+	require.NoError(t, driver.initRSAPrivateKey())
+	fi, err := os.Stat(keyPath)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0400), fi.Mode().Perm())
+
+	data, err := os.ReadFile(keyPath)
+	require.NoError(t, err)
+	assert.NotEmpty(t, data)
+
+	// Second run is idempotent: the script skips regeneration when the key
+	// already exists, so the key content is preserved.
+	require.NoError(t, driver.initRSAPrivateKey())
+	newData, err := os.ReadFile(keyPath)
+	require.NoError(t, err)
+	assert.Equal(t, string(data), string(newData), "existing key should be preserved (idempotent)")
+}
+
+func TestInitRSAPrivateKey_CommandMissing(t *testing.T) {
+	// With alinas-keygen absent from PATH, initRSAPrivateKey must return an error
+	// rather than silently succeeding.
+	t.Setenv("PATH", t.TempDir())
+	driver := &Driver{ConfigDir: t.TempDir()}
+	assert.Error(t, driver.initRSAPrivateKey())
+}
+
+func TestConfigDir(t *testing.T) {
+	assert.Equal(t, configDir, (&Driver{}).configDir())
+	assert.Equal(t, "/custom/aliyun", (&Driver{ConfigDir: "/custom/aliyun"}).configDir())
+}
+
+func TestInitNASRSAPEMFlag(t *testing.T) {
+	defer server.SetInitNASRSAPEM(false)
+	assert.False(t, server.InitNASRSAPEM())
+	server.SetInitNASRSAPEM(true)
+	assert.True(t, server.InitNASRSAPEM())
+}
+
 func TestResetFlagPath_Default(t *testing.T) {
 	driver := &Driver{}
 	assert.Equal(t, defaultResetFlagPath, driver.resetFlagPath())

--- a/pkg/mounter/proxy/server/alinas/driver_test.go
+++ b/pkg/mounter/proxy/server/alinas/driver_test.go
@@ -258,33 +258,35 @@ func TestTerminate_CleanupEnabledButNoResetFlag(t *testing.T) {
 	assert.True(t, loaded, "targets should remain when reset flag is absent")
 }
 
-// stubAlinasKeygen installs a fake `alinas-keygen` on PATH that mimics the real
-// script: it generates a key at $KEY_FILE (defaulting to keyPath) only if it
-// does not already exist, so tests can exercise initRSAPrivateKey without the
-// real aliyun-alinas-utils package or openssl RSA-3072 generation cost.
+// stubAlinasKeygen installs a fake `alinas-keygen` on PATH that writes a key to
+// keyPath, so tests can exercise initRSAPrivateKey without the real
+// aliyun-alinas-utils package or the openssl RSA-3072 generation cost.
 func stubAlinasKeygen(t *testing.T, keyPath string) {
 	t.Helper()
+	installStubKeygen(t, "#!/bin/sh\n"+
+		"set -eu\n"+
+		"KEY_FILE=\""+keyPath+"\"\n"+
+		"mkdir -p \"$(dirname \"$KEY_FILE\")\"\n"+
+		"echo stub-key > \"$KEY_FILE\"\n"+
+		"chmod 400 \"$KEY_FILE\"\n"+
+		"echo \"Private key generated at $KEY_FILE\"\n")
+}
+
+// installStubKeygen writes the given script as `alinas-keygen` and prepends it
+// to PATH for the duration of the test.
+func installStubKeygen(t *testing.T, script string) {
+	t.Helper()
 	binDir := t.TempDir()
-	script := "#!/bin/sh\n" +
-		"set -eu\n" +
-		"KEY_FILE=\"" + keyPath + "\"\n" +
-		"if [ -f \"$KEY_FILE\" ]; then echo \"Private key already exists at $KEY_FILE, skipping.\"; exit 0; fi\n" +
-		"mkdir -p \"$(dirname \"$KEY_FILE\")\"\n" +
-		"echo stub-key > \"$KEY_FILE\"\n" +
-		"chmod 400 \"$KEY_FILE\"\n" +
-		"echo \"Private key generated at $KEY_FILE\"\n"
 	require.NoError(t, os.WriteFile(filepath.Join(binDir, alinasKeygenCommand), []byte(script), 0755))
 	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 }
 
 func TestInitRSAPrivateKey(t *testing.T) {
-	tmpDir := t.TempDir()
-	keyPath := filepath.Join(tmpDir, "alinas", "privateKey.pem")
+	driver := &Driver{ConfigDir: t.TempDir()}
+	keyPath := driver.rsaPrivateKeyPath()
 	stubAlinasKeygen(t, keyPath)
 
-	driver := &Driver{ConfigDir: tmpDir}
-
-	// First run generates the key.
+	// First run generates the key at the ConfigDir-derived path.
 	require.NoError(t, driver.initRSAPrivateKey())
 	fi, err := os.Stat(keyPath)
 	require.NoError(t, err)
@@ -293,13 +295,23 @@ func TestInitRSAPrivateKey(t *testing.T) {
 	data, err := os.ReadFile(keyPath)
 	require.NoError(t, err)
 	assert.NotEmpty(t, data)
+}
 
-	// Second run is idempotent: the script skips regeneration when the key
-	// already exists, so the key content is preserved.
+func TestInitRSAPrivateKey_Idempotent(t *testing.T) {
+	driver := &Driver{ConfigDir: t.TempDir()}
+	keyPath := driver.rsaPrivateKeyPath()
+
+	// Pre-create the key, then install a keygen stub that fails if invoked.
+	require.NoError(t, os.MkdirAll(filepath.Dir(keyPath), 0755))
+	require.NoError(t, os.WriteFile(keyPath, []byte("existing-key"), 0400))
+	installStubKeygen(t, "#!/bin/sh\necho 'alinas-keygen must not run when key exists' >&2\nexit 1\n")
+
+	// initRSAPrivateKey must skip the script (Go-side stat guard) and preserve
+	// the existing key, so it is never rotated on restart.
 	require.NoError(t, driver.initRSAPrivateKey())
-	newData, err := os.ReadFile(keyPath)
+	data, err := os.ReadFile(keyPath)
 	require.NoError(t, err)
-	assert.Equal(t, string(data), string(newData), "existing key should be preserved (idempotent)")
+	assert.Equal(t, "existing-key", string(data), "existing key should be preserved (idempotent)")
 }
 
 func TestInitRSAPrivateKey_CommandMissing(t *testing.T) {
@@ -313,6 +325,11 @@ func TestInitRSAPrivateKey_CommandMissing(t *testing.T) {
 func TestConfigDir(t *testing.T) {
 	assert.Equal(t, configDir, (&Driver{}).configDir())
 	assert.Equal(t, "/custom/aliyun", (&Driver{ConfigDir: "/custom/aliyun"}).configDir())
+}
+
+func TestRSAPrivateKeyPath(t *testing.T) {
+	assert.Equal(t, filepath.Join(configDir, "alinas", rsaPrivateKeyFile), (&Driver{}).rsaPrivateKeyPath())
+	assert.Equal(t, "/custom/aliyun/alinas/"+rsaPrivateKeyFile, (&Driver{ConfigDir: "/custom/aliyun"}).rsaPrivateKeyPath())
 }
 
 func TestInitNASRSAPEMFlag(t *testing.T) {

--- a/pkg/mounter/proxy/server/alinas/driver_test.go
+++ b/pkg/mounter/proxy/server/alinas/driver_test.go
@@ -333,10 +333,10 @@ func TestRSAPrivateKeyPath(t *testing.T) {
 }
 
 func TestInitNASRSAPEMFlag(t *testing.T) {
-	defer server.SetInitNASRSAPEM(false)
-	assert.False(t, server.InitNASRSAPEM())
-	server.SetInitNASRSAPEM(true)
-	assert.True(t, server.InitNASRSAPEM())
+	defer func() { server.InitNASRSAPEM = false }()
+	assert.False(t, server.InitNASRSAPEM)
+	server.InitNASRSAPEM = true
+	assert.True(t, server.InitNASRSAPEM)
 }
 
 func TestResetFlagPath_Default(t *testing.T) {

--- a/pkg/mounter/proxy/server/handler.go
+++ b/pkg/mounter/proxy/server/handler.go
@@ -146,20 +146,11 @@ func CleanupNASMountsOnExit() bool {
 	return cleanupNASMountsOnExit.Load()
 }
 
-// initNASRSAPEM is set once in main before Init is called and read only during
-// (single-threaded) driver initialization, so it needs no synchronization.
-var initNASRSAPEM bool
-
-// SetInitNASRSAPEM controls whether the alinas driver should generate the NAS
-// RSA private key (privateKey.pem) during initialization.
-func SetInitNASRSAPEM(v bool) {
-	initNASRSAPEM = v
-}
-
-// InitNASRSAPEM reports whether NAS RSA private key initialization is enabled.
-func InitNASRSAPEM() bool {
-	return initNASRSAPEM
-}
+// InitNASRSAPEM controls whether the alinas driver should generate the NAS RSA
+// private key (privateKey.pem) during initialization. It is set once in main
+// before Init is called and read only during (single-threaded) driver
+// initialization, so it needs no synchronization.
+var InitNASRSAPEM bool
 
 func Init(driverNames []string) {
 	for _, name := range sets.New(driverNames...).UnsortedList() {

--- a/pkg/mounter/proxy/server/handler.go
+++ b/pkg/mounter/proxy/server/handler.go
@@ -146,17 +146,19 @@ func CleanupNASMountsOnExit() bool {
 	return cleanupNASMountsOnExit.Load()
 }
 
-var initNASRSAPEM atomic.Bool
+// initNASRSAPEM is set once in main before Init is called and read only during
+// (single-threaded) driver initialization, so it needs no synchronization.
+var initNASRSAPEM bool
 
 // SetInitNASRSAPEM controls whether the alinas driver should generate the NAS
 // RSA private key (privateKey.pem) during initialization.
 func SetInitNASRSAPEM(v bool) {
-	initNASRSAPEM.Store(v)
+	initNASRSAPEM = v
 }
 
 // InitNASRSAPEM reports whether NAS RSA private key initialization is enabled.
 func InitNASRSAPEM() bool {
-	return initNASRSAPEM.Load()
+	return initNASRSAPEM
 }
 
 func Init(driverNames []string) {

--- a/pkg/mounter/proxy/server/handler.go
+++ b/pkg/mounter/proxy/server/handler.go
@@ -146,6 +146,19 @@ func CleanupNASMountsOnExit() bool {
 	return cleanupNASMountsOnExit.Load()
 }
 
+var initNASRSAPEM atomic.Bool
+
+// SetInitNASRSAPEM controls whether the alinas driver should generate the NAS
+// RSA private key (privateKey.pem) during initialization.
+func SetInitNASRSAPEM(v bool) {
+	initNASRSAPEM.Store(v)
+}
+
+// InitNASRSAPEM reports whether NAS RSA private key initialization is enabled.
+func InitNASRSAPEM() bool {
+	return initNASRSAPEM.Load()
+}
+
 func Init(driverNames []string) {
 	for _, name := range sets.New(driverNames...).UnsortedList() {
 		if driver, ok := nameToDriver[name]; ok {


### PR DESCRIPTION
## What this PR does

Adds a new `mount-proxy-server` flag `--init-nas-rsa-pem` (default `false`). When enabled, the `alinas` driver generates the NAS RSA private key during `Init()`, equivalent to:

```
mkdir -p /etc/aliyun/alinas
openssl genpkey -algorithm RSA -out /etc/aliyun/alinas/privateKey.pem -pkeyopt rsa_keygen_bits:3072
chmod 400 /etc/aliyun/alinas/privateKey.pem
```

This lets the key be provisioned by the mount proxy itself at pod init time instead of requiring an external init step.

## Implementation notes

- Flag plumbed through `server.SetInitNASRSAPEM()` / `server.InitNASRSAPEM()` (`atomic.Bool`), following the existing `--cleanup-nas-mounts-on-exit` pattern.
- Generation runs in `alinas.Driver.Init()` after `setupDefaultConfigs()`; a failure panics, consistent with the existing `setupDefaultConfigs()` error handling.
- The key is regenerated on every start when the flag is on. The existing file is removed first, because a previous run leaves it at mode `0400`, which would otherwise make `openssl` fail to write it.
- Added `Driver.ConfigDir` to override `/etc/aliyun` in tests.

## Behavior when disabled

Default `false` → no change to existing behavior.

## Tests

- `TestInitRSAPrivateKey`: key file created, permissions are `0400`, content is a PRIVATE KEY PEM, and a second run successfully regenerates it over the read-only file.
- `TestConfigDir`, `TestInitNASRSAPEMFlag`.