### PR TITLE
feat(nas): bind-mount subpath on fallback to avoid a second NFS mount

### DIFF
--- a/pkg/nas/bindmount_test.go
+++ b/pkg/nas/bindmount_test.go
@@ -1,0 +1,65 @@
+//go:build !windows
+
+package nas
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pkg/mounter"
+	"github.com/stretchr/testify/assert"
+	mountutils "k8s.io/mount-utils"
+)
+
+// fallbackMounter fails the first ExtendedMount with an NFS "path not found"
+// error to trigger the subpath-creation fallback, succeeds later ExtendedMounts
+// (the temporary root mount), and records local Mount (bind) calls.
+type fallbackMounter struct {
+	mountutils.FakeMounter
+	extendedCalls int
+	bindOptions   [][]string
+}
+
+func (m *fallbackMounter) ExtendedMount(_ context.Context, _ *mounter.MountOperation) error {
+	m.extendedCalls++
+	if m.extendedCalls == 1 {
+		return errors.New("reason given by server: No such file or directory")
+	}
+	return nil
+}
+
+func (m *fallbackMounter) Mount(_, _, _ string, options []string) error {
+	m.bindOptions = append(m.bindOptions, options)
+	return nil
+}
+
+func TestDoMount_PlainNFSFallbackUsesBind(t *testing.T) {
+	m := &fallbackMounter{}
+	opt := &Options{
+		Server:        "1.2.3.4",
+		Path:          "/subdir",
+		Vers:          "3",
+		MountProtocol: MountProtocolNFS,
+	}
+	err := doMount(m, opt, t.TempDir(), "vol-123", "pod-uid", false)
+	assert.NoError(t, err)
+	// One failed target mount + one temporary root mount, then bind (no second
+	// NFS mount of the target).
+	assert.Equal(t, 2, m.extendedCalls)
+	assert.Equal(t, [][]string{{"bind"}}, m.bindOptions)
+}
+
+func TestDoMount_PlainNFSFallbackReadOnlyRemounts(t *testing.T) {
+	m := &fallbackMounter{}
+	opt := &Options{
+		Server:        "1.2.3.4",
+		Path:          "/subdir",
+		Vers:          "3",
+		Options:       []string{"ro"},
+		MountProtocol: MountProtocolNFS,
+	}
+	err := doMount(m, opt, t.TempDir(), "vol-123", "pod-uid", false)
+	assert.NoError(t, err)
+	assert.Equal(t, [][]string{{"bind"}, {"bind", "remount", "ro"}}, m.bindOptions)
+}

--- a/pkg/nas/utils.go
+++ b/pkg/nas/utils.go
@@ -199,8 +199,28 @@ func doMount(m mounter.Mounter, opt *Options, targetPath, volumeId, podUid strin
 			return err
 		}
 	}
+	// For plain NFS, bind mount the created subpath onto the target instead of
+	// doing a second NFS mount below: it saves an NFS round-trip and the target
+	// stays usable after the temporary root is unmounted (shared superblock).
+	// Only plain NFS is safe here: alinas/cpfs targets are broker-owned and a
+	// local bind would break broker unmount ownership.
+	bindDone := false
+	if mountFstype == MountProtocolNFS {
+		if err := m.Mount(subDir, targetPath, "", []string{"bind"}); err != nil {
+			return err
+		}
+		if slices.Contains(combinedOptions, "ro") {
+			if err := m.Mount(subDir, targetPath, "", []string{"bind", "remount", "ro"}); err != nil {
+				return err
+			}
+		}
+		bindDone = true
+	}
 	if err := cleanupMountpoint(m, tmpPath); err != nil {
 		klog.Errorf("failed to cleanup tmp mountpoint %s: %v", tmpPath, err)
+	}
+	if bindDone {
+		return nil
 	}
 	return m.ExtendedMount(context.Background(), &mounter.MountOperation{
 		Source:   source,


### PR DESCRIPTION
## What this PR does / why we need it

The NAS subpath `NodePublishVolume` fallback path is only hit when the subpath directory does **not yet exist** on the NFS server (i.e. the controller-side `nas:CreateDir` was skipped, or a non-standard filesystem creates the subdir lazily on the node).

Today that fallback creates the directory under a temporary root mount, unmounts the root, then does a **second, independent NFS mount** of `server:/<subpath>` onto the target — an extra NFS round-trip on the publish critical path.

This PR bind-mounts the freshly created subpath directory onto the target before unmounting the temporary root:

```
MkdirTemp -> rw-mount root -> mkdir -> mount --bind subdir -> target -> unmount root
```

A bind mount shares the underlying NFS superblock with the temporary root, so the target stays usable after the root is unmounted; the underlying NFS is released when the target is finally unmounted. `NodeUnpublishVolume` is unchanged — the target is still a single mount point.

## Scope / no regression (no feature gate)

Restricted to the plain `nfs` fstype, where a local bind is a true equivalent of the second NFS mount:

- **The primary path is unchanged** (subpath already exists -> direct `server:/<subpath>` mount).
- **Plain NFS targets are always unmounted locally**, so the bind introduces no unmount-side change.
- **`alinas`/`cpfs`/`cpfs-nfs` (incl. AccessPoint and EFC) are excluded**: those targets are mounted through the mount broker, which records per-target ownership for `NodeUnpublishVolume`. A local bind is not broker-owned, so its unmount would fall back to the slow local `umount` path dropped by the `csi_mount_proxy` nftables rule (~3s). They keep the second-NFS-mount path.

## Does this PR introduce a user-facing change?

```release-note
NONE
```

## Testing

- `go test ./pkg/nas/...` — all pass, including existing `TestDoMount*` (no regression)
- New tests exercise the plain-NFS fallback bind path (`TestDoMount_PlainNFSFallbackUsesBind`, `TestDoMount_PlainNFSFallbackReadOnlyRemounts`)