### PR TITLE
fix(mount-proxy): stop relying on the process trust store for AgentIdentity

### DIFF
--- a/pkg/mounter/jwtauth/jwtauth.go
+++ b/pkg/mounter/jwtauth/jwtauth.go
@@ -16,6 +16,8 @@ import (
 	"net/http"
 	"os"
 	"time"
+
+	"k8s.io/klog/v2"
 )
 
 const (
@@ -79,10 +81,16 @@ type credentialResponse struct {
 }
 
 // buildHTTPClient builds the HTTP client used to exchange the jwtauth token
-// for STS credentials. This is a security-sensitive channel (it carries
-// AK/SK), so TLS verification is never disabled: when a CA file is configured
-// it must be readable and parsable, otherwise it fails; when no CA file is
-// configured the system root pool is used (tls.Config.RootCAs == nil).
+// for STS credentials. A configured CA file must be readable and parsable,
+// otherwise it fails.
+//
+// Without a CA file, verification is skipped rather than deferred to the system
+// root pool. The AgentIdentity endpoint is an in-cluster service holding a
+// private certificate that no public root signs, so the system pool can only
+// accept it while something injects that private CA into the process-wide trust
+// store — and such an injection also hides every public root from the same
+// process, breaking unrelated OSS connections. Skipping verification keeps the
+// two concerns apart, matching how ossfs treats an empty agent_identity_ca_file.
 func buildHTTPClient(caFile string) (*http.Client, error) {
 	tlsConfig := &tls.Config{}
 	if caFile != "" {
@@ -95,6 +103,9 @@ func buildHTTPClient(caFile string) (*http.Client, error) {
 			return nil, fmt.Errorf("parse CA file %s: no valid certificate found", caFile)
 		}
 		tlsConfig.RootCAs = pool
+	} else {
+		klog.Warningf("no agent identity CA file configured, skipping TLS verification for the AgentIdentity endpoint")
+		tlsConfig.InsecureSkipVerify = true
 	}
 	return &http.Client{
 		Timeout:   httpTimeout,

--- a/pkg/mounter/jwtauth/refresher_test.go
+++ b/pkg/mounter/jwtauth/refresher_test.go
@@ -602,12 +602,13 @@ func generateTestCA(t *testing.T) []byte {
 }
 
 func TestBuildHTTPClientTLS(t *testing.T) {
-	t.Run("no CA uses system root pool", func(t *testing.T) {
+	t.Run("no CA skips verification instead of using the system root pool", func(t *testing.T) {
 		client, err := buildHTTPClient("")
 		require.NoError(t, err)
 		tr := client.Transport.(*http.Transport)
-		assert.Nil(t, tr.TLSClientConfig.RootCAs, "system root pool expected (RootCAs nil)")
-		assert.False(t, tr.TLSClientConfig.InsecureSkipVerify, "TLS verification must never be disabled")
+		assert.Nil(t, tr.TLSClientConfig.RootCAs, "no root pool expected (RootCAs nil)")
+		assert.True(t, tr.TLSClientConfig.InsecureSkipVerify,
+			"the AgentIdentity endpoint is private, so without a CA the system pool cannot verify it")
 	})
 
 	t.Run("valid CA file is loaded", func(t *testing.T) {

--- a/pkg/mounter/proxy/server/ossfs/driver.go
+++ b/pkg/mounter/proxy/server/ossfs/driver.go
@@ -89,9 +89,13 @@ func (h *Driver) ApplyOptionDefaults(options []string) []string {
 	var appends []string
 
 	// agent_identity_ca_file: only appended if configured and the file is readable.
+	// An unreadable path is left out so ossfs falls back to its own default of an
+	// empty value, which skips verification for the AgentIdentity endpoint alone.
 	if caPath := agentidentity.GetCAFilePath(); caPath != "" {
 		if unix.Access(caPath, unix.R_OK) == nil {
 			appends = append(appends, fmt.Sprintf("agent_identity_ca_file=%s", caPath))
+		} else {
+			klog.Warningf("agent identity CA file %q is not readable, ossfs will skip TLS verification for the AgentIdentity endpoint", caPath)
 		}
 	}
 

--- a/pkg/mounter/proxy/server/ossfs2/driver.go
+++ b/pkg/mounter/proxy/server/ossfs2/driver.go
@@ -89,9 +89,13 @@ func (h *Driver) ApplyOptionDefaults(options []string) []string {
 	var appends []string
 
 	// agent_identity_ca_file: only appended if configured and the file is readable.
+	// An unreadable path is left out so ossfs falls back to its own default of an
+	// empty value, which skips verification for the AgentIdentity endpoint alone.
 	if caPath := agentidentity.GetCAFilePath(); caPath != "" {
 		if unix.Access(caPath, unix.R_OK) == nil {
 			appends = append(appends, fmt.Sprintf("agent_identity_ca_file=%s", caPath))
+		} else {
+			klog.Warningf("agent identity CA file %q is not readable, ossfs2 will skip TLS verification for the AgentIdentity endpoint", caPath)
 		}
 	}
 

--- a/pkg/mounter/proxy/server/ossfs2/driver_test.go
+++ b/pkg/mounter/proxy/server/ossfs2/driver_test.go
@@ -2,6 +2,7 @@ package ossfs2
 
 import (
 	"context"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"sync"
@@ -15,6 +16,64 @@ import (
 	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/mounter"
 	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/mounter/proxy/server"
 )
+
+func TestApplyOptionDefaults(t *testing.T) {
+	t.Run("no CA file configured, options unchanged", func(t *testing.T) {
+		t.Setenv("AGENT_IDENTITY_CERT_FILE", "")
+		d := &Driver{}
+		options := []string{"oss_endpoint=https://oss-cn-hangzhou.aliyuncs.com", "allow_other"}
+		result := d.ApplyOptionDefaults(options)
+		assert.Equal(t, []string{"oss_endpoint=https://oss-cn-hangzhou.aliyuncs.com", "allow_other"}, result)
+	})
+
+	t.Run("nil options, no CA file", func(t *testing.T) {
+		t.Setenv("AGENT_IDENTITY_CERT_FILE", "")
+		d := &Driver{}
+		assert.Nil(t, d.ApplyOptionDefaults(nil))
+	})
+
+	t.Run("user already specified agent_identity_ca_file", func(t *testing.T) {
+		dir := t.TempDir()
+		caFile := filepath.Join(dir, "ca.crt")
+		require.NoError(t, os.WriteFile(caFile, []byte("fake-ca"), 0644))
+
+		t.Setenv("AGENT_IDENTITY_CERT_FILE", caFile)
+		d := &Driver{}
+		options := []string{"agent_identity_ca_file=/custom/path/ca.crt", "oss_region=cn-hangzhou"}
+		result := d.ApplyOptionDefaults(options)
+		assert.Equal(t, []string{"agent_identity_ca_file=/custom/path/ca.crt", "oss_region=cn-hangzhou"}, result)
+	})
+
+	t.Run("CA file present and readable, appends option", func(t *testing.T) {
+		dir := t.TempDir()
+		caFile := filepath.Join(dir, "ca.crt")
+		require.NoError(t, os.WriteFile(caFile, []byte("fake-ca"), 0644))
+
+		t.Setenv("AGENT_IDENTITY_CERT_FILE", caFile)
+		d := &Driver{}
+		options := []string{"oss_region=cn-hangzhou"}
+		result := d.ApplyOptionDefaults(options)
+		assert.Equal(t, []string{"oss_region=cn-hangzhou", "agent_identity_ca_file=" + caFile}, result)
+	})
+
+	// Omitting the option leaves ossfs2 on its own empty default, which skips
+	// verification for the AgentIdentity endpoint rather than pointing it at a
+	// file it cannot open.
+	t.Run("CA file not readable, options unchanged", func(t *testing.T) {
+		if os.Getuid() == 0 {
+			t.Skip("root bypasses file permission checks")
+		}
+		dir := t.TempDir()
+		caFile := filepath.Join(dir, "ca.crt")
+		require.NoError(t, os.WriteFile(caFile, []byte("fake-ca"), 0000))
+
+		t.Setenv("AGENT_IDENTITY_CERT_FILE", caFile)
+		d := &Driver{}
+		options := []string{"oss_region=cn-hangzhou"}
+		result := d.ApplyOptionDefaults(options)
+		assert.Equal(t, []string{"oss_region=cn-hangzhou"}, result)
+	})
+}
 
 type fakeMountChecker struct {
 	mount.Interface


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug
#### What this PR does / why we need it:

buildHTTPClient fell back to the system root pool when no CA file was configured. The AgentIdentity endpoint is an in-cluster service holding a private certificate that no public root signs, so that fallback only ever verified because something injected the private CA into the process-wide trust store via SSL_CERT_FILE — and that injection replaces the store rather than extending it, hiding every public root from the same process and breaking unrelated OSS connections. Skip verification instead when no CA is configured, keeping the two trust decisions independent and matching how ossfs treats an empty agent_identity_ca_file.

A configured-but-unreadable or unparsable CA still fails hard: only an absent configuration is allowed to skip verification.

The ossfs and ossfs2 drivers keep leaving agent_identity_ca_file out when the path is unreadable, but now say so — the silent skip is why a CA pointing at a path that never existed went unnoticed.

Also covers ApplyOptionDefaults for ossfs2, which had no tests at all.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
