### PR TITLE
build: bring the blkid stages up to date

### DIFF
--- a/build/multi/Dockerfile.multi
+++ b/build/multi/Dockerfile.multi
@@ -32,9 +32,9 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked,id=apt-cache-$TARGET
     --mount=type=cache,target=/var/lib/apt,sharing=locked,id=apt-lib-$TARGETARCH \
     rm -f /etc/apt/apt.conf.d/docker-clean && \
     echo 'Acquire::Check-Valid-Until false;' > /etc/apt/apt.conf.d/snapshot && \
-    sed -i '/^URIs:/d; s|^# \(http://snapshot.debian.org/\)|URIs: \1|' /etc/apt/sources.list.d/debian.sources && \
+    sed -i '/^URIs:/d; s|^# http://snapshot.debian.org/|URIs: http://snapshot-cloudflare.debian.org/|' /etc/apt/sources.list.d/debian.sources && \
     apt-get update && \
-    apt-get install -y nfs-common e2fsprogs xfsprogs fdisk util-linux
+    apt-get install -y --no-install-recommends nfs-common e2fsprogs xfsprogs fdisk util-linux
 
 RUN --mount=type=bind,from=distroless-base,target=/base \
     --mount=type=bind,source=build/gather-node-deps.sh,target=/deps.sh \
@@ -44,32 +44,37 @@ RUN --mount=type=bind,from=distroless-base,target=/base \
 FROM distroless-base as dep-list
 COPY --link --from=debian /staging-node /
 
-FROM --platform=$BUILDPLATFORM registry-cn-hangzhou.ack.aliyuncs.com/dev/debian:bookworm-20260623-slim as build-0
+# blkid from source: newer libblkid mistakes non-filesystem data for a filesystem less often than
+# the one Debian stable ships, and a false positive makes us refuse to format an empty disk.
+FROM --platform=$BUILDPLATFORM registry-cn-hangzhou.ack.aliyuncs.com/dev/debian:bookworm-20260623-slim as build-util-linux
 ARG BUILDARCH
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked,id=apt-cache-$BUILDARCH \
     --mount=type=cache,target=/var/lib/apt,sharing=locked,id=apt-lib-$BUILDARCH \
     rm -f /etc/apt/apt.conf.d/docker-clean && \
     echo 'Acquire::Check-Valid-Until false;' > /etc/apt/apt.conf.d/snapshot && \
-    sed -i '/^URIs:/d; s|^# \(http://snapshot.debian.org/\)|URIs: \1|' /etc/apt/sources.list.d/debian.sources && \
+    sed -i '/^URIs:/d; s|^# http://snapshot.debian.org/|URIs: http://snapshot-cloudflare.debian.org/|' /etc/apt/sources.list.d/debian.sources && \
     apt-get update && \
-    apt-get install -y tar xz-utils make diffutils
+    apt-get install -y --no-install-recommends tar xz-utils make diffutils dpkg-dev
 
-FROM build-0 as build-util-linux-amd64
-ENV HOST=x86_64-linux-gnu
-
-FROM build-0 as build-util-linux-arm64
-ENV HOST=aarch64-linux-gnu
-
-FROM build-util-linux-$TARGETARCH as build-util-linux
-ARG BUILDARCH
+# Above - shared by multiple TARGETARCH
+# Below - per-target
+ARG TARGETARCH
+# The target's libc via multiarch, not the libc6-dev-*-cross gcc recommends: those stay at the
+# revision the release froze at, and they put the libraries where libtool does not recognise a
+# system path, so it hardcodes a DT_RUNPATH into everything it links.
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked,id=apt-cache-$BUILDARCH \
     --mount=type=cache,target=/var/lib/apt,sharing=locked,id=apt-lib-$BUILDARCH <<EOF
 #!/bin/bash
-apt-get update && apt-get install -y gcc-${HOST//_/-}
+set -e
+eval "$(dpkg-architecture -a$TARGETARCH -s)"
+dpkg --add-architecture $DEB_HOST_ARCH
+apt-get update && apt-get install -y --no-install-recommends gcc-${DEB_HOST_GNU_TYPE//_/-} libc6-dev:$DEB_HOST_ARCH
 EOF
 
-ADD --link --checksum=sha256:6062a1d89b571a61932e6fc0211f36060c4183568b81ee866cf363bce9f6583e \
-    https://www.kernel.org/pub/linux/utils/util-linux/v2.41/util-linux-2.41.2.tar.xz /src.tar.xz
+# kernel.org takes ten minutes to serve this file to us.
+# The checksum is what makes the source trustworthy; the SBOM below names the canonical URL.
+ADD --link --checksum=sha256:f586e35d320ff537aab3ffeca37e9ecd482ccbe013590db4429a414d8aa6a728 \
+    https://mirrors.cernet.edu.cn/kernel.org/linux/utils/util-linux/v2.41/util-linux-2.41.5.tar.xz /src.tar.xz
 RUN mkdir -p /src && tar -C /src --strip-components=1 -xf /src.tar.xz
 
 RUN <<EOF
@@ -78,8 +83,14 @@ cd /src
 SOURCE_DATE_EPOCH=$(stat -c %Y /src.tar.xz)
 export SOURCE_DATE_EPOCH
 echo "util-linux released at $(date --date "@$SOURCE_DATE_EPOCH" --iso-8601=seconds)"
-./configure --disable-all-programs --enable-blkid --enable-libblkid --libdir=\${prefix}/lib/$HOST \
-    --disable-nls --disable-bash-completion --disable-asciidoc --disable-dependency-tracking --disable-static --host=$HOST
+# Build it the way Debian builds everything else in this image, incl. the security hardening.
+# blkid is what reads attacker-controlled bytes here.
+eval "$(dpkg-architecture -a$TARGETARCH -s)"
+export CC=$DEB_HOST_GNU_TYPE-gcc DEB_BUILD_MAINT_OPTIONS=hardening=+bindnow
+eval "$(dpkg-buildflags --export=sh)"
+./configure --disable-all-programs --enable-blkid --enable-libblkid --libdir=\${prefix}/lib/$DEB_HOST_MULTIARCH \
+    --disable-nls --disable-bash-completion --disable-asciidoc --disable-dependency-tracking --disable-static \
+    --host=$DEB_HOST_GNU_TYPE
 make -j
 make install-strip DESTDIR=/install
 mkdir -p /out
@@ -91,26 +102,26 @@ COPY <<"EOT" /out/usr/local/share/sbom/blkid.spdx.json
 {
     "spdxVersion": "SPDX-2.3",
     "SPDXID": "SPDXRef-DOCUMENT",
-    "name": "util-linux-2.41.2",
+    "name": "util-linux-2.41.5",
     "packages": [
         {
             "name": "util-linux",
             "SPDXID": "SPDXRef-Package-source-util-linux",
-            "versionInfo": "2.41.2",
+            "versionInfo": "2.41.5",
             "filesAnalyzed": false,
             "primaryPackagePurpose" : "SOURCE",
-            "packageFileName" : "util-linux-2.41.2.tar.xz",
-            "downloadLocation" : "https://www.kernel.org/pub/linux/utils/util-linux/v2.41/util-linux-2.41.2.tar.xz",
+            "packageFileName" : "util-linux-2.41.5.tar.xz",
+            "downloadLocation" : "https://www.kernel.org/pub/linux/utils/util-linux/v2.41/util-linux-2.41.5.tar.xz",
             "checksums" : [{
                 "algorithm" : "SHA256",
-                "checksumValue" : "6062a1d89b571a61932e6fc0211f36060c4183568b81ee866cf363bce9f6583e"
+                "checksumValue" : "f586e35d320ff537aab3ffeca37e9ecd482ccbe013590db4429a414d8aa6a728"
             }],
-            "releaseDate": "2025-09-22T11:32:01Z",
+            "releaseDate": "2026-06-16T12:20:59Z",
             "externalRefs": [
                 {
                     "referenceCategory": "SECURITY",
                     "referenceType": "cpe23Type",
-                    "referenceLocator": "cpe:2.3:a:util-linux:util-linux:2.41.2:*:*:*:*:*:*:*"
+                    "referenceLocator": "cpe:2.3:a:util-linux:util-linux:2.41.5:*:*:*:*:*:*:*"
                 }
             ]
         }
@@ -118,7 +129,7 @@ COPY <<"EOT" /out/usr/local/share/sbom/blkid.spdx.json
 }
 EOT
 
-RUN find /out -exec touch --reference=/src.tar.xz {} +
+RUN find /out -exec touch -h --reference=/src.tar.xz {} +
 
 FROM scratch as download-amd64
 ADD --link --checksum=sha256:751ce5f900a954ffb4c87eb530d4e5d63f449041f1816207334abdd09ebf8c70 \


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Brings the blkid-from-source build stages in `build/multi/Dockerfile.multi` up to date.

- Snapshot mirror: `snapshot-cloudflare.debian.org` instead of the canonical `snapshot.debian.org` host, which serves China at ~20 kB/s and times out an uncached build; the CDN alias serves the same immutable archives at ~1.5 MB/s.
- util-linux tarball from `mirrors.cernet.edu.cn` instead of kernel.org, which served the 9.5 MB file at ~16 kB/s (609 s of an 11-minute CI build). The `--checksum` on the ADD is what makes the source trustworthy, so the host does not have to be; the SBOM still names the canonical kernel.org URL.
- util-linux 2.41.2 → 2.41.5, for two fixes to code we aim at guest-written disks as root: a use-after-free in nested partition probing (partition array grown with `reallocarray()` while nested probers held pointers into it) and EBR bounds validation against a `uint32_t` overflow that let a crafted image register partitions at arbitrary sectors.
- Hardening, which was missing entirely: blkid was the only unhardened binary in an image whose mkfs and fsck all come hardened from Debian, and it is the one that reads attacker-controlled bytes. Flags now come from `dpkg-buildflags` (so a base-image bump brings the newer set along on its own) plus `bindnow`, which is what util-linux's own `debian/rules` asks for. Nine `_chk` entry points show up in the result.
- Target libc from multiarch (`libc6-dev:$DEB_HOST_ARCH`) instead of `libc6-dev-*-cross`: those cross packages are frozen at the bookworm release revision and install libraries outside any path libtool treats as a system one, so it hardcoded a `DT_RUNPATH` into the arm64 binaries. Multiarch is a no-op when the target is the builder's arch.
- `dpkg-architecture` for the triplet, retiring the hand-maintained arch table and the two per-arch stages (`build-util-linux-amd64`/`-arm64`) plus `build-0` that only existed to be their base. `ARG TARGETARCH` now marks the line between shared and per-target steps.
- `touch -h` so symlinks take the release tarball's mtime; without it `libblkid.so.1` kept the wall clock of whenever the stage last ran, the only thing that stopped the layer digest from being a function of the built content.
- `--no-install-recommends` in the deps stage, dropping ca-certificates, krb5-locales, libgpm2, libldap-common, libsasl2-modules and openssl from a stage we only harvest binaries out of.

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

Verified on both arches with a local buildkitd (`buildctl ... --opt target=build-util-linux`): the cross-compiled (arm64 host → amd64) and native (arm64) binaries are both stripped, carry 9 fortify `_chk` entry points, and have no `DT_RUNPATH`. The `debian` stage's `gather-node-deps.sh` completes cleanly with `--no-install-recommends` — none of the dropped packages provide binaries or libs that the gather step harvests.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```